### PR TITLE
Allow Create and Delete to return WaitingOnEvent

### DIFF
--- a/internal/controllers/flavor/actuator.go
+++ b/internal/controllers/flavor/actuator.go
@@ -106,7 +106,7 @@ func (obj flavorActuator) GetOSResourceByImportFilter(ctx context.Context) (bool
 	return true, flavor, err
 }
 
-func (obj flavorActuator) CreateResource(ctx context.Context) ([]string, *flavors.Flavor, error) {
+func (obj flavorActuator) CreateResource(ctx context.Context) ([]generic.WaitingOnEvent, *flavors.Flavor, error) {
 	resource := obj.Spec.Resource
 
 	if resource == nil {
@@ -137,8 +137,8 @@ func (obj flavorActuator) CreateResource(ctx context.Context) ([]string, *flavor
 	return nil, osResource, nil
 }
 
-func (obj flavorActuator) DeleteResource(ctx context.Context, flavor *flavors.Flavor) error {
-	return obj.osClient.DeleteFlavor(ctx, flavor.ID)
+func (obj flavorActuator) DeleteResource(ctx context.Context, flavor *flavors.Flavor) ([]generic.WaitingOnEvent, error) {
+	return nil, obj.osClient.DeleteFlavor(ctx, flavor.ID)
 }
 
 // getResourceName returns the name of the OpenStack resource we should use.

--- a/internal/controllers/flavor/controller.go
+++ b/internal/controllers/flavor/controller.go
@@ -18,7 +18,6 @@ package flavor
 
 import (
 	"context"
-	"time"
 
 	"k8s.io/client-go/tools/record"
 	ctrl "sigs.k8s.io/controller-runtime"
@@ -47,11 +46,6 @@ const (
 func ssaFieldOwner(txn string) client.FieldOwner {
 	return client.FieldOwner(FieldOwner + "/" + txn)
 }
-
-const (
-	// The time to wait before reconciling again when importing a resource that doesn't exist yet
-	externalUpdatePollingPeriod = 15 * time.Second
-)
 
 type flavorReconcilerConstructor struct {
 	scopeFactory scope.Factory

--- a/internal/controllers/flavor/reconcile.go
+++ b/internal/controllers/flavor/reconcile.go
@@ -20,7 +20,6 @@ import (
 	"context"
 	"errors"
 	"fmt"
-	"strings"
 
 	"github.com/gophercloud/gophercloud/v2/openstack/compute/v2/flavors"
 	apierrors "k8s.io/apimachinery/pkg/api/errors"
@@ -92,19 +91,23 @@ func (r *orcFlavorReconciler) reconcileNormal(ctx context.Context, orcObject *or
 		return ctrl.Result{}, err
 	}
 
-	waitMsgs, osResource, err := generic.GetOrCreateOSResource(ctx, log, r.client, actuator)
+	waitEvents, osResource, err := generic.GetOrCreateOSResource(ctx, log, r.client, actuator)
 	if err != nil {
 		return ctrl.Result{}, err
 	}
 
+	if len(waitEvents) > 0 {
+		log.V(3).Info("Waiting on events before creation")
+		addStatus(withProgressMessage(waitEvents[0].Message()))
+		return ctrl.Result{RequeueAfter: generic.MaxRequeue(waitEvents)}, nil
+	}
+
 	if osResource == nil {
-		log.V(3).Info("OpenStack resource does not yet exist")
-		addStatus(withProgressMessage(strings.Join(waitMsgs, ", ")))
-		return ctrl.Result{RequeueAfter: externalUpdatePollingPeriod}, err
+		// Programming error: if we don't have a resource we should either have an error or be waiting on something
+		return ctrl.Result{}, fmt.Errorf("oResource is not set, but no wait events or error")
 	}
 
 	addStatus(withResource(osResource))
-
 	if orcObject.Status.ID == nil {
 		if err := r.setStatusID(ctx, orcObject, osResource.ID); err != nil {
 			return ctrl.Result{}, err

--- a/internal/controllers/image/actuator.go
+++ b/internal/controllers/image/actuator.go
@@ -119,7 +119,7 @@ func (obj imageActuator) GetOSResourceByImportFilter(ctx context.Context) (bool,
 	return true, image, err
 }
 
-func (obj imageActuator) CreateResource(ctx context.Context) ([]string, *images.Image, error) {
+func (obj imageActuator) CreateResource(ctx context.Context) ([]generic.WaitingOnEvent, *images.Image, error) {
 	resource := obj.Spec.Resource
 	if resource == nil {
 		// Should have been caught by API validation
@@ -179,8 +179,8 @@ func (obj imageActuator) CreateResource(ctx context.Context) ([]string, *images.
 	return nil, image, err
 }
 
-func (obj imageActuator) DeleteResource(ctx context.Context, osResource *images.Image) error {
-	return obj.osClient.DeleteImage(ctx, osResource.ID)
+func (obj imageActuator) DeleteResource(ctx context.Context, osResource *images.Image) ([]generic.WaitingOnEvent, error) {
+	return nil, obj.osClient.DeleteImage(ctx, osResource.ID)
 }
 
 // getResourceName returns the name of the glance image we should use.

--- a/internal/controllers/network/actuator.go
+++ b/internal/controllers/network/actuator.go
@@ -132,7 +132,7 @@ func (obj networkActuator) GetOSResourceByImportFilter(ctx context.Context) (boo
 	return true, osResource, nil
 }
 
-func (obj networkActuator) CreateResource(ctx context.Context) ([]string, *networkExt, error) {
+func (obj networkActuator) CreateResource(ctx context.Context) ([]generic.WaitingOnEvent, *networkExt, error) {
 	resource := obj.Spec.Resource
 	if resource == nil {
 		// Should have been caught by API validation
@@ -198,8 +198,8 @@ func (obj networkActuator) CreateResource(ctx context.Context) ([]string, *netwo
 	return nil, osResource, nil
 }
 
-func (obj networkActuator) DeleteResource(ctx context.Context, network *networkExt) error {
-	return obj.osClient.DeleteNetwork(ctx, network.ID).ExtractErr()
+func (obj networkActuator) DeleteResource(ctx context.Context, network *networkExt) ([]generic.WaitingOnEvent, error) {
+	return nil, obj.osClient.DeleteNetwork(ctx, network.ID).ExtractErr()
 }
 
 // getResourceName returns the name of the OpenStack resource we should use.

--- a/internal/controllers/network/controller.go
+++ b/internal/controllers/network/controller.go
@@ -18,7 +18,6 @@ package network
 
 import (
 	"context"
-	"time"
 
 	"k8s.io/client-go/tools/record"
 	ctrl "sigs.k8s.io/controller-runtime"
@@ -47,11 +46,6 @@ const (
 func ssaFieldOwner(txn string) client.FieldOwner {
 	return client.FieldOwner(FieldOwner + "/" + txn)
 }
-
-const (
-	// The time to wait before reconciling again when we are expecting glance to finish some task and update status.
-	externalUpdatePollingPeriod = 15 * time.Second
-)
 
 type networkReconcilerConstructor struct {
 	scopeFactory scope.Factory

--- a/internal/controllers/network/reconcile.go
+++ b/internal/controllers/network/reconcile.go
@@ -20,7 +20,6 @@ import (
 	"context"
 	"errors"
 	"fmt"
-	"strings"
 
 	"github.com/gophercloud/gophercloud/v2/openstack/networking/v2/extensions/attributestags"
 	"github.com/gophercloud/gophercloud/v2/openstack/networking/v2/extensions/dns"
@@ -108,19 +107,23 @@ func (r *orcNetworkReconciler) reconcileNormal(ctx context.Context, orcObject *o
 		return ctrl.Result{}, err
 	}
 
-	waitMsgs, osResource, err := generic.GetOrCreateOSResource(ctx, log, r.client, actuator)
+	waitEvents, osResource, err := generic.GetOrCreateOSResource(ctx, log, r.client, actuator)
 	if err != nil {
 		return ctrl.Result{}, err
 	}
 
+	if len(waitEvents) > 0 {
+		log.V(3).Info("Waiting on events before creation")
+		addStatus(withProgressMessage(waitEvents[0].Message()))
+		return ctrl.Result{RequeueAfter: generic.MaxRequeue(waitEvents)}, nil
+	}
+
 	if osResource == nil {
-		log.V(3).Info("OpenStack resource does not yet exist")
-		addStatus(withProgressMessage(strings.Join(waitMsgs, ", ")))
-		return ctrl.Result{RequeueAfter: externalUpdatePollingPeriod}, nil
+		// Programming error: if we don't have a resource we should either have an error or be waiting on something
+		return ctrl.Result{}, fmt.Errorf("oResource is not set, but no wait events or error")
 	}
 
 	addStatus(withResource(osResource))
-
 	if orcObject.Status.ID == nil {
 		if err := r.setStatusID(ctx, orcObject, osResource.ID); err != nil {
 			return ctrl.Result{}, err

--- a/internal/controllers/port/controller.go
+++ b/internal/controllers/port/controller.go
@@ -19,7 +19,6 @@ package port
 import (
 	"context"
 	"errors"
-	"time"
 
 	"k8s.io/client-go/tools/record"
 	ctrl "sigs.k8s.io/controller-runtime"
@@ -51,11 +50,6 @@ const (
 func ssaFieldOwner(txn string) client.FieldOwner {
 	return client.FieldOwner(FieldOwner + "/" + txn)
 }
-
-const (
-	// The time to wait before reconciling again when we are expecting glance to finish some task and update status.
-	externalUpdatePollingPeriod = 15 * time.Second
-)
 
 type portReconcilerConstructor struct {
 	scopeFactory scope.Factory

--- a/internal/controllers/port/reconcile.go
+++ b/internal/controllers/port/reconcile.go
@@ -20,7 +20,6 @@ import (
 	"context"
 	"errors"
 	"fmt"
-	"strings"
 
 	"github.com/gophercloud/gophercloud/v2/openstack/networking/v2/extensions/attributestags"
 	"github.com/gophercloud/gophercloud/v2/openstack/networking/v2/ports"
@@ -114,19 +113,23 @@ func (r *orcPortReconciler) reconcileNormal(ctx context.Context, orcObject *orcv
 		return ctrl.Result{}, err
 	}
 
-	waitMsgs, osResource, err := generic.GetOrCreateOSResource(ctx, log, r.client, actuator)
+	waitEvents, osResource, err := generic.GetOrCreateOSResource(ctx, log, r.client, actuator)
 	if err != nil {
 		return ctrl.Result{}, err
 	}
 
+	if len(waitEvents) > 0 {
+		log.V(3).Info("Waiting on events before creation")
+		addStatus(withProgressMessage(waitEvents[0].Message()))
+		return ctrl.Result{RequeueAfter: generic.MaxRequeue(waitEvents)}, nil
+	}
+
 	if osResource == nil {
-		log.V(3).Info("OpenStack resource does not yet exist")
-		addStatus(withProgressMessage(strings.Join(waitMsgs, ", ")))
-		return ctrl.Result{RequeueAfter: externalUpdatePollingPeriod}, nil
+		// Programming error: if we don't have a resource we should either have an error or be waiting on something
+		return ctrl.Result{}, fmt.Errorf("oResource is not set, but no wait events or error")
 	}
 
 	addStatus(withResource(osResource))
-
 	if orcObject.Status.ID == nil {
 		if err := r.setStatusID(ctx, orcObject, osResource.ID); err != nil {
 			return ctrl.Result{}, err

--- a/internal/controllers/router/controller.go
+++ b/internal/controllers/router/controller.go
@@ -19,7 +19,6 @@ package router
 import (
 	"context"
 	"errors"
-	"time"
 
 	"k8s.io/client-go/tools/record"
 	ctrl "sigs.k8s.io/controller-runtime"
@@ -49,11 +48,6 @@ const (
 func ssaFieldOwner(txn string) client.FieldOwner {
 	return client.FieldOwner(FieldOwner + "/" + txn)
 }
-
-const (
-	// The time to wait before reconciling again when we are expecting glance to finish some task and update status.
-	externalUpdatePollingPeriod = 15 * time.Second
-)
 
 type routerReconcilerConstructor struct {
 	scopeFactory scope.Factory

--- a/internal/controllers/router/reconcile.go
+++ b/internal/controllers/router/reconcile.go
@@ -20,7 +20,6 @@ import (
 	"context"
 	"errors"
 	"fmt"
-	"strings"
 
 	"github.com/gophercloud/gophercloud/v2/openstack/networking/v2/extensions/attributestags"
 	"github.com/gophercloud/gophercloud/v2/openstack/networking/v2/extensions/layer3/routers"
@@ -94,15 +93,20 @@ func (r *orcRouterReconciler) reconcileNormal(ctx context.Context, orcObject *or
 		return ctrl.Result{}, err
 	}
 
-	waitMsgs, osResource, err := generic.GetOrCreateOSResource(ctx, log, r.client, actuator)
+	waitEvents, osResource, err := generic.GetOrCreateOSResource(ctx, log, r.client, actuator)
 	if err != nil {
 		return ctrl.Result{}, err
 	}
 
+	if len(waitEvents) > 0 {
+		log.V(3).Info("Waiting on events before creation")
+		addStatus(withProgressMessage(waitEvents[0].Message()))
+		return ctrl.Result{RequeueAfter: generic.MaxRequeue(waitEvents)}, nil
+	}
+
 	if osResource == nil {
-		log.V(3).Info("OpenStack resource does not yet exist")
-		addStatus(withProgressMessage(strings.Join(waitMsgs, ", ")))
-		return ctrl.Result{RequeueAfter: externalUpdatePollingPeriod}, nil
+		// Programming error: if we don't have a resource we should either have an error or be waiting on something
+		return ctrl.Result{}, fmt.Errorf("oResource is not set, but no wait events or error")
 	}
 
 	addStatus(withResource(osResource))

--- a/internal/controllers/securitygroup/actuator.go
+++ b/internal/controllers/securitygroup/actuator.go
@@ -113,7 +113,7 @@ func (obj securityGroupActuator) GetOSResourceByImportFilter(ctx context.Context
 	return true, osResource, err
 }
 
-func (obj securityGroupActuator) CreateResource(ctx context.Context) ([]string, *groups.SecGroup, error) {
+func (obj securityGroupActuator) CreateResource(ctx context.Context) ([]generic.WaitingOnEvent, *groups.SecGroup, error) {
 	resource := obj.Spec.Resource
 	if resource == nil {
 		// Should have been caught by API validation
@@ -165,8 +165,8 @@ func (obj securityGroupActuator) CreateResource(ctx context.Context) ([]string, 
 	return nil, osResource, nil
 }
 
-func (obj securityGroupActuator) DeleteResource(ctx context.Context, osResource *groups.SecGroup) error {
-	return obj.osClient.DeleteSecGroup(ctx, osResource.ID)
+func (obj securityGroupActuator) DeleteResource(ctx context.Context, osResource *groups.SecGroup) ([]generic.WaitingOnEvent, error) {
+	return nil, obj.osClient.DeleteSecGroup(ctx, osResource.ID)
 }
 
 // getResourceName returns the name of the OpenStack resource we should use.

--- a/internal/controllers/securitygroup/controller.go
+++ b/internal/controllers/securitygroup/controller.go
@@ -18,7 +18,6 @@ package securitygroup
 
 import (
 	"context"
-	"time"
 
 	"k8s.io/client-go/tools/record"
 	ctrl "sigs.k8s.io/controller-runtime"
@@ -45,11 +44,6 @@ const (
 func ssaFieldOwner(txn string) client.FieldOwner {
 	return client.FieldOwner(FieldOwner + "/" + txn)
 }
-
-const (
-	// The time to wait before reconciling again when we are expecting glance to finish some task and update status.
-	externalUpdatePollingPeriod = 15 * time.Second
-)
 
 type securitygroupReconcilerConstructor struct {
 	scopeFactory scope.Factory

--- a/internal/controllers/securitygroup/reconcile.go
+++ b/internal/controllers/securitygroup/reconcile.go
@@ -20,7 +20,6 @@ import (
 	"context"
 	"errors"
 	"fmt"
-	"strings"
 
 	"github.com/gophercloud/gophercloud/v2/openstack/networking/v2/extensions/attributestags"
 	"github.com/gophercloud/gophercloud/v2/openstack/networking/v2/extensions/security/groups"
@@ -93,15 +92,21 @@ func (r *orcSecurityGroupReconciler) reconcileNormal(ctx context.Context, orcObj
 	if err != nil {
 		return ctrl.Result{}, nil
 	}
-	waitMsgs, osResource, err := generic.GetOrCreateOSResource(ctx, log, r.client, actuator)
+
+	waitEvents, osResource, err := generic.GetOrCreateOSResource(ctx, log, r.client, actuator)
 	if err != nil {
 		return ctrl.Result{}, err
 	}
 
+	if len(waitEvents) > 0 {
+		log.V(3).Info("Waiting on events before creation")
+		addStatus(withProgressMessage(waitEvents[0].Message()))
+		return ctrl.Result{RequeueAfter: generic.MaxRequeue(waitEvents)}, nil
+	}
+
 	if osResource == nil {
-		log.V(3).Info("OpenStack resource does not yet exist")
-		addStatus(withProgressMessage(strings.Join(waitMsgs, ", ")))
-		return ctrl.Result{RequeueAfter: externalUpdatePollingPeriod}, nil
+		// Programming error: if we don't have a resource we should either have an error or be waiting on something
+		return ctrl.Result{}, fmt.Errorf("oResource is not set, but no wait events or error")
 	}
 
 	addStatus(withResource(osResource))

--- a/internal/controllers/server/reconcile.go
+++ b/internal/controllers/server/reconcile.go
@@ -20,7 +20,6 @@ import (
 	"context"
 	"errors"
 	"fmt"
-	"strings"
 
 	"github.com/gophercloud/gophercloud/v2/openstack/compute/v2/servers"
 	apierrors "k8s.io/apimachinery/pkg/api/errors"
@@ -92,15 +91,21 @@ func (r *orcServerReconciler) reconcileNormal(ctx context.Context, orcObject *or
 	if err != nil {
 		return ctrl.Result{}, err
 	}
-	waitMsgs, osResource, err := generic.GetOrCreateOSResource(ctx, log, r.client, actuator)
+
+	waitEvents, osResource, err := generic.GetOrCreateOSResource(ctx, log, r.client, actuator)
 	if err != nil {
 		return ctrl.Result{}, err
 	}
 
+	if len(waitEvents) > 0 {
+		log.V(3).Info("Waiting on events before creation")
+		addStatus(withProgressMessage(waitEvents[0].Message()))
+		return ctrl.Result{RequeueAfter: generic.MaxRequeue(waitEvents)}, nil
+	}
+
 	if osResource == nil {
-		log.V(3).Info("OpenStack resource does not yet exist")
-		addStatus(withProgressMessage(strings.Join(waitMsgs, ", ")))
-		return ctrl.Result{RequeueAfter: externalUpdatePollingPeriod}, nil
+		// Programming error: if we don't have a resource we should either have an error or be waiting on something
+		return ctrl.Result{}, fmt.Errorf("oResource is not set, but no wait events or error")
 	}
 
 	addStatus(withResource(osResource))


### PR DESCRIPTION
Fixes a bug in create where we were incorrectly polling while waiting on an ORC event.

Will allow us to wait on ORC router interface deletion when deleting a Subnet.