### PR TITLE
Add all CRDs to the openstack category

### DIFF
--- a/api/v1alpha1/zz_generated.flavor-resource.go
+++ b/api/v1alpha1/zz_generated.flavor-resource.go
@@ -118,6 +118,7 @@ func (i *Flavor) GetConditions() []metav1.Condition {
 
 // +genclient
 // +kubebuilder:object:root=true
+// +kubebuilder:resource:categories=openstack
 // +kubebuilder:subresource:status
 // +kubebuilder:printcolumn:name="ID",type="string",JSONPath=".status.id",description="Resource ID"
 // +kubebuilder:printcolumn:name="Available",type="string",JSONPath=".status.conditions[?(@.type=='Available')].status",description="Availability status of resource"

--- a/api/v1alpha1/zz_generated.image-resource.go
+++ b/api/v1alpha1/zz_generated.image-resource.go
@@ -121,6 +121,7 @@ func (i *Image) GetConditions() []metav1.Condition {
 
 // +genclient
 // +kubebuilder:object:root=true
+// +kubebuilder:resource:categories=openstack
 // +kubebuilder:subresource:status
 // +kubebuilder:printcolumn:name="ID",type="string",JSONPath=".status.id",description="Resource ID"
 // +kubebuilder:printcolumn:name="Available",type="string",JSONPath=".status.conditions[?(@.type=='Available')].status",description="Availability status of resource"

--- a/api/v1alpha1/zz_generated.network-resource.go
+++ b/api/v1alpha1/zz_generated.network-resource.go
@@ -118,6 +118,7 @@ func (i *Network) GetConditions() []metav1.Condition {
 
 // +genclient
 // +kubebuilder:object:root=true
+// +kubebuilder:resource:categories=openstack
 // +kubebuilder:subresource:status
 // +kubebuilder:printcolumn:name="ID",type="string",JSONPath=".status.id",description="Resource ID"
 // +kubebuilder:printcolumn:name="Available",type="string",JSONPath=".status.conditions[?(@.type=='Available')].status",description="Availability status of resource"

--- a/api/v1alpha1/zz_generated.port-resource.go
+++ b/api/v1alpha1/zz_generated.port-resource.go
@@ -120,6 +120,7 @@ func (i *Port) GetConditions() []metav1.Condition {
 
 // +genclient
 // +kubebuilder:object:root=true
+// +kubebuilder:resource:categories=openstack
 // +kubebuilder:subresource:status
 // +kubebuilder:printcolumn:name="ID",type="string",JSONPath=".status.id",description="Resource ID"
 // +kubebuilder:printcolumn:name="Available",type="string",JSONPath=".status.conditions[?(@.type=='Available')].status",description="Availability status of resource"

--- a/api/v1alpha1/zz_generated.router-resource.go
+++ b/api/v1alpha1/zz_generated.router-resource.go
@@ -118,6 +118,7 @@ func (i *Router) GetConditions() []metav1.Condition {
 
 // +genclient
 // +kubebuilder:object:root=true
+// +kubebuilder:resource:categories=openstack
 // +kubebuilder:subresource:status
 // +kubebuilder:printcolumn:name="ID",type="string",JSONPath=".status.id",description="Resource ID"
 // +kubebuilder:printcolumn:name="Available",type="string",JSONPath=".status.conditions[?(@.type=='Available')].status",description="Availability status of resource"

--- a/api/v1alpha1/zz_generated.securitygroup-resource.go
+++ b/api/v1alpha1/zz_generated.securitygroup-resource.go
@@ -118,6 +118,7 @@ func (i *SecurityGroup) GetConditions() []metav1.Condition {
 
 // +genclient
 // +kubebuilder:object:root=true
+// +kubebuilder:resource:categories=openstack
 // +kubebuilder:subresource:status
 // +kubebuilder:printcolumn:name="ID",type="string",JSONPath=".status.id",description="Resource ID"
 // +kubebuilder:printcolumn:name="Available",type="string",JSONPath=".status.conditions[?(@.type=='Available')].status",description="Availability status of resource"

--- a/api/v1alpha1/zz_generated.server-resource.go
+++ b/api/v1alpha1/zz_generated.server-resource.go
@@ -118,6 +118,7 @@ func (i *Server) GetConditions() []metav1.Condition {
 
 // +genclient
 // +kubebuilder:object:root=true
+// +kubebuilder:resource:categories=openstack
 // +kubebuilder:subresource:status
 // +kubebuilder:printcolumn:name="ID",type="string",JSONPath=".status.id",description="Resource ID"
 // +kubebuilder:printcolumn:name="Available",type="string",JSONPath=".status.conditions[?(@.type=='Available')].status",description="Availability status of resource"

--- a/api/v1alpha1/zz_generated.subnet-resource.go
+++ b/api/v1alpha1/zz_generated.subnet-resource.go
@@ -120,6 +120,7 @@ func (i *Subnet) GetConditions() []metav1.Condition {
 
 // +genclient
 // +kubebuilder:object:root=true
+// +kubebuilder:resource:categories=openstack
 // +kubebuilder:subresource:status
 // +kubebuilder:printcolumn:name="ID",type="string",JSONPath=".status.id",description="Resource ID"
 // +kubebuilder:printcolumn:name="Available",type="string",JSONPath=".status.conditions[?(@.type=='Available')].status",description="Availability status of resource"

--- a/cmd/resource-generator/data/api.template
+++ b/cmd/resource-generator/data/api.template
@@ -127,6 +127,7 @@ func (i *{{ .Name }}) GetConditions() []metav1.Condition {
 
 // +genclient
 // +kubebuilder:object:root=true
+// +kubebuilder:resource:categories=openstack
 // +kubebuilder:subresource:status
 // +kubebuilder:printcolumn:name="ID",type="string",JSONPath=".status.id",description="Resource ID"
 // +kubebuilder:printcolumn:name="Available",type="string",JSONPath=".status.conditions[?(@.type=='Available')].status",description="Availability status of resource"

--- a/config/crd/bases/openstack.k-orc.cloud_flavors.yaml
+++ b/config/crd/bases/openstack.k-orc.cloud_flavors.yaml
@@ -8,6 +8,8 @@ metadata:
 spec:
   group: openstack.k-orc.cloud
   names:
+    categories:
+    - openstack
     kind: Flavor
     listKind: FlavorList
     plural: flavors

--- a/config/crd/bases/openstack.k-orc.cloud_images.yaml
+++ b/config/crd/bases/openstack.k-orc.cloud_images.yaml
@@ -8,6 +8,8 @@ metadata:
 spec:
   group: openstack.k-orc.cloud
   names:
+    categories:
+    - openstack
     kind: Image
     listKind: ImageList
     plural: images

--- a/config/crd/bases/openstack.k-orc.cloud_networks.yaml
+++ b/config/crd/bases/openstack.k-orc.cloud_networks.yaml
@@ -8,6 +8,8 @@ metadata:
 spec:
   group: openstack.k-orc.cloud
   names:
+    categories:
+    - openstack
     kind: Network
     listKind: NetworkList
     plural: networks

--- a/config/crd/bases/openstack.k-orc.cloud_ports.yaml
+++ b/config/crd/bases/openstack.k-orc.cloud_ports.yaml
@@ -8,6 +8,8 @@ metadata:
 spec:
   group: openstack.k-orc.cloud
   names:
+    categories:
+    - openstack
     kind: Port
     listKind: PortList
     plural: ports

--- a/config/crd/bases/openstack.k-orc.cloud_routers.yaml
+++ b/config/crd/bases/openstack.k-orc.cloud_routers.yaml
@@ -8,6 +8,8 @@ metadata:
 spec:
   group: openstack.k-orc.cloud
   names:
+    categories:
+    - openstack
     kind: Router
     listKind: RouterList
     plural: routers

--- a/config/crd/bases/openstack.k-orc.cloud_securitygroups.yaml
+++ b/config/crd/bases/openstack.k-orc.cloud_securitygroups.yaml
@@ -8,6 +8,8 @@ metadata:
 spec:
   group: openstack.k-orc.cloud
   names:
+    categories:
+    - openstack
     kind: SecurityGroup
     listKind: SecurityGroupList
     plural: securitygroups

--- a/config/crd/bases/openstack.k-orc.cloud_servers.yaml
+++ b/config/crd/bases/openstack.k-orc.cloud_servers.yaml
@@ -8,6 +8,8 @@ metadata:
 spec:
   group: openstack.k-orc.cloud
   names:
+    categories:
+    - openstack
     kind: Server
     listKind: ServerList
     plural: servers

--- a/config/crd/bases/openstack.k-orc.cloud_subnets.yaml
+++ b/config/crd/bases/openstack.k-orc.cloud_subnets.yaml
@@ -8,6 +8,8 @@ metadata:
 spec:
   group: openstack.k-orc.cloud
   names:
+    categories:
+    - openstack
     kind: Subnet
     listKind: SubnetList
     plural: subnets


### PR DESCRIPTION
This allows the user to do 'kubectl get openstack' to list all ORC OpenStack resources
of every type, e.g.:

```bash
$ kubectl get openstack
NAME                                                ID                                     AVAILABLE   MESSAGE                           AGE
flavor.openstack.k-orc.cloud/mbooth-cirros-flavor   5b2647a4-888f-4993-87c7-92851d21da01   True        OpenStack resource is available   49s

NAME                                               ID                                     AVAILABLE   MESSAGE                     AGE
image.openstack.k-orc.cloud/mbooth-cirros-cirros   d11a362a-a4c5-4141-b0d3-7ad41f486607   True        Glance image is available   49s

NAME                                                           ID                                     AVAILABLE   MESSAGE                           AGE
network.openstack.k-orc.cloud/mbooth-cirros-provider-network   3fdeb18a-2ad4-4536-bc23-c3c488a382ad   True        OpenStack resource is available   49s

NAME                                            ID                                     AVAILABLE   MESSAGE                           AGE
port.openstack.k-orc.cloud/mbooth-cirros-port   656c452f-5cc1-4d8c-b54b-14eb04e5df1c   True        OpenStack resource is available   49s

NAME                                                          ID                                     AVAILABLE   MESSAGE                           AGE
securitygroup.openstack.k-orc.cloud/mbooth-cirros-allow-ssh   34d2f291-c47c-41f5-9a86-0f1e8f34875a   True        OpenStack resource is available   49s

NAME                                                ID                                     AVAILABLE   MESSAGE                           AGE
server.openstack.k-orc.cloud/mbooth-cirros-server   c832db5e-38de-4a35-87f4-341ef09373e8   True        OpenStack resource is available   49s

NAME                                                              ID                                     AVAILABLE   MESSAGE                           AGE
subnet.openstack.k-orc.cloud/mbooth-cirros-provider-subnet-ipv4   489315d5-1d84-4b7f-9349-f5a14faff452   True        OpenStack resource is available   49s
subnet.openstack.k-orc.cloud/mbooth-cirros-provider-subnet-ipv6   e4dba1d2-f211-4d19-96f9-367eb281a41d   True        OpenStack resource is available   49s
```