### PR TITLE
Remove Ethertype from the security group example

### DIFF
--- a/examples/bases/cirros/securitygroup.yaml
+++ b/examples/bases/cirros/securitygroup.yaml
@@ -15,4 +15,3 @@ spec:
       protocol: tcp
       portRangeMin: 22
       portRangeMax: 22
-      ethertype: IPv4


### PR DESCRIPTION
As there is a default of IPv4, there is no need to set it explicitly.