### PR TITLE
actions: Add permission to ensure-labels.yaml

### DIFF
--- a/.github/workflows/ensure-labels.yaml
+++ b/.github/workflows/ensure-labels.yaml
@@ -6,6 +6,8 @@ on:
     paths:
       - .github/labels.yaml
       - .github/workflows/ensure-labels.yaml
+permissions:
+  pull-requests: write
 
 jobs:
   ensure:


### PR DESCRIPTION
The permission needs to be granted for the workflow otherwise it's not able to update labels and fails silently.