### PR TITLE
actions: Only build website on main

### DIFF
--- a/.github/workflows/website.yaml
+++ b/.github/workflows/website.yaml
@@ -5,10 +5,6 @@ on:
     paths:
     - 'website/**'
     - 'api/v1alpha1/**'
-  pull_request:
-    paths:
-    - 'website/**'
-    - 'api/v1alpha1/**'
 name: website
 
 jobs:


### PR DESCRIPTION
Website building would fail on pull requests because the provider secret can't be used there.