### PR TITLE
Stop pushing a latest tag for container images

### DIFF
--- a/.github/workflows/container_image.yaml
+++ b/.github/workflows/container_image.yaml
@@ -9,7 +9,6 @@ permissions:
   contents: read
 
 env:
-  image_tag_latest: quay.io/orc/openstack-resource-controller:latest
   image_tag_branch: quay.io/orc/openstack-resource-controller:branch-${GITHUB_REF_NAME}
   image_tag_commit: quay.io/orc/openstack-resource-controller:commit-${GITHUB_SHA::7}
 
@@ -23,9 +22,8 @@ jobs:
     - run: |
         docker login -u="${{ secrets.QUAY_USERNAME }}" -p="${{ secrets.QUAY_TOKEN }}" quay.io
 
-        docker build -t ${{ env.image_tag_branch }} -t ${{ env.image_tag_latest }} .
+        docker build -t ${{ env.image_tag_branch }} .
         docker push ${{ env.image_tag_branch }}
-        docker push ${{ env.image_tag_latest }}
 
         docker build -t ${{ env.image_tag_commit }} --label quay.expires-after=4w .
         docker push ${{ env.image_tag_commit }}


### PR DESCRIPTION
We don't want users to accidentally get nasty surprises on major bumps.

To follow the development branch, use `branch-main` tag instead, however you should know that we could introduce breaking changes at anytime in the development branch. You've been warned.