### PR TITLE
actions: Grant more permissions to workflows

### DIFF
--- a/.github/workflows/backport.yaml
+++ b/.github/workflows/backport.yaml
@@ -5,6 +5,9 @@ on:
     types:
       - closed
       - labeled
+permissions:
+  contents: read
+  pull-requests: write
 
 jobs:
   backport_v1_0:

--- a/.github/workflows/label-pr.yaml
+++ b/.github/workflows/label-pr.yaml
@@ -5,6 +5,9 @@ on:
       - opened
       - synchronize
       - reopened
+permissions:
+  contents: read
+  pull-requests: write
 
 jobs:
   semver:
@@ -79,9 +82,6 @@ jobs:
           Failed to assess the semver bump. See [logs](${{ github.server_url }}/${{ github.repository }}/actions/runs/${{ github.run_id }}) for details.
 
   edits:
-    permissions:
-      contents: read
-      pull-requests: write
     runs-on: ubuntu-latest
     steps:
     - uses: actions/labeler@v5


### PR DESCRIPTION
We can no longer give write permission to the GITHUB_TOKEN globally and need to individually grant permissions to workflows. This should cover the workflows with the missing explicit permissions.