### PR TITLE
actions: Add backport automation tooling

### DIFF
--- a/.github/labeler.yml
+++ b/.github/labeler.yml
@@ -1,0 +1,2 @@
+v1.0:
+- base-branch: 'release-1.0'

--- a/.github/labels.yaml
+++ b/.github/labels.yaml
@@ -1,0 +1,25 @@
+- color: '30ABB9'
+  description: This PR will be backported to v1.0
+  name: backport-v1.0
+- color: 'BCF611'
+  description: A good issue for first-time contributors
+  name: good first issue
+- color: '9E1957'
+  description: Breaking change
+  name: semver:major
+- color: 'FBCA04'
+  description: Backwards-compatible change
+  name: semver:minor
+- color: '6E7624'
+  description: No API change
+  name: semver:patch
+- color: 'D73A4A'
+  description: Do not merge
+  name: hold
+- color: 'F9D0C4'
+  description: Additional information requested
+  name: needinfo
+
+- color: '30ABB9'
+  description: This PR targets v1.0
+  name: v1.0

--- a/.github/workflows/backport.yaml
+++ b/.github/workflows/backport.yaml
@@ -1,0 +1,67 @@
+name: Pull Request backporting
+
+on:
+  pull_request_target:
+    types:
+      - closed
+      - labeled
+
+jobs:
+  backport_v1.0:
+    name: "Backport to v1.0"
+    # Only react to merged PRs for security reasons.
+    # See https://docs.github.com/en/actions/using-workflows/events-that-trigger-workflows#pull_request_target.
+    if: >
+      github.event.pull_request.merged
+      && (
+        github.event.action == 'closed'
+          && contains(github.event.pull_request.labels.*.name, 'backport-v1.0')
+        || (
+          github.event.action == 'labeled'
+          && contains(github.event.label.name, 'backport-v1.0')
+        )
+      )
+    runs-on: ubuntu-latest
+    steps:
+      - name: Generate a token from the gophercloud-backport-bot github-app
+        id: generate_token
+        uses: getsentry/action-github-app-token@a0061014b82a6a5d6aeeb3b824aced47e3c3a7ef
+        with:
+          app_id: ${{ secrets.BACKPORT_APP_ID }}
+          private_key: ${{ secrets.BACKPORT_APP_PRIVATE_KEY }}
+
+      - name: Backporting
+        if: >
+          contains(github.event.pull_request.labels.*.name, 'semver:patch')
+          || contains(github.event.label.name, 'semver:patch')
+        uses: kiegroup/git-backporting@b9ed3ac959d1479e81bf4f0a5e5f0a72251ce895
+        with:
+          target-branch: release-1.0
+          pull-request: ${{ github.event.pull_request.url }}
+          auth: ${{ steps.generate_token.outputs.token }}
+          no-squash: true
+          strategy-option: find-renames
+
+      - name: Report failure
+        if: failure()
+        run: gh issue comment "$NUMBER" --body "$BODY"
+        env:
+          GH_TOKEN: ${{ secrets.GITHUB_TOKEN }}
+          GH_REPO: ${{ github.repository }}
+          NUMBER: ${{ github.event.pull_request.number }}
+          BODY: >
+            Failed to backport PR to `release-1.0` branch. See [logs](${{ github.server_url }}/${{ github.repository }}/actions/runs/${{ github.run_id }}) for details.
+
+      - name: Report an error if backport unsupported labels
+        if: >
+          contains(github.event.pull_request.labels.*.name, 'semver:major')
+          || contains(github.event.pull_request.labels.*.name, 'semver:minor')
+          || contains(github.event.label.name, 'semver:major')
+          || contains(github.event.label.name, 'semver:minor')
+        run: gh pr comment "$NUMBER" --body "$BODY"
+        env:
+          GH_TOKEN: ${{ secrets.GITHUB_TOKEN }}
+          GH_REPO: ${{ github.repository }}
+          NUMBER: ${{ github.event.pull_request.number }}
+          BODY: >
+            Labels `semver:major` and `semver:minor` block backports to the branch `release-1.0`.

--- a/.github/workflows/check-pr-labels.yaml
+++ b/.github/workflows/check-pr-labels.yaml
@@ -1,0 +1,21 @@
+name: Ready
+on:
+  pull_request_target:
+    types:
+      - labeled
+      - opened
+      - reopened
+      - synchronize
+      - unlabeled
+
+jobs:
+  hold:
+    if: github.event.pull_request.merged == false
+    runs-on: ubuntu-latest
+    steps:
+      - if: >
+          contains(github.event.pull_request.labels.*.name, 'hold')
+        run: 'false'
+      - if: >
+          !contains(github.event.pull_request.labels.*.name, 'hold')
+        run: 'true'

--- a/.github/workflows/ensure-labels.yaml
+++ b/.github/workflows/ensure-labels.yaml
@@ -1,0 +1,18 @@
+name: Apply labels in .github/labels.yaml
+on:
+  push:
+    branches:
+      - main
+    paths:
+      - .github/labels.yaml
+      - .github/workflows/ensure-labels.yaml
+jobs:
+  ensure:
+    runs-on: ubuntu-latest
+    steps:
+      - uses: actions/checkout@v4
+      - uses: micnncim/action-label-syncer@v1
+        env:
+          GITHUB_TOKEN: ${{ secrets.GITHUB_TOKEN }}
+        with:
+          manifest: .github/labels.yaml

--- a/.github/workflows/label-issue.yaml
+++ b/.github/workflows/label-issue.yaml
@@ -1,0 +1,19 @@
+name: Label issue
+on:
+  issue_comment:
+    types:
+    - created
+
+jobs:
+  clear_needinfo:
+    name: Clear needinfo
+    if: ${{ github.event.issue.user.login }} == ${{ github.event.comment.user.login }}
+    runs-on: ubuntu-latest
+    permissions:
+      issues: write
+    steps:
+    - run: gh issue edit "$NUMBER" --remove-label "needinfo"
+      env:
+        GH_TOKEN: ${{ secrets.GITHUB_TOKEN }}
+        GH_REPO: ${{ github.repository }}
+        NUMBER: ${{ github.event.issue.number }}

--- a/.github/workflows/label-pr.yaml
+++ b/.github/workflows/label-pr.yaml
@@ -1,0 +1,87 @@
+name: Label PR
+on:
+  pull_request_target:
+    types:
+      - opened
+      - synchronize
+      - reopened
+
+jobs:
+  semver:
+    runs-on: ubuntu-latest
+    steps:
+    - uses: actions/checkout@v4
+      with:
+        fetch-depth: 0
+        ref: ${{ github.event.pull_request.head.sha }}
+        token: ${{ secrets.GITHUB_TOKEN }}
+
+    - name: Rebase the PR against origin/github.base_ref to ensure actual API compatibility
+      run: |
+        git config --global user.email "localrebase@k-orc.cloud"
+        git config --global user.name "Local rebase"
+        git rebase -i origin/${{ github.base_ref }}
+      env:
+        GIT_SEQUENCE_EDITOR: '/usr/bin/true'
+
+    - uses: actions/setup-go@v5
+      with:
+        go-version: '1'
+
+    - name: Checking Go API Compatibility
+      id: go-apidiff
+      # if semver=major, this will return RC=1, so let's ignore the failure so label
+      # can be set later. We check for actual errors in the next step.
+      continue-on-error: true
+      uses: joelanford/go-apidiff@002aa613b261e8d1547b516fb71793280f05bb78
+
+    # go-apidiff returns RC=1 when semver=major, which makes the workflow to return
+    # a failure. Instead let's just return a failure if go-apidiff failed to run.
+    - name: Return an error if Go API Compatibility couldn't be verified
+      if: steps.go-apidiff.outcome != 'success' && steps.go-apidiff.outputs.semver-type != 'major'
+      run: exit 1
+
+    - name: Add label semver:patch
+      if: steps.go-apidiff.outputs.semver-type == 'patch'
+      run: gh pr edit "$NUMBER" --add-label "semver:patch" --remove-label "semver:major,semver:minor"
+      env:
+        GH_TOKEN: ${{ secrets.GITHUB_TOKEN }}
+        GH_REPO: ${{ github.repository }}
+        NUMBER: ${{ github.event.pull_request.number }}
+
+    - name: Add label semver:minor
+      if: steps.go-apidiff.outputs.semver-type == 'minor'
+      run: gh pr edit "$NUMBER" --add-label "semver:minor" --remove-label "semver:major,semver:patch"
+      env:
+        GH_TOKEN: ${{ secrets.GITHUB_TOKEN }}
+        GH_REPO: ${{ github.repository }}
+        NUMBER: ${{ github.event.pull_request.number }}
+
+    - name: Add label semver:major
+      if: steps.go-apidiff.outputs.semver-type == 'major'
+      run: gh pr edit "$NUMBER" --add-label "semver:major" --remove-label "semver:minor,semver:patch"
+      env:
+        GH_TOKEN: ${{ secrets.GITHUB_TOKEN }}
+        GH_REPO: ${{ github.repository }}
+        NUMBER: ${{ github.event.pull_request.number }}
+
+    - name: Report failure
+      if: failure()
+      run: |
+        gh pr edit "$NUMBER" --remove-label "semver:major,semver:minor,semver:patch"
+        gh issue comment "$NUMBER" --body "$BODY"
+        exit 1
+      env:
+        GH_TOKEN: ${{ secrets.GITHUB_TOKEN }}
+        GH_REPO: ${{ github.repository }}
+        NUMBER: ${{ github.event.pull_request.number }}
+        BODY: >
+          Failed to assess the semver bump. See [logs](${{ github.server_url }}/${{ github.repository }}/actions/runs/${{ github.run_id }}) for details.
+
+  edits:
+    permissions:
+      contents: read
+      pull-requests: write
+    runs-on: ubuntu-latest
+    steps:
+    - uses: actions/labeler@v5


### PR DESCRIPTION
Copy and adapt relevant workflows from gophercloud to handle backporting to stable branches. Specifically:

* `ensure-labels.yaml` syncs labels defined in `.github/labels.yaml`
* `label-pr.yaml` runs go-apidiff on PRs and label them with a corresponding `semver:major`, `semver:minor`, or `semver:patch` label. Also labels PRs submitted to stable branches.
* `label-issue.yaml` clears the `needinfo` label on issues when the reported responded.
* `check-pr-labels.yaml` prevents merging PRs that have a `hold` label.
* `backport.yaml` effectively creates backports for PRs that have the `backport-v1.0` and `semver:patch` labels.