### PR TITLE
Remove RemoteGroupID from SecurityGroupRule

### DIFF
--- a/api/v1alpha1/securitygroup_types.go
+++ b/api/v1alpha1/securitygroup_types.go
@@ -44,9 +44,6 @@ type SecurityGroupRule struct {
 
 	// RemoteAddressGroupId (Not in gophercloud)
 
-	// RemoteGroupID
-	RemoteGroupID *UUID `json:"remoteGroupID,omitempty"`
-
 	// RemoteIPPrefix
 	RemoteIPPrefix *CIDR `json:"remoteIPPrefix,omitempty"`
 

--- a/api/v1alpha1/zz_generated.deepcopy.go
+++ b/api/v1alpha1/zz_generated.deepcopy.go
@@ -2132,11 +2132,6 @@ func (in *SecurityGroupRule) DeepCopyInto(out *SecurityGroupRule) {
 		*out = new(RuleDirection)
 		**out = **in
 	}
-	if in.RemoteGroupID != nil {
-		in, out := &in.RemoteGroupID, &out.RemoteGroupID
-		*out = new(UUID)
-		**out = **in
-	}
 	if in.RemoteIPPrefix != nil {
 		in, out := &in.RemoteIPPrefix, &out.RemoteIPPrefix
 		*out = new(CIDR)

--- a/cmd/models-schema/zz_generated.openapi.go
+++ b/cmd/models-schema/zz_generated.openapi.go
@@ -4312,13 +4312,6 @@ func schema_k_orc_openstack_resource_controller_api_v1alpha1_SecurityGroupRule(r
 							Format:      "",
 						},
 					},
-					"remoteGroupID": {
-						SchemaProps: spec.SchemaProps{
-							Description: "RemoteGroupID",
-							Type:        []string{"string"},
-							Format:      "",
-						},
-					},
 					"remoteIPPrefix": {
 						SchemaProps: spec.SchemaProps{
 							Description: "RemoteIPPrefix",

--- a/config/crd/bases/openstack.k-orc.cloud_securitygroups.yaml
+++ b/config/crd/bases/openstack.k-orc.cloud_securitygroups.yaml
@@ -270,11 +270,6 @@ spec:
                           minLength: 1
                           pattern: \b([01]?[0-9][0-9]?|2[0-4][0-9]|25[0-5])\b|any|ah|dccp|egp|esp|gre|icmp|icmpv6|igmp|ipip|ipv6-encap|ipv6-frag|ipv6-icmp|ipv6-nonxt|ipv6-opts|ipv6-route|ospf|pgm|rsvp|sctp|tcp|udp|udplite|vrrp
                           type: string
-                        remoteGroupID:
-                          description: RemoteGroupID
-                          format: uuid
-                          maxLength: 36
-                          type: string
                         remoteIPPrefix:
                           description: RemoteIPPrefix
                           format: cidr

--- a/internal/controllers/securitygroup/actuator.go
+++ b/internal/controllers/securitygroup/actuator.go
@@ -145,7 +145,6 @@ func (obj securityGroupActuator) CreateResource(ctx context.Context) ([]generic.
 			SecGroupID:     osResource.ID,
 			Description:    string(ptr.Deref(resource.Rules[i].Description, "")),
 			Direction:      rules.RuleDirection(ptr.Deref(resource.Rules[i].Direction, "")),
-			RemoteGroupID:  string(ptr.Deref(resource.Rules[i].RemoteGroupID, "")),
 			RemoteIPPrefix: string(ptr.Deref(resource.Rules[i].RemoteIPPrefix, "")),
 			Protocol:       rules.RuleProtocol(ptr.Deref(resource.Rules[i].Protocol, "")),
 			EtherType:      rules.RuleEtherType(ptr.Deref(resource.Rules[i].Ethertype, "")),

--- a/pkg/clients/applyconfiguration/api/v1alpha1/securitygrouprule.go
+++ b/pkg/clients/applyconfiguration/api/v1alpha1/securitygrouprule.go
@@ -27,7 +27,6 @@ import (
 type SecurityGroupRuleApplyConfiguration struct {
 	Description    *v1alpha1.OpenStackDescription `json:"description,omitempty"`
 	Direction      *v1alpha1.RuleDirection        `json:"direction,omitempty"`
-	RemoteGroupID  *v1alpha1.UUID                 `json:"remoteGroupID,omitempty"`
 	RemoteIPPrefix *v1alpha1.CIDR                 `json:"remoteIPPrefix,omitempty"`
 	Protocol       *v1alpha1.Protocol             `json:"protocol,omitempty"`
 	Ethertype      *v1alpha1.Ethertype            `json:"ethertype,omitempty"`
@@ -54,14 +53,6 @@ func (b *SecurityGroupRuleApplyConfiguration) WithDescription(value v1alpha1.Ope
 // If called multiple times, the Direction field is set to the value of the last call.
 func (b *SecurityGroupRuleApplyConfiguration) WithDirection(value v1alpha1.RuleDirection) *SecurityGroupRuleApplyConfiguration {
 	b.Direction = &value
-	return b
-}
-
-// WithRemoteGroupID sets the RemoteGroupID field in the declarative configuration to the given value
-// and returns the receiver, so that objects can be built by chaining "With" function invocations.
-// If called multiple times, the RemoteGroupID field is set to the value of the last call.
-func (b *SecurityGroupRuleApplyConfiguration) WithRemoteGroupID(value v1alpha1.UUID) *SecurityGroupRuleApplyConfiguration {
-	b.RemoteGroupID = &value
 	return b
 }
 

--- a/pkg/clients/applyconfiguration/internal/internal.go
+++ b/pkg/clients/applyconfiguration/internal/internal.go
@@ -1290,9 +1290,6 @@ var schemaYAML = typed.YAMLObject(`types:
     - name: protocol
       type:
         scalar: string
-    - name: remoteGroupID
-      type:
-        scalar: string
     - name: remoteIPPrefix
       type:
         scalar: string


### PR DESCRIPTION
We don't want to dependend on Openstack resources, only on ORC resources