### PR TITLE
Server: Fix panic creating server

### DIFF
--- a/internal/controllers/server/actuator.go
+++ b/internal/controllers/server/actuator.go
@@ -207,8 +207,8 @@ func (obj serverCreateActuator) CreateResource(ctx context.Context) ([]generic.W
 
 	osResource, err := obj.osClient.CreateServer(ctx, &createOpts, schedulerHints)
 
-	// We should require the spec to be updated before retrying a create which returned a conflict
-	if !orcerrors.IsRetryable(err) {
+	// We should require the spec to be updated before retrying a create which returned a non-retryable error
+	if err != nil && !orcerrors.IsRetryable(err) {
 		return nil, nil, orcerrors.Terminal(orcv1alpha1.OpenStackConditionReasonInvalidConfiguration, "invalid configuration creating resource: "+err.Error(), err)
 	}
 


### PR DESCRIPTION
If the server was created successfully, we were incorrectly attempting to return a terminal error, which paniced because the error was nil. This bug was hidden because when the controller restarts it idempotently adopted the previously created resource, so it came up correctly anyway.