### PR TITLE
Image, Flavor: Compute a unique UUID

### DIFF
--- a/api/v1alpha1/openstackflavor_types.go
+++ b/api/v1alpha1/openstackflavor_types.go
@@ -155,7 +155,7 @@ func (r *OpenStackFlavor) ComputedSpecID() string {
 	if r.Spec.Resource.ID != "" {
 		return r.Spec.Resource.ID
 	}
-	return uuid.NewV5(UuidNamespace, r.GetName()).String()
+	return uuid.NewV5(UuidNamespace, r.GetCreationTimestamp().String()+r.GetName()).String()
 }
 
 //+kubebuilder:object:root=true

--- a/api/v1alpha1/openstackimage_types.go
+++ b/api/v1alpha1/openstackimage_types.go
@@ -216,7 +216,7 @@ func (r *OpenStackImage) ComputedSpecID() string {
 	if r.Spec.Resource.ID != "" {
 		return r.Spec.Resource.ID
 	}
-	return uuid.NewV5(UuidNamespace, r.GetName()).String()
+	return uuid.NewV5(UuidNamespace, r.GetCreationTimestamp().String()+r.GetName()).String()
 }
 
 //+kubebuilder:object:root=true

--- a/website/docs/design-decisions.md
+++ b/website/docs/design-decisions.md
@@ -6,7 +6,7 @@ Before creating any resources, ORC checks that it doesn't already exist in the O
 
 Because the OpenStack API is not the same for every resource, ORC must use different strategies based on the available tools.
 
-For some resources, the API allows the caller to set an arbitrary ID upon creation. When that is possible, ORC uses it for retrieval. If the ID is not set in the resource spec, ORC computes one deterministically based on the name of the Kubernetes resource.
+For some resources, the API allows the caller to set an arbitrary ID upon creation. When that is possible, ORC uses it for retrieval. If the ID is not set in the resource spec, ORC computes one deterministically based on the name of the Kubernetes resource and the timestamp of its creation.
 
 For some resources, the name is guaranteed to be unique. When that is the case, ORC uses it for retrieval.
 


### PR DESCRIPTION
IDs in OpenStack are also unique in time. Before this change, only the name of the Kubernetes resource was used to generate a deterministic OpenStack UUID. Which meant that once an image (or flavor) name was taken on a given cloud, it could never be recreated.

With this patch, the creation time of the Kubernetes resource is also used to compute a deterministic OpenStack UUID.