### PR TITLE
Generic finalizer handling

### DIFF
--- a/internal/controllers/flavor/actuator.go
+++ b/internal/controllers/flavor/actuator.go
@@ -57,6 +57,10 @@ func newActuator(ctx context.Context, k8sClient client.Client, scopeFactory scop
 var _ generic.CreateResourceActuator[*flavors.Flavor] = flavorActuator{}
 var _ generic.DeleteResourceActuator[*flavors.Flavor] = flavorActuator{}
 
+func (flavorActuator) GetControllerName() string {
+	return "flavor"
+}
+
 func (obj flavorActuator) GetObject() client.Object {
 	return obj.Flavor
 }

--- a/internal/controllers/flavor/actuator.go
+++ b/internal/controllers/flavor/actuator.go
@@ -57,6 +57,10 @@ func newActuator(ctx context.Context, k8sClient client.Client, scopeFactory scop
 var _ generic.CreateResourceActuator[*flavors.Flavor] = flavorActuator{}
 var _ generic.DeleteResourceActuator[*flavors.Flavor] = flavorActuator{}
 
+func (obj flavorActuator) GetObject() client.Object {
+	return obj.Flavor
+}
+
 func (obj flavorActuator) GetManagementPolicy() orcv1alpha1.ManagementPolicy {
 	return obj.Spec.ManagementPolicy
 }

--- a/internal/controllers/flavor/actuator.go
+++ b/internal/controllers/flavor/actuator.go
@@ -27,19 +27,19 @@ import (
 	orcv1alpha1 "github.com/k-orc/openstack-resource-controller/api/v1alpha1"
 	"github.com/k-orc/openstack-resource-controller/internal/controllers/generic"
 	osclients "github.com/k-orc/openstack-resource-controller/internal/osclients"
-	"github.com/k-orc/openstack-resource-controller/internal/scope"
 	orcerrors "github.com/k-orc/openstack-resource-controller/internal/util/errors"
 )
 
 type flavorActuator struct {
 	*orcv1alpha1.Flavor
-	osClient osclients.ComputeClient
+	osClient   osclients.ComputeClient
+	controller generic.ResourceControllerCommon
 }
 
-func newActuator(ctx context.Context, k8sClient client.Client, scopeFactory scope.Factory, orcObject *orcv1alpha1.Flavor) (flavorActuator, error) {
+func newActuator(ctx context.Context, controller generic.ResourceControllerCommon, orcObject *orcv1alpha1.Flavor) (flavorActuator, error) {
 	log := ctrl.LoggerFrom(ctx)
 
-	clientScope, err := scopeFactory.NewClientScopeFromObject(ctx, k8sClient, log, orcObject)
+	clientScope, err := controller.GetScopeFactory().NewClientScopeFromObject(ctx, controller.GetK8sClient(), log, orcObject)
 	if err != nil {
 		return flavorActuator{}, err
 	}
@@ -49,8 +49,9 @@ func newActuator(ctx context.Context, k8sClient client.Client, scopeFactory scop
 	}
 
 	return flavorActuator{
-		Flavor:   orcObject,
-		osClient: osClient,
+		Flavor:     orcObject,
+		osClient:   osClient,
+		controller: controller,
 	}, nil
 }
 
@@ -63,6 +64,10 @@ func (flavorActuator) GetControllerName() string {
 
 func (obj flavorActuator) GetObject() client.Object {
 	return obj.Flavor
+}
+
+func (obj flavorActuator) GetController() generic.ResourceControllerCommon {
+	return obj.controller
 }
 
 func (obj flavorActuator) GetManagementPolicy() orcv1alpha1.ManagementPolicy {

--- a/internal/controllers/flavor/controller.go
+++ b/internal/controllers/flavor/controller.go
@@ -31,15 +31,9 @@ import (
 )
 
 const (
-	Finalizer = "openstack.k-orc.cloud/flavor"
-
 	FieldOwner = "openstack.k-orc.cloud/flavorcontroller"
-	// Field owner of the object finalizer.
-	SSAFinalizerTxn = "finalizer"
 	// Field owner of transient status.
 	SSAStatusTxn = "status"
-	// Field owner of persistent id field.
-	SSAIDTxn = "id"
 )
 
 // ssaFieldOwner returns the field owner for a specific named SSA transaction.

--- a/internal/controllers/flavor/controller.go
+++ b/internal/controllers/flavor/controller.go
@@ -27,6 +27,7 @@ import (
 	orcv1alpha1 "github.com/k-orc/openstack-resource-controller/api/v1alpha1"
 
 	ctrlexport "github.com/k-orc/openstack-resource-controller/internal/controllers/export"
+	"github.com/k-orc/openstack-resource-controller/internal/controllers/generic"
 	"github.com/k-orc/openstack-resource-controller/internal/scope"
 )
 
@@ -55,17 +56,29 @@ func (flavorReconcilerConstructor) GetName() string {
 
 // orcFlavorReconciler reconciles an ORC Flavor.
 type orcFlavorReconciler struct {
-	client       client.Client
-	recorder     record.EventRecorder
-	scopeFactory scope.Factory
+	client   client.Client
+	recorder record.EventRecorder
+
+	flavorReconcilerConstructor
+}
+
+var _ generic.ResourceControllerCommon = &orcFlavorReconciler{}
+
+func (r orcFlavorReconciler) GetK8sClient() client.Client {
+	return r.client
+}
+
+func (r orcFlavorReconciler) GetScopeFactory() scope.Factory {
+	return r.scopeFactory
 }
 
 // SetupWithManager sets up the controller with the Manager.
 func (c flavorReconcilerConstructor) SetupWithManager(ctx context.Context, mgr ctrl.Manager, options controller.Options) error {
 	reconciler := orcFlavorReconciler{
-		client:       mgr.GetClient(),
-		recorder:     mgr.GetEventRecorderFor("orc-flavor-controller"),
-		scopeFactory: c.scopeFactory,
+		client:   mgr.GetClient(),
+		recorder: mgr.GetEventRecorderFor("orc-flavor-controller"),
+
+		flavorReconcilerConstructor: c,
 	}
 
 	return ctrl.NewControllerManagedBy(mgr).

--- a/internal/controllers/flavor/reconcile.go
+++ b/internal/controllers/flavor/reconcile.go
@@ -75,7 +75,7 @@ func (r *orcFlavorReconciler) reconcileNormal(ctx context.Context, orcObject *or
 		}
 	}()
 
-	actuator, err := newActuator(ctx, r.client, r.scopeFactory, orcObject)
+	actuator, err := newActuator(ctx, r, orcObject)
 	if err != nil {
 		return ctrl.Result{}, err
 	}
@@ -139,7 +139,7 @@ func (r *orcFlavorReconciler) reconcileDelete(ctx context.Context, orcObject *or
 		}
 	}()
 
-	actuator, err := newActuator(ctx, r.client, r.scopeFactory, orcObject)
+	actuator, err := newActuator(ctx, r, orcObject)
 	if err != nil {
 		return ctrl.Result{}, err
 	}

--- a/internal/controllers/flavor/reconcile.go
+++ b/internal/controllers/flavor/reconcile.go
@@ -23,18 +23,12 @@ import (
 
 	"github.com/gophercloud/gophercloud/v2/openstack/compute/v2/flavors"
 	apierrors "k8s.io/apimachinery/pkg/api/errors"
-	"k8s.io/apimachinery/pkg/types"
 	ctrl "sigs.k8s.io/controller-runtime"
-	"sigs.k8s.io/controller-runtime/pkg/client"
-	"sigs.k8s.io/controller-runtime/pkg/controller/controllerutil"
 
 	orcv1alpha1 "github.com/k-orc/openstack-resource-controller/api/v1alpha1"
-	"github.com/k-orc/openstack-resource-controller/internal/controllers/common"
 	"github.com/k-orc/openstack-resource-controller/internal/controllers/generic"
 	osclients "github.com/k-orc/openstack-resource-controller/internal/osclients"
-	"github.com/k-orc/openstack-resource-controller/internal/util/applyconfigs"
 	orcerrors "github.com/k-orc/openstack-resource-controller/internal/util/errors"
-	orcapplyconfigv1alpha1 "github.com/k-orc/openstack-resource-controller/pkg/clients/applyconfiguration/api/v1alpha1"
 )
 
 // +kubebuilder:rbac:groups=openstack.k-orc.cloud,resources=flavors,verbs=get;list;watch;create;update;patch;delete
@@ -80,11 +74,6 @@ func (r *orcFlavorReconciler) reconcileNormal(ctx context.Context, orcObject *or
 			err = nil
 		}
 	}()
-
-	if !controllerutil.ContainsFinalizer(orcObject, Finalizer) {
-		patch := common.SetFinalizerPatch(orcObject, Finalizer)
-		return ctrl.Result{}, r.client.Patch(ctx, orcObject, patch, client.ForceOwnership, ssaFieldOwner(SSAFinalizerTxn))
-	}
 
 	actuator, err := newActuator(ctx, r.client, r.scopeFactory, orcObject)
 	if err != nil {
@@ -155,15 +144,9 @@ func (r *orcFlavorReconciler) reconcileDelete(ctx context.Context, orcObject *or
 		return ctrl.Result{}, err
 	}
 
-	osResource, result, err := generic.DeleteResource(ctx, log, actuator, func() error {
-		deleted = true
-
-		// Clear the finalizer
-		applyConfig := orcapplyconfigv1alpha1.Flavor(orcObject.Name, orcObject.Namespace).WithUID(orcObject.UID)
-		return r.client.Patch(ctx, orcObject, applyconfigs.Patch(types.ApplyPatchType, applyConfig), client.ForceOwnership, ssaFieldOwner(SSAFinalizerTxn))
-	})
+	deleted, waitEvents, osResource, err := generic.DeleteResource(ctx, log, r.client, actuator)
 	addStatus(withResource(osResource))
-	return result, err
+	return ctrl.Result{RequeueAfter: generic.MaxRequeue(waitEvents)}, err
 }
 
 // needsUpdate returns a slice of functions that call the OpenStack API to

--- a/internal/controllers/flavor/status.go
+++ b/internal/controllers/flavor/status.go
@@ -40,7 +40,7 @@ func (r *orcFlavorReconciler) setStatusID(ctx context.Context, obj client.Object
 		WithStatus(orcapplyconfigv1alpha1.FlavorStatus().
 			WithID(id))
 
-	return r.client.Status().Patch(ctx, obj, applyconfigs.Patch(types.ApplyPatchType, applyConfig), client.ForceOwnership, ssaFieldOwner(SSAIDTxn))
+	return r.client.Status().Patch(ctx, obj, applyconfigs.Patch(types.MergePatchType, applyConfig))
 }
 
 type updateStatusOpts struct {

--- a/internal/controllers/image/actuator.go
+++ b/internal/controllers/image/actuator.go
@@ -60,6 +60,10 @@ func newActuator(ctx context.Context, k8sClient client.Client, scopeFactory scop
 var _ generic.CreateResourceActuator[*images.Image] = imageActuator{}
 var _ generic.DeleteResourceActuator[*images.Image] = imageActuator{}
 
+func (imageActuator) GetControllerName() string {
+	return "image"
+}
+
 func (obj imageActuator) GetObject() client.Object {
 	return obj.Image
 }

--- a/internal/controllers/image/actuator.go
+++ b/internal/controllers/image/actuator.go
@@ -60,6 +60,10 @@ func newActuator(ctx context.Context, k8sClient client.Client, scopeFactory scop
 var _ generic.CreateResourceActuator[*images.Image] = imageActuator{}
 var _ generic.DeleteResourceActuator[*images.Image] = imageActuator{}
 
+func (obj imageActuator) GetObject() client.Object {
+	return obj.Image
+}
+
 func (obj imageActuator) GetManagementPolicy() orcv1alpha1.ManagementPolicy {
 	return obj.Spec.ManagementPolicy
 }

--- a/internal/controllers/image/actuator.go
+++ b/internal/controllers/image/actuator.go
@@ -30,19 +30,19 @@ import (
 	orcv1alpha1 "github.com/k-orc/openstack-resource-controller/api/v1alpha1"
 	"github.com/k-orc/openstack-resource-controller/internal/controllers/generic"
 	"github.com/k-orc/openstack-resource-controller/internal/osclients"
-	"github.com/k-orc/openstack-resource-controller/internal/scope"
 	orcerrors "github.com/k-orc/openstack-resource-controller/internal/util/errors"
 )
 
 type imageActuator struct {
 	*orcv1alpha1.Image
-	osClient osclients.ImageClient
+	osClient   osclients.ImageClient
+	controller generic.ResourceControllerCommon
 }
 
-func newActuator(ctx context.Context, k8sClient client.Client, scopeFactory scope.Factory, orcObject *orcv1alpha1.Image) (imageActuator, error) {
+func newActuator(ctx context.Context, controller generic.ResourceControllerCommon, orcObject *orcv1alpha1.Image) (imageActuator, error) {
 	log := ctrl.LoggerFrom(ctx)
 
-	clientScope, err := scopeFactory.NewClientScopeFromObject(ctx, k8sClient, log, orcObject)
+	clientScope, err := controller.GetScopeFactory().NewClientScopeFromObject(ctx, controller.GetK8sClient(), log, orcObject)
 	if err != nil {
 		return imageActuator{}, err
 	}
@@ -52,20 +52,21 @@ func newActuator(ctx context.Context, k8sClient client.Client, scopeFactory scop
 	}
 
 	return imageActuator{
-		Image:    orcObject,
-		osClient: osClient,
+		Image:      orcObject,
+		osClient:   osClient,
+		controller: controller,
 	}, nil
 }
 
 var _ generic.CreateResourceActuator[*images.Image] = imageActuator{}
 var _ generic.DeleteResourceActuator[*images.Image] = imageActuator{}
 
-func (imageActuator) GetControllerName() string {
-	return "image"
-}
-
 func (obj imageActuator) GetObject() client.Object {
 	return obj.Image
+}
+
+func (obj imageActuator) GetController() generic.ResourceControllerCommon {
+	return obj.controller
 }
 
 func (obj imageActuator) GetManagementPolicy() orcv1alpha1.ManagementPolicy {

--- a/internal/controllers/image/controller.go
+++ b/internal/controllers/image/controller.go
@@ -28,6 +28,7 @@ import (
 	orcv1alpha1 "github.com/k-orc/openstack-resource-controller/api/v1alpha1"
 
 	ctrlexport "github.com/k-orc/openstack-resource-controller/internal/controllers/export"
+	"github.com/k-orc/openstack-resource-controller/internal/controllers/generic"
 	"github.com/k-orc/openstack-resource-controller/internal/scope"
 )
 
@@ -67,17 +68,29 @@ func (imageReconcilerConstructor) GetName() string {
 
 // orcImageReconciler reconciles an ORC Image.
 type orcImageReconciler struct {
-	client       client.Client
-	recorder     record.EventRecorder
-	scopeFactory scope.Factory
+	client   client.Client
+	recorder record.EventRecorder
+
+	imageReconcilerConstructor
+}
+
+var _ generic.ResourceControllerCommon = &orcImageReconciler{}
+
+func (r *orcImageReconciler) GetK8sClient() client.Client {
+	return r.client
+}
+
+func (r *orcImageReconciler) GetScopeFactory() scope.Factory {
+	return r.scopeFactory
 }
 
 // SetupWithManager sets up the controller with the Manager.
 func (c imageReconcilerConstructor) SetupWithManager(_ context.Context, mgr ctrl.Manager, options controller.Options) error {
 	reconciler := orcImageReconciler{
-		client:       mgr.GetClient(),
-		recorder:     mgr.GetEventRecorderFor("orc-image-controller"),
-		scopeFactory: c.scopeFactory,
+		client:   mgr.GetClient(),
+		recorder: mgr.GetEventRecorderFor("orc-image-controller"),
+
+		imageReconcilerConstructor: c,
 	}
 
 	return ctrl.NewControllerManagedBy(mgr).

--- a/internal/controllers/image/controller.go
+++ b/internal/controllers/image/controller.go
@@ -32,11 +32,7 @@ import (
 )
 
 const (
-	Finalizer = "openstack.k-orc.cloud/image"
-
 	FieldOwner = "openstack.k-orc.cloud/imagecontroller"
-	// Field owner of the object finalizer.
-	SSAFinalizerTxn = "finalizer"
 	// Field owner of transient status.
 	SSAStatusTxn = "status"
 )

--- a/internal/controllers/image/reconcile.go
+++ b/internal/controllers/image/reconcile.go
@@ -76,7 +76,7 @@ func (r *orcImageReconciler) reconcileNormal(ctx context.Context, orcObject *orc
 		}
 	}()
 
-	actuator, err := newActuator(ctx, r.client, r.scopeFactory, orcObject)
+	actuator, err := newActuator(ctx, r, orcObject)
 	if err != nil {
 		return ctrl.Result{}, err
 	}
@@ -196,7 +196,7 @@ func (r *orcImageReconciler) reconcileDelete(ctx context.Context, orcObject *orc
 		}
 	}()
 
-	actuator, err := newActuator(ctx, r.client, r.scopeFactory, orcObject)
+	actuator, err := newActuator(ctx, r, orcObject)
 	if err != nil {
 		return ctrl.Result{}, err
 	}

--- a/internal/controllers/image/reconcile.go
+++ b/internal/controllers/image/reconcile.go
@@ -23,19 +23,13 @@ import (
 
 	"github.com/gophercloud/gophercloud/v2/openstack/image/v2/images"
 	apierrors "k8s.io/apimachinery/pkg/api/errors"
-	"k8s.io/apimachinery/pkg/types"
 	"k8s.io/utils/ptr"
 	ctrl "sigs.k8s.io/controller-runtime"
-	"sigs.k8s.io/controller-runtime/pkg/client"
-	"sigs.k8s.io/controller-runtime/pkg/controller/controllerutil"
 
 	orcv1alpha1 "github.com/k-orc/openstack-resource-controller/api/v1alpha1"
-	"github.com/k-orc/openstack-resource-controller/internal/controllers/common"
 	"github.com/k-orc/openstack-resource-controller/internal/controllers/generic"
 	osclients "github.com/k-orc/openstack-resource-controller/internal/osclients"
-	"github.com/k-orc/openstack-resource-controller/internal/util/applyconfigs"
 	orcerrors "github.com/k-orc/openstack-resource-controller/internal/util/errors"
-	orcapplyconfigv1alpha1 "github.com/k-orc/openstack-resource-controller/pkg/clients/applyconfiguration/api/v1alpha1"
 )
 
 // +kubebuilder:rbac:groups=openstack.k-orc.cloud,resources=images,verbs=get;list;watch;create;update;patch;delete
@@ -81,11 +75,6 @@ func (r *orcImageReconciler) reconcileNormal(ctx context.Context, orcObject *orc
 			err = nil
 		}
 	}()
-
-	if !controllerutil.ContainsFinalizer(orcObject, Finalizer) {
-		patch := common.SetFinalizerPatch(orcObject, Finalizer)
-		return ctrl.Result{}, r.client.Patch(ctx, orcObject, patch, client.ForceOwnership, ssaFieldOwner(SSAFinalizerTxn))
-	}
 
 	actuator, err := newActuator(ctx, r.client, r.scopeFactory, orcObject)
 	if err != nil {
@@ -212,15 +201,9 @@ func (r *orcImageReconciler) reconcileDelete(ctx context.Context, orcObject *orc
 		return ctrl.Result{}, err
 	}
 
-	osResource, result, err := generic.DeleteResource(ctx, log, actuator, func() error {
-		deleted = true
-
-		// Clear the finalizer
-		applyConfig := orcapplyconfigv1alpha1.Image(orcObject.Name, orcObject.Namespace).WithUID(orcObject.UID)
-		return r.client.Patch(ctx, orcObject, applyconfigs.Patch(types.ApplyPatchType, applyConfig), client.ForceOwnership, ssaFieldOwner(SSAFinalizerTxn))
-	})
+	deleted, waitEvents, osResource, err := generic.DeleteResource(ctx, log, r.client, actuator)
 	addStatus(withResource(osResource))
-	return result, err
+	return ctrl.Result{RequeueAfter: generic.MaxRequeue(waitEvents)}, err
 }
 
 func downloadingMessage(msg string, orcImage *orcv1alpha1.Image) string {

--- a/internal/controllers/image/upload_test.go
+++ b/internal/controllers/image/upload_test.go
@@ -170,11 +170,11 @@ var _ = Describe("Upload tests", Ordered, func() {
 		mockCtrl = gomock.NewController(GinkgoT())
 		scopeFactory = scope.NewMockScopeFactory(mockCtrl)
 		reconciler = &orcImageReconciler{
-			client:       k8sClient,
-			scopeFactory: scopeFactory,
+			client: k8sClient,
 			// NOTE(mdbooth): I have no idea what 1024 means here, or if it is a sensible value 🤷
 			recorder: record.NewFakeRecorder(1024),
 		}
+		reconciler.scopeFactory = scopeFactory
 	})
 
 	uploadTest := func(imageName string, aopts ...uploadTestOpt) error {

--- a/internal/controllers/network/actuator.go
+++ b/internal/controllers/network/actuator.go
@@ -62,6 +62,10 @@ func newActuator(ctx context.Context, k8sClient client.Client, scopeFactory scop
 var _ generic.CreateResourceActuator[*networkExt] = networkActuator{}
 var _ generic.DeleteResourceActuator[*networkExt] = networkActuator{}
 
+func (obj networkActuator) GetObject() client.Object {
+	return obj.Network
+}
+
 func (obj networkActuator) GetManagementPolicy() orcv1alpha1.ManagementPolicy {
 	return obj.Spec.ManagementPolicy
 }

--- a/internal/controllers/network/actuator.go
+++ b/internal/controllers/network/actuator.go
@@ -62,6 +62,10 @@ func newActuator(ctx context.Context, k8sClient client.Client, scopeFactory scop
 var _ generic.CreateResourceActuator[*networkExt] = networkActuator{}
 var _ generic.DeleteResourceActuator[*networkExt] = networkActuator{}
 
+func (networkActuator) GetControllerName() string {
+	return "network"
+}
+
 func (obj networkActuator) GetObject() client.Object {
 	return obj.Network
 }

--- a/internal/controllers/network/controller.go
+++ b/internal/controllers/network/controller.go
@@ -27,6 +27,7 @@ import (
 	orcv1alpha1 "github.com/k-orc/openstack-resource-controller/api/v1alpha1"
 
 	ctrlexport "github.com/k-orc/openstack-resource-controller/internal/controllers/export"
+	"github.com/k-orc/openstack-resource-controller/internal/controllers/generic"
 	"github.com/k-orc/openstack-resource-controller/internal/scope"
 )
 
@@ -57,17 +58,29 @@ func (networkReconcilerConstructor) GetName() string {
 
 // orcNetworkReconciler reconciles an ORC Subnet.
 type orcNetworkReconciler struct {
-	client       client.Client
-	recorder     record.EventRecorder
-	scopeFactory scope.Factory
+	client   client.Client
+	recorder record.EventRecorder
+
+	networkReconcilerConstructor
+}
+
+var _ generic.ResourceControllerCommon = &orcNetworkReconciler{}
+
+func (r *orcNetworkReconciler) GetK8sClient() client.Client {
+	return r.client
+}
+
+func (r *orcNetworkReconciler) GetScopeFactory() scope.Factory {
+	return r.scopeFactory
 }
 
 // SetupWithManager sets up the controller with the Manager.
 func (c networkReconcilerConstructor) SetupWithManager(_ context.Context, mgr ctrl.Manager, options controller.Options) error {
 	reconciler := orcNetworkReconciler{
-		client:       mgr.GetClient(),
-		recorder:     mgr.GetEventRecorderFor("orc-network-controller"),
-		scopeFactory: c.scopeFactory,
+		client:   mgr.GetClient(),
+		recorder: mgr.GetEventRecorderFor("orc-network-controller"),
+
+		networkReconcilerConstructor: c,
 	}
 
 	return ctrl.NewControllerManagedBy(mgr).

--- a/internal/controllers/network/controller.go
+++ b/internal/controllers/network/controller.go
@@ -31,15 +31,9 @@ import (
 )
 
 const (
-	Finalizer = "openstack.k-orc.cloud/network"
-
 	FieldOwner = "openstack.k-orc.cloud/networkcontroller"
-	// Field owner of the object finalizer.
-	SSAFinalizerTxn = "finalizer"
 	// Field owner of transient status.
 	SSAStatusTxn = "status"
-	// Field owner of persistent id field.
-	SSAIDTxn = "id"
 )
 
 // ssaFieldOwner returns the field owner for a specific named SSA transaction.

--- a/internal/controllers/network/reconcile.go
+++ b/internal/controllers/network/reconcile.go
@@ -29,19 +29,13 @@ import (
 	"github.com/gophercloud/gophercloud/v2/openstack/networking/v2/extensions/provider"
 	"github.com/gophercloud/gophercloud/v2/openstack/networking/v2/networks"
 	apierrors "k8s.io/apimachinery/pkg/api/errors"
-	"k8s.io/apimachinery/pkg/types"
 	"k8s.io/utils/set"
 	ctrl "sigs.k8s.io/controller-runtime"
-	"sigs.k8s.io/controller-runtime/pkg/client"
-	"sigs.k8s.io/controller-runtime/pkg/controller/controllerutil"
 
 	orcv1alpha1 "github.com/k-orc/openstack-resource-controller/api/v1alpha1"
-	"github.com/k-orc/openstack-resource-controller/internal/controllers/common"
 	"github.com/k-orc/openstack-resource-controller/internal/controllers/generic"
 	osclients "github.com/k-orc/openstack-resource-controller/internal/osclients"
-	"github.com/k-orc/openstack-resource-controller/internal/util/applyconfigs"
 	orcerrors "github.com/k-orc/openstack-resource-controller/internal/util/errors"
-	orcapplyconfigv1alpha1 "github.com/k-orc/openstack-resource-controller/pkg/clients/applyconfiguration/api/v1alpha1"
 )
 
 type networkExt struct {
@@ -96,11 +90,6 @@ func (r *orcNetworkReconciler) reconcileNormal(ctx context.Context, orcObject *o
 			err = nil
 		}
 	}()
-
-	if !controllerutil.ContainsFinalizer(orcObject, Finalizer) {
-		patch := common.SetFinalizerPatch(orcObject, Finalizer)
-		return ctrl.Result{}, r.client.Patch(ctx, orcObject, patch, client.ForceOwnership, ssaFieldOwner(SSAFinalizerTxn))
-	}
 
 	actuator, err := newActuator(ctx, r.client, r.scopeFactory, orcObject)
 	if err != nil {
@@ -171,15 +160,9 @@ func (r *orcNetworkReconciler) reconcileDelete(ctx context.Context, orcObject *o
 		return ctrl.Result{}, err
 	}
 
-	osResource, result, err := generic.DeleteResource(ctx, log, actuator, func() error {
-		deleted = true
-
-		// Clear the finalizer
-		applyConfig := orcapplyconfigv1alpha1.Network(orcObject.Name, orcObject.Namespace).WithUID(orcObject.UID)
-		return r.client.Patch(ctx, orcObject, applyconfigs.Patch(types.ApplyPatchType, applyConfig), client.ForceOwnership, ssaFieldOwner(SSAFinalizerTxn))
-	})
+	deleted, waitEvents, osResource, err := generic.DeleteResource(ctx, log, r.client, actuator)
 	addStatus(withResource(osResource))
-	return result, err
+	return ctrl.Result{RequeueAfter: generic.MaxRequeue(waitEvents)}, err
 }
 
 // needsUpdate returns a slice of functions that call the OpenStack API to

--- a/internal/controllers/network/reconcile.go
+++ b/internal/controllers/network/reconcile.go
@@ -91,7 +91,7 @@ func (r *orcNetworkReconciler) reconcileNormal(ctx context.Context, orcObject *o
 		}
 	}()
 
-	actuator, err := newActuator(ctx, r.client, r.scopeFactory, orcObject)
+	actuator, err := newActuator(ctx, r, orcObject)
 	if err != nil {
 		return ctrl.Result{}, err
 	}
@@ -155,7 +155,7 @@ func (r *orcNetworkReconciler) reconcileDelete(ctx context.Context, orcObject *o
 		}
 	}()
 
-	actuator, err := newActuator(ctx, r.client, r.scopeFactory, orcObject)
+	actuator, err := newActuator(ctx, r, orcObject)
 	if err != nil {
 		return ctrl.Result{}, err
 	}

--- a/internal/controllers/network/status.go
+++ b/internal/controllers/network/status.go
@@ -40,7 +40,7 @@ func (r *orcNetworkReconciler) setStatusID(ctx context.Context, obj client.Objec
 		WithStatus(orcapplyconfigv1alpha1.NetworkStatus().
 			WithID(id))
 
-	return r.client.Status().Patch(ctx, obj, applyconfigs.Patch(types.ApplyPatchType, applyConfig), client.ForceOwnership, ssaFieldOwner(SSAIDTxn))
+	return r.client.Status().Patch(ctx, obj, applyconfigs.Patch(types.MergePatchType, applyConfig))
 }
 
 type updateStatusOpts struct {

--- a/internal/controllers/port/actuator.go
+++ b/internal/controllers/port/actuator.go
@@ -80,6 +80,10 @@ func newCreateActuator(ctx context.Context, k8sClient client.Client, scopeFactor
 var _ generic.DeleteResourceActuator[*ports.Port] = portActuator{}
 var _ generic.CreateResourceActuator[*ports.Port] = portCreateActuator{}
 
+func (portActuator) GetControllerName() string {
+	return "port"
+}
+
 func (obj portActuator) GetObject() client.Object {
 	return obj.Port
 }

--- a/internal/controllers/port/actuator.go
+++ b/internal/controllers/port/actuator.go
@@ -80,6 +80,10 @@ func newCreateActuator(ctx context.Context, k8sClient client.Client, scopeFactor
 var _ generic.DeleteResourceActuator[*ports.Port] = portActuator{}
 var _ generic.CreateResourceActuator[*ports.Port] = portCreateActuator{}
 
+func (obj portActuator) GetObject() client.Object {
+	return obj.Port
+}
+
 func (obj portActuator) GetManagementPolicy() orcv1alpha1.ManagementPolicy {
 	return obj.Spec.ManagementPolicy
 }

--- a/internal/controllers/port/controller.go
+++ b/internal/controllers/port/controller.go
@@ -38,12 +38,8 @@ const (
 	Finalizer = "openstack.k-orc.cloud/port"
 
 	FieldOwner = "openstack.k-orc.cloud/portcontroller"
-	// Field owner of the object finalizer.
-	SSAFinalizerTxn = "finalizer"
 	// Field owner of transient status.
 	SSAStatusTxn = "status"
-	// Field owner of persistent id field.
-	SSAIDTxn = "id"
 )
 
 // ssaFieldOwner returns the field owner for a specific named SSA transaction.

--- a/internal/controllers/port/reconcile.go
+++ b/internal/controllers/port/reconcile.go
@@ -97,7 +97,7 @@ func (r *orcPortReconciler) reconcileNormal(ctx context.Context, orcObject *orcv
 	}
 	networkID := orcv1alpha1.UUID(*orcNetwork.Status.ID)
 
-	actuator, err := newCreateActuator(ctx, r.client, r.scopeFactory, orcObject, networkID)
+	actuator, err := newCreateActuator(ctx, r, orcObject, networkID)
 	if err != nil {
 		return ctrl.Result{}, err
 	}
@@ -161,7 +161,7 @@ func (r *orcPortReconciler) reconcileDelete(ctx context.Context, orcObject *orcv
 		}
 	}()
 
-	portActuator, err := newActuator(ctx, r.client, r.scopeFactory, orcObject)
+	portActuator, err := newActuator(ctx, r, orcObject)
 	if err != nil {
 		return ctrl.Result{}, err
 	}

--- a/internal/controllers/router/actuator.go
+++ b/internal/controllers/router/actuator.go
@@ -77,6 +77,10 @@ func newCreateActuator(ctx context.Context, k8sClient client.Client, scopeFactor
 var _ generic.DeleteResourceActuator[*routers.Router] = routerActuator{}
 var _ generic.CreateResourceActuator[*routers.Router] = routerCreateActuator{}
 
+func (obj routerActuator) GetObject() client.Object {
+	return obj.Router
+}
+
 func (obj routerActuator) GetManagementPolicy() orcv1alpha1.ManagementPolicy {
 	return obj.Spec.ManagementPolicy
 }

--- a/internal/controllers/router/actuator.go
+++ b/internal/controllers/router/actuator.go
@@ -77,6 +77,10 @@ func newCreateActuator(ctx context.Context, k8sClient client.Client, scopeFactor
 var _ generic.DeleteResourceActuator[*routers.Router] = routerActuator{}
 var _ generic.CreateResourceActuator[*routers.Router] = routerCreateActuator{}
 
+func (routerActuator) GetControllerName() string {
+	return "router"
+}
+
 func (obj routerActuator) GetObject() client.Object {
 	return obj.Router
 }

--- a/internal/controllers/router/controller.go
+++ b/internal/controllers/router/controller.go
@@ -38,8 +38,6 @@ const (
 	Finalizer = "openstack.k-orc.cloud/router"
 
 	FieldOwner = "openstack.k-orc.cloud/routercontroller"
-	// Field owner of the object finalizer.
-	SSAFinalizerTxn = "finalizer"
 	// Field owner of transient status.
 	SSAStatusTxn = "status"
 )

--- a/internal/controllers/router/reconcile.go
+++ b/internal/controllers/router/reconcile.go
@@ -24,19 +24,13 @@ import (
 	"github.com/gophercloud/gophercloud/v2/openstack/networking/v2/extensions/attributestags"
 	"github.com/gophercloud/gophercloud/v2/openstack/networking/v2/extensions/layer3/routers"
 	apierrors "k8s.io/apimachinery/pkg/api/errors"
-	"k8s.io/apimachinery/pkg/types"
 	"k8s.io/utils/set"
 	ctrl "sigs.k8s.io/controller-runtime"
-	"sigs.k8s.io/controller-runtime/pkg/client"
-	"sigs.k8s.io/controller-runtime/pkg/controller/controllerutil"
 
 	orcv1alpha1 "github.com/k-orc/openstack-resource-controller/api/v1alpha1"
-	"github.com/k-orc/openstack-resource-controller/internal/controllers/common"
 	"github.com/k-orc/openstack-resource-controller/internal/controllers/generic"
 	osclients "github.com/k-orc/openstack-resource-controller/internal/osclients"
-	"github.com/k-orc/openstack-resource-controller/internal/util/applyconfigs"
 	orcerrors "github.com/k-orc/openstack-resource-controller/internal/util/errors"
-	orcapplyconfigv1alpha1 "github.com/k-orc/openstack-resource-controller/pkg/clients/applyconfiguration/api/v1alpha1"
 )
 
 // +kubebuilder:rbac:groups=openstack.k-orc.cloud,resources=routers,verbs=get;list;watch;create;update;patch;delete
@@ -82,11 +76,6 @@ func (r *orcRouterReconciler) reconcileNormal(ctx context.Context, orcObject *or
 			err = nil
 		}
 	}()
-
-	if !controllerutil.ContainsFinalizer(orcObject, Finalizer) {
-		patch := common.SetFinalizerPatch(orcObject, Finalizer)
-		return ctrl.Result{}, r.client.Patch(ctx, orcObject, patch, client.ForceOwnership, ssaFieldOwner(SSAFinalizerTxn))
-	}
 
 	actuator, err := newCreateActuator(ctx, r.client, r.scopeFactory, orcObject)
 	if err != nil {
@@ -157,15 +146,9 @@ func (r *orcRouterReconciler) reconcileDelete(ctx context.Context, orcObject *or
 		return ctrl.Result{}, err
 	}
 
-	osResource, result, err := generic.DeleteResource(ctx, log, actuator, func() error {
-		deleted = true
-
-		// Clear the finalizer
-		applyConfig := orcapplyconfigv1alpha1.Router(orcObject.Name, orcObject.Namespace).WithUID(orcObject.UID)
-		return r.client.Patch(ctx, orcObject, applyconfigs.Patch(types.ApplyPatchType, applyConfig), client.ForceOwnership, ssaFieldOwner(SSAFinalizerTxn))
-	})
+	deleted, waitEvents, osResource, err := generic.DeleteResource(ctx, log, r.client, actuator)
 	addStatus(withResource(osResource))
-	return result, err
+	return ctrl.Result{RequeueAfter: generic.MaxRequeue(waitEvents)}, err
 }
 
 // needsUpdate returns a slice of functions that call the OpenStack API to

--- a/internal/controllers/router/reconcile.go
+++ b/internal/controllers/router/reconcile.go
@@ -77,7 +77,7 @@ func (r *orcRouterReconciler) reconcileNormal(ctx context.Context, orcObject *or
 		}
 	}()
 
-	actuator, err := newCreateActuator(ctx, r.client, r.scopeFactory, orcObject)
+	actuator, err := newCreateActuator(ctx, r, orcObject)
 	if err != nil {
 		return ctrl.Result{}, err
 	}
@@ -141,7 +141,7 @@ func (r *orcRouterReconciler) reconcileDelete(ctx context.Context, orcObject *or
 		}
 	}()
 
-	actuator, err := newActuator(ctx, r.client, r.scopeFactory, orcObject)
+	actuator, err := newActuator(ctx, r, orcObject)
 	if err != nil {
 		return ctrl.Result{}, err
 	}

--- a/internal/controllers/securitygroup/actuator.go
+++ b/internal/controllers/securitygroup/actuator.go
@@ -59,6 +59,10 @@ func newActuator(ctx context.Context, k8sClient client.Client, scopeFactory scop
 var _ generic.DeleteResourceActuator[*groups.SecGroup] = securityGroupActuator{}
 var _ generic.CreateResourceActuator[*groups.SecGroup] = securityGroupActuator{}
 
+func (securityGroupActuator) GetControllerName() string {
+	return "securitygroup"
+}
+
 func (obj securityGroupActuator) GetObject() client.Object {
 	return obj.SecurityGroup
 }

--- a/internal/controllers/securitygroup/actuator.go
+++ b/internal/controllers/securitygroup/actuator.go
@@ -59,6 +59,10 @@ func newActuator(ctx context.Context, k8sClient client.Client, scopeFactory scop
 var _ generic.DeleteResourceActuator[*groups.SecGroup] = securityGroupActuator{}
 var _ generic.CreateResourceActuator[*groups.SecGroup] = securityGroupActuator{}
 
+func (obj securityGroupActuator) GetObject() client.Object {
+	return obj.SecurityGroup
+}
+
 func (obj securityGroupActuator) GetManagementPolicy() orcv1alpha1.ManagementPolicy {
 	return obj.Spec.ManagementPolicy
 }

--- a/internal/controllers/securitygroup/controller.go
+++ b/internal/controllers/securitygroup/controller.go
@@ -31,11 +31,7 @@ import (
 )
 
 const (
-	Finalizer = "openstack.k-orc.cloud/securitygroup"
-
 	FieldOwner = "openstack.k-orc.cloud/securitygroupcontroller"
-	// Field owner of the object finalizer.
-	SSAFinalizerTxn = "finalizer"
 	// Field owner of transient status.
 	SSAStatusTxn = "status"
 )

--- a/internal/controllers/securitygroup/controller.go
+++ b/internal/controllers/securitygroup/controller.go
@@ -27,6 +27,7 @@ import (
 	orcv1alpha1 "github.com/k-orc/openstack-resource-controller/api/v1alpha1"
 
 	ctrlexport "github.com/k-orc/openstack-resource-controller/internal/controllers/export"
+	"github.com/k-orc/openstack-resource-controller/internal/controllers/generic"
 	"github.com/k-orc/openstack-resource-controller/internal/scope"
 )
 
@@ -57,17 +58,29 @@ func (securitygroupReconcilerConstructor) GetName() string {
 
 // orcSecurityGroupReconciler reconciles an ORC Subnet.
 type orcSecurityGroupReconciler struct {
-	client       client.Client
-	recorder     record.EventRecorder
-	scopeFactory scope.Factory
+	client   client.Client
+	recorder record.EventRecorder
+
+	securitygroupReconcilerConstructor
+}
+
+var _ generic.ResourceControllerCommon = &orcSecurityGroupReconciler{}
+
+func (r *orcSecurityGroupReconciler) GetK8sClient() client.Client {
+	return r.client
+}
+
+func (r *orcSecurityGroupReconciler) GetScopeFactory() scope.Factory {
+	return r.scopeFactory
 }
 
 // SetupWithManager sets up the controller with the Manager.
 func (c securitygroupReconcilerConstructor) SetupWithManager(_ context.Context, mgr ctrl.Manager, options controller.Options) error {
 	reconciler := orcSecurityGroupReconciler{
-		client:       mgr.GetClient(),
-		recorder:     mgr.GetEventRecorderFor("orc-securitygroup-controller"),
-		scopeFactory: c.scopeFactory,
+		client:   mgr.GetClient(),
+		recorder: mgr.GetEventRecorderFor("orc-" + c.GetName() + "-controller"),
+
+		securitygroupReconcilerConstructor: c,
 	}
 
 	return ctrl.NewControllerManagedBy(mgr).

--- a/internal/controllers/securitygroup/reconcile.go
+++ b/internal/controllers/securitygroup/reconcile.go
@@ -77,7 +77,7 @@ func (r *orcSecurityGroupReconciler) reconcileNormal(ctx context.Context, orcObj
 		}
 	}()
 
-	actuator, err := newActuator(ctx, r.client, r.scopeFactory, orcObject)
+	actuator, err := newActuator(ctx, r, orcObject)
 	if err != nil {
 		return ctrl.Result{}, nil
 	}
@@ -141,7 +141,7 @@ func (r *orcSecurityGroupReconciler) reconcileDelete(ctx context.Context, orcObj
 		}
 	}()
 
-	actuator, err := newActuator(ctx, r.client, r.scopeFactory, orcObject)
+	actuator, err := newActuator(ctx, r, orcObject)
 	if err != nil {
 		return ctrl.Result{}, err
 	}

--- a/internal/controllers/server/actuator.go
+++ b/internal/controllers/server/actuator.go
@@ -78,6 +78,10 @@ func newCreateActuator(ctx context.Context, k8sClient client.Client, scopeFactor
 var _ generic.DeleteResourceActuator[*servers.Server] = serverActuator{}
 var _ generic.CreateResourceActuator[*servers.Server] = serverCreateActuator{}
 
+func (serverActuator) GetControllerName() string {
+	return "server"
+}
+
 func (obj serverActuator) GetObject() client.Object {
 	return obj.Server
 }

--- a/internal/controllers/server/actuator.go
+++ b/internal/controllers/server/actuator.go
@@ -78,6 +78,10 @@ func newCreateActuator(ctx context.Context, k8sClient client.Client, scopeFactor
 var _ generic.DeleteResourceActuator[*servers.Server] = serverActuator{}
 var _ generic.CreateResourceActuator[*servers.Server] = serverCreateActuator{}
 
+func (obj serverActuator) GetObject() client.Object {
+	return obj.Server
+}
+
 func (obj serverActuator) GetManagementPolicy() orcv1alpha1.ManagementPolicy {
 	return obj.Spec.ManagementPolicy
 }

--- a/internal/controllers/server/controller.go
+++ b/internal/controllers/server/controller.go
@@ -39,12 +39,8 @@ const (
 	Finalizer = "openstack.k-orc.cloud/server"
 
 	FieldOwner = "openstack.k-orc.cloud/servercontroller"
-	// Field owner of the object finalizer.
-	SSAFinalizerTxn = "finalizer"
 	// Field owner of transient status.
 	SSAStatusTxn = "status"
-	// Field owner of persistent id field.
-	SSAIDTxn = "id"
 )
 
 // ssaFieldOwner returns the field owner for a specific named SSA transaction.

--- a/internal/controllers/server/reconcile.go
+++ b/internal/controllers/server/reconcile.go
@@ -23,18 +23,12 @@ import (
 
 	"github.com/gophercloud/gophercloud/v2/openstack/compute/v2/servers"
 	apierrors "k8s.io/apimachinery/pkg/api/errors"
-	"k8s.io/apimachinery/pkg/types"
 	ctrl "sigs.k8s.io/controller-runtime"
-	"sigs.k8s.io/controller-runtime/pkg/client"
-	"sigs.k8s.io/controller-runtime/pkg/controller/controllerutil"
 
 	orcv1alpha1 "github.com/k-orc/openstack-resource-controller/api/v1alpha1"
-	"github.com/k-orc/openstack-resource-controller/internal/controllers/common"
 	"github.com/k-orc/openstack-resource-controller/internal/controllers/generic"
 	osclients "github.com/k-orc/openstack-resource-controller/internal/osclients"
-	"github.com/k-orc/openstack-resource-controller/internal/util/applyconfigs"
 	orcerrors "github.com/k-orc/openstack-resource-controller/internal/util/errors"
-	orcapplyconfigv1alpha1 "github.com/k-orc/openstack-resource-controller/pkg/clients/applyconfiguration/api/v1alpha1"
 )
 
 // +kubebuilder:rbac:groups=openstack.k-orc.cloud,resources=servers,verbs=get;list;watch;create;update;patch;delete
@@ -80,12 +74,6 @@ func (r *orcServerReconciler) reconcileNormal(ctx context.Context, orcObject *or
 			err = nil
 		}
 	}()
-
-	// Don't add finalizer until parent network is available to avoid unnecessary reconcile on delete
-	if !controllerutil.ContainsFinalizer(orcObject, Finalizer) {
-		patch := common.SetFinalizerPatch(orcObject, Finalizer)
-		return ctrl.Result{}, r.client.Patch(ctx, orcObject, patch, client.ForceOwnership, ssaFieldOwner(SSAFinalizerTxn))
-	}
 
 	actuator, err := newCreateActuator(ctx, r.client, r.scopeFactory, orcObject)
 	if err != nil {
@@ -165,15 +153,9 @@ func (r *orcServerReconciler) reconcileDelete(ctx context.Context, orcObject *or
 	if err != nil {
 		return ctrl.Result{}, nil
 	}
-	osResource, result, err := generic.DeleteResource(ctx, log, actuator, func() error {
-		deleted = true
-
-		// Clear the finalizer
-		applyConfig := orcapplyconfigv1alpha1.Server(orcObject.Name, orcObject.Namespace).WithUID(orcObject.UID)
-		return r.client.Patch(ctx, orcObject, applyconfigs.Patch(types.ApplyPatchType, applyConfig), client.ForceOwnership, ssaFieldOwner(SSAFinalizerTxn))
-	})
+	deleted, waitEvents, osResource, err := generic.DeleteResource(ctx, log, r.client, actuator)
 	addStatus(withResource(osResource))
-	return result, err
+	return ctrl.Result{RequeueAfter: generic.MaxRequeue(waitEvents)}, err
 }
 
 // needsUpdate returns a slice of functions that call the OpenStack API to

--- a/internal/controllers/server/reconcile.go
+++ b/internal/controllers/server/reconcile.go
@@ -75,7 +75,7 @@ func (r *orcServerReconciler) reconcileNormal(ctx context.Context, orcObject *or
 		}
 	}()
 
-	actuator, err := newCreateActuator(ctx, r.client, r.scopeFactory, orcObject)
+	actuator, err := newCreateActuator(ctx, r, orcObject)
 	if err != nil {
 		return ctrl.Result{}, err
 	}
@@ -149,7 +149,7 @@ func (r *orcServerReconciler) reconcileDelete(ctx context.Context, orcObject *or
 		}
 	}()
 
-	actuator, err := newActuator(ctx, r.client, r.scopeFactory, orcObject)
+	actuator, err := newActuator(ctx, r, orcObject)
 	if err != nil {
 		return ctrl.Result{}, nil
 	}

--- a/internal/controllers/server/status.go
+++ b/internal/controllers/server/status.go
@@ -43,7 +43,7 @@ func (r *orcServerReconciler) setStatusID(ctx context.Context, obj client.Object
 		WithStatus(applyconfigv1alpha1.ServerStatus().
 			WithID(id))
 
-	return r.client.Status().Patch(ctx, obj, applyconfigs.Patch(types.ApplyPatchType, applyConfig), client.ForceOwnership, ssaFieldOwner(SSAIDTxn))
+	return r.client.Status().Patch(ctx, obj, applyconfigs.Patch(types.MergePatchType, applyConfig))
 }
 
 type updateStatusOpts struct {

--- a/internal/controllers/subnet/actuator.go
+++ b/internal/controllers/subnet/actuator.go
@@ -108,6 +108,10 @@ func newDeleteActuator(ctx context.Context, k8sClient client.Client, scopeFactor
 	}, nil
 }
 
+func (obj subnetActuator) GetObject() client.Object {
+	return obj.Subnet
+}
+
 func (obj subnetActuator) GetManagementPolicy() orcv1alpha1.ManagementPolicy {
 	return obj.Spec.ManagementPolicy
 }

--- a/internal/controllers/subnet/actuator.go
+++ b/internal/controllers/subnet/actuator.go
@@ -50,9 +50,6 @@ type subnetDeleteActuator struct {
 	k8sClient client.Client
 }
 
-var _ generic.DeleteResourceActuator[*subnets.Subnet] = subnetDeleteActuator{}
-var _ generic.CreateResourceActuator[*subnets.Subnet] = subnetCreateActuator{}
-
 func newActuator(ctx context.Context, k8sClient client.Client, scopeFactory scope.Factory, orcObject *orcv1alpha1.Subnet) (subnetActuator, error) {
 	if orcObject == nil {
 		return subnetActuator{}, fmt.Errorf("orcObject may not be nil")
@@ -106,6 +103,13 @@ func newDeleteActuator(ctx context.Context, k8sClient client.Client, scopeFactor
 		subnetActuator: actuator,
 		k8sClient:      k8sClient,
 	}, nil
+}
+
+var _ generic.DeleteResourceActuator[*subnets.Subnet] = subnetDeleteActuator{}
+var _ generic.CreateResourceActuator[*subnets.Subnet] = subnetCreateActuator{}
+
+func (subnetActuator) GetControllerName() string {
+	return "subnet"
 }
 
 func (obj subnetActuator) GetObject() client.Object {

--- a/internal/controllers/subnet/controller.go
+++ b/internal/controllers/subnet/controller.go
@@ -41,12 +41,8 @@ const (
 	Finalizer = "openstack.k-orc.cloud/subnet"
 
 	FieldOwner = "openstack.k-orc.cloud/subnetcontroller"
-	// Field owner of the object finalizer.
-	SSAFinalizerTxn = "finalizer"
 	// Field owner of transient status.
 	SSAStatusTxn = "status"
-	// Field owner of persistent id field.
-	SSAIDTxn = "id"
 )
 
 // ssaFieldOwner returns the field owner for a specific named SSA transaction.

--- a/internal/controllers/subnet/reconcile.go
+++ b/internal/controllers/subnet/reconcile.go
@@ -81,7 +81,7 @@ func (r *orcSubnetReconciler) reconcileNormal(ctx context.Context, orcObject *or
 		}
 	}()
 
-	waitEvents, actuator, err := newCreateActuator(ctx, r.client, r.scopeFactory, orcObject)
+	waitEvents, actuator, err := newCreateActuator(ctx, r, orcObject)
 	if err != nil {
 		return ctrl.Result{}, err
 	}
@@ -150,7 +150,7 @@ func (r *orcSubnetReconciler) reconcileDelete(ctx context.Context, orcObject *or
 		}
 	}()
 
-	actuator, err := newDeleteActuator(ctx, r.client, r.scopeFactory, orcObject)
+	actuator, err := newDeleteActuator(ctx, r, orcObject)
 	if err != nil {
 		return ctrl.Result{}, nil
 	}

--- a/internal/controllers/subnet/status.go
+++ b/internal/controllers/subnet/status.go
@@ -38,7 +38,7 @@ func (r *orcSubnetReconciler) setStatusID(ctx context.Context, obj client.Object
 		WithStatus(orcapplyconfigv1alpha1.SubnetStatus().
 			WithID(id))
 
-	return r.client.Status().Patch(ctx, obj, applyconfigs.Patch(types.ApplyPatchType, applyConfig), client.ForceOwnership, ssaFieldOwner(SSAIDTxn))
+	return r.client.Status().Patch(ctx, obj, applyconfigs.Patch(types.MergePatchType, applyConfig))
 }
 
 type updateStatusOpts struct {


### PR DESCRIPTION
- **Actuator has GetObject() instead of implementing client.Object**
- **Generic finalizer handling**
- **Add ResourceControllerCommon**

Move finalizer creation and deletion into generic methods. This ensures that it
is done consistently.

This also ensures that we don't add a finalizer until after we have an
authenticated openstack client. This prevents a situation when creating objects
with invalid credentials where the objects can't be deleted without first
fixing the credentials, which is unnecessary as they could never have resulted
in the creation of an OpenStack resource.
