### PR TITLE
Fix KAL offences in generated API

### DIFF
--- a/api/v1alpha1/zz_generated.flavor-resource.go
+++ b/api/v1alpha1/zz_generated.flavor-resource.go
@@ -26,14 +26,14 @@ import (
 // +kubebuilder:validation:MinProperties:=1
 // +kubebuilder:validation:MaxProperties:=1
 type FlavorImport struct {
-	// ID contains the unique identifier of an existing OpenStack resource. Note
+	// id contains the unique identifier of an existing OpenStack resource. Note
 	// that when specifying an import by ID, the resource MUST already exist.
 	// The ORC object will enter an error state if the resource does not exist.
 	// +optional
 	// +kubebuilder:validation:Format:=uuid
 	ID *string `json:"id,omitempty"`
 
-	// Filter contains a resource query which is expected to return a single
+	// filter contains a resource query which is expected to return a single
 	// result. The controller will continue to retry if filter returns no
 	// results. If filter returns multiple results the controller will set an
 	// error state and will not continue to retry.
@@ -48,20 +48,20 @@ type FlavorImport struct {
 // +kubebuilder:validation:XValidation:rule="self.managementPolicy == 'unmanaged' ? has(self.__import__) : true",message="import must be specified when policy is unmanaged"
 // +kubebuilder:validation:XValidation:rule="has(self.managedOptions) ? self.managementPolicy == 'managed' : true",message="managedOptions may only be provided when policy is managed"
 type FlavorSpec struct {
-	// Import refers to an existing OpenStack resource which will be imported instead of
+	// import refers to an existing OpenStack resource which will be imported instead of
 	// creating a new one.
 	// +optional
 	Import *FlavorImport `json:"import,omitempty"`
 
-	// Resource specifies the desired state of the resource.
+	// resource specifies the desired state of the resource.
 	//
-	// Resource may not be specified if the management policy is `unmanaged`.
+	// resource may not be specified if the management policy is `unmanaged`.
 	//
-	// Resource must be specified if the management policy is `managed`.
+	// resource must be specified if the management policy is `managed`.
 	// +optional
 	Resource *FlavorResourceSpec `json:"resource,omitempty"`
 
-	// ManagementPolicy defines how ORC will treat the object. Valid values are
+	// managementPolicy defines how ORC will treat the object. Valid values are
 	// `managed`: ORC will create, update, and delete the resource; `unmanaged`:
 	// ORC will import an existing resource, and will not apply updates to it or
 	// delete it.
@@ -70,18 +70,18 @@ type FlavorSpec struct {
 	// +optional
 	ManagementPolicy ManagementPolicy `json:"managementPolicy,omitempty"`
 
-	// ManagedOptions specifies options which may be applied to managed objects.
+	// managedOptions specifies options which may be applied to managed objects.
 	// +optional
 	ManagedOptions *ManagedOptions `json:"managedOptions,omitempty"`
 
-	// CloudCredentialsRef points to a secret containing OpenStack credentials
-	// +kubebuilder:validation:Required
+	// cloudCredentialsRef points to a secret containing OpenStack credentials
+	// +required
 	CloudCredentialsRef CloudCredentialsReference `json:"cloudCredentialsRef"`
 }
 
 // FlavorStatus defines the observed state of an ORC resource.
 type FlavorStatus struct {
-	// Conditions represents the observed status of the object.
+	// conditions represents the observed status of the object.
 	// Known .status.conditions.type are: "Available", "Progressing"
 	//
 	// Available represents the availability of the OpenStack resource. If it is
@@ -99,13 +99,14 @@ type FlavorStatus struct {
 	// +patchStrategy=merge
 	// +listType=map
 	// +listMapKey=type
+	// +optional
 	Conditions []metav1.Condition `json:"conditions,omitempty" patchStrategy:"merge" patchMergeKey:"type"`
 
-	// ID is the unique identifier of the OpenStack resource.
+	// id is the unique identifier of the OpenStack resource.
 	// +optional
 	ID *string `json:"id,omitempty"`
 
-	// Resource contains the observed state of the OpenStack resource.
+	// resource contains the observed state of the OpenStack resource.
 	// +optional
 	Resource *FlavorResourceStatus `json:"resource,omitempty"`
 }
@@ -128,9 +129,17 @@ func (i *Flavor) GetConditions() []metav1.Condition {
 // Flavor is the Schema for an ORC resource.
 type Flavor struct {
 	metav1.TypeMeta   `json:",inline"`
+
+	// metadata contains the object metadata
+	// +optional
 	metav1.ObjectMeta `json:"metadata,omitempty"`
 
+	// spec specifies the desired state of the resource.
+	// +optional
 	Spec   FlavorSpec   `json:"spec,omitempty"`
+
+	// status defines the observed state of the resource.
+	// +optional
 	Status FlavorStatus `json:"status,omitempty"`
 }
 
@@ -139,7 +148,13 @@ type Flavor struct {
 // FlavorList contains a list of Flavor.
 type FlavorList struct {
 	metav1.TypeMeta `json:",inline"`
+
+	// metadata contains the list metadata
+	// +optional
 	metav1.ListMeta `json:"metadata,omitempty"`
+
+	// items contains a list of Flavor.
+	// +required
 	Items           []Flavor `json:"items"`
 }
 

--- a/api/v1alpha1/zz_generated.image-resource.go
+++ b/api/v1alpha1/zz_generated.image-resource.go
@@ -26,14 +26,14 @@ import (
 // +kubebuilder:validation:MinProperties:=1
 // +kubebuilder:validation:MaxProperties:=1
 type ImageImport struct {
-	// ID contains the unique identifier of an existing OpenStack resource. Note
+	// id contains the unique identifier of an existing OpenStack resource. Note
 	// that when specifying an import by ID, the resource MUST already exist.
 	// The ORC object will enter an error state if the resource does not exist.
 	// +optional
 	// +kubebuilder:validation:Format:=uuid
 	ID *string `json:"id,omitempty"`
 
-	// Filter contains a resource query which is expected to return a single
+	// filter contains a resource query which is expected to return a single
 	// result. The controller will continue to retry if filter returns no
 	// results. If filter returns multiple results the controller will set an
 	// error state and will not continue to retry.
@@ -49,20 +49,20 @@ type ImageImport struct {
 // +kubebuilder:validation:XValidation:rule="has(self.managedOptions) ? self.managementPolicy == 'managed' : true",message="managedOptions may only be provided when policy is managed"
 // +kubebuilder:validation:XValidation:rule="!has(self.__import__) ? has(self.resource.content) : true",message="resource content must be specified when not importing"
 type ImageSpec struct {
-	// Import refers to an existing OpenStack resource which will be imported instead of
+	// import refers to an existing OpenStack resource which will be imported instead of
 	// creating a new one.
 	// +optional
 	Import *ImageImport `json:"import,omitempty"`
 
-	// Resource specifies the desired state of the resource.
+	// resource specifies the desired state of the resource.
 	//
-	// Resource may not be specified if the management policy is `unmanaged`.
+	// resource may not be specified if the management policy is `unmanaged`.
 	//
-	// Resource must be specified if the management policy is `managed`.
+	// resource must be specified if the management policy is `managed`.
 	// +optional
 	Resource *ImageResourceSpec `json:"resource,omitempty"`
 
-	// ManagementPolicy defines how ORC will treat the object. Valid values are
+	// managementPolicy defines how ORC will treat the object. Valid values are
 	// `managed`: ORC will create, update, and delete the resource; `unmanaged`:
 	// ORC will import an existing resource, and will not apply updates to it or
 	// delete it.
@@ -71,18 +71,18 @@ type ImageSpec struct {
 	// +optional
 	ManagementPolicy ManagementPolicy `json:"managementPolicy,omitempty"`
 
-	// ManagedOptions specifies options which may be applied to managed objects.
+	// managedOptions specifies options which may be applied to managed objects.
 	// +optional
 	ManagedOptions *ManagedOptions `json:"managedOptions,omitempty"`
 
-	// CloudCredentialsRef points to a secret containing OpenStack credentials
-	// +kubebuilder:validation:Required
+	// cloudCredentialsRef points to a secret containing OpenStack credentials
+	// +required
 	CloudCredentialsRef CloudCredentialsReference `json:"cloudCredentialsRef"`
 }
 
 // ImageStatus defines the observed state of an ORC resource.
 type ImageStatus struct {
-	// Conditions represents the observed status of the object.
+	// conditions represents the observed status of the object.
 	// Known .status.conditions.type are: "Available", "Progressing"
 	//
 	// Available represents the availability of the OpenStack resource. If it is
@@ -100,13 +100,14 @@ type ImageStatus struct {
 	// +patchStrategy=merge
 	// +listType=map
 	// +listMapKey=type
+	// +optional
 	Conditions []metav1.Condition `json:"conditions,omitempty" patchStrategy:"merge" patchMergeKey:"type"`
 
-	// ID is the unique identifier of the OpenStack resource.
+	// id is the unique identifier of the OpenStack resource.
 	// +optional
 	ID *string `json:"id,omitempty"`
 
-	// Resource contains the observed state of the OpenStack resource.
+	// resource contains the observed state of the OpenStack resource.
 	// +optional
 	Resource *ImageResourceStatus `json:"resource,omitempty"`
 
@@ -131,9 +132,17 @@ func (i *Image) GetConditions() []metav1.Condition {
 // Image is the Schema for an ORC resource.
 type Image struct {
 	metav1.TypeMeta   `json:",inline"`
+
+	// metadata contains the object metadata
+	// +optional
 	metav1.ObjectMeta `json:"metadata,omitempty"`
 
+	// spec specifies the desired state of the resource.
+	// +optional
 	Spec   ImageSpec   `json:"spec,omitempty"`
+
+	// status defines the observed state of the resource.
+	// +optional
 	Status ImageStatus `json:"status,omitempty"`
 }
 
@@ -142,7 +151,13 @@ type Image struct {
 // ImageList contains a list of Image.
 type ImageList struct {
 	metav1.TypeMeta `json:",inline"`
+
+	// metadata contains the list metadata
+	// +optional
 	metav1.ListMeta `json:"metadata,omitempty"`
+
+	// items contains a list of Image.
+	// +required
 	Items           []Image `json:"items"`
 }
 

--- a/api/v1alpha1/zz_generated.network-resource.go
+++ b/api/v1alpha1/zz_generated.network-resource.go
@@ -26,14 +26,14 @@ import (
 // +kubebuilder:validation:MinProperties:=1
 // +kubebuilder:validation:MaxProperties:=1
 type NetworkImport struct {
-	// ID contains the unique identifier of an existing OpenStack resource. Note
+	// id contains the unique identifier of an existing OpenStack resource. Note
 	// that when specifying an import by ID, the resource MUST already exist.
 	// The ORC object will enter an error state if the resource does not exist.
 	// +optional
 	// +kubebuilder:validation:Format:=uuid
 	ID *string `json:"id,omitempty"`
 
-	// Filter contains a resource query which is expected to return a single
+	// filter contains a resource query which is expected to return a single
 	// result. The controller will continue to retry if filter returns no
 	// results. If filter returns multiple results the controller will set an
 	// error state and will not continue to retry.
@@ -48,20 +48,20 @@ type NetworkImport struct {
 // +kubebuilder:validation:XValidation:rule="self.managementPolicy == 'unmanaged' ? has(self.__import__) : true",message="import must be specified when policy is unmanaged"
 // +kubebuilder:validation:XValidation:rule="has(self.managedOptions) ? self.managementPolicy == 'managed' : true",message="managedOptions may only be provided when policy is managed"
 type NetworkSpec struct {
-	// Import refers to an existing OpenStack resource which will be imported instead of
+	// import refers to an existing OpenStack resource which will be imported instead of
 	// creating a new one.
 	// +optional
 	Import *NetworkImport `json:"import,omitempty"`
 
-	// Resource specifies the desired state of the resource.
+	// resource specifies the desired state of the resource.
 	//
-	// Resource may not be specified if the management policy is `unmanaged`.
+	// resource may not be specified if the management policy is `unmanaged`.
 	//
-	// Resource must be specified if the management policy is `managed`.
+	// resource must be specified if the management policy is `managed`.
 	// +optional
 	Resource *NetworkResourceSpec `json:"resource,omitempty"`
 
-	// ManagementPolicy defines how ORC will treat the object. Valid values are
+	// managementPolicy defines how ORC will treat the object. Valid values are
 	// `managed`: ORC will create, update, and delete the resource; `unmanaged`:
 	// ORC will import an existing resource, and will not apply updates to it or
 	// delete it.
@@ -70,18 +70,18 @@ type NetworkSpec struct {
 	// +optional
 	ManagementPolicy ManagementPolicy `json:"managementPolicy,omitempty"`
 
-	// ManagedOptions specifies options which may be applied to managed objects.
+	// managedOptions specifies options which may be applied to managed objects.
 	// +optional
 	ManagedOptions *ManagedOptions `json:"managedOptions,omitempty"`
 
-	// CloudCredentialsRef points to a secret containing OpenStack credentials
-	// +kubebuilder:validation:Required
+	// cloudCredentialsRef points to a secret containing OpenStack credentials
+	// +required
 	CloudCredentialsRef CloudCredentialsReference `json:"cloudCredentialsRef"`
 }
 
 // NetworkStatus defines the observed state of an ORC resource.
 type NetworkStatus struct {
-	// Conditions represents the observed status of the object.
+	// conditions represents the observed status of the object.
 	// Known .status.conditions.type are: "Available", "Progressing"
 	//
 	// Available represents the availability of the OpenStack resource. If it is
@@ -99,13 +99,14 @@ type NetworkStatus struct {
 	// +patchStrategy=merge
 	// +listType=map
 	// +listMapKey=type
+	// +optional
 	Conditions []metav1.Condition `json:"conditions,omitempty" patchStrategy:"merge" patchMergeKey:"type"`
 
-	// ID is the unique identifier of the OpenStack resource.
+	// id is the unique identifier of the OpenStack resource.
 	// +optional
 	ID *string `json:"id,omitempty"`
 
-	// Resource contains the observed state of the OpenStack resource.
+	// resource contains the observed state of the OpenStack resource.
 	// +optional
 	Resource *NetworkResourceStatus `json:"resource,omitempty"`
 }
@@ -128,9 +129,17 @@ func (i *Network) GetConditions() []metav1.Condition {
 // Network is the Schema for an ORC resource.
 type Network struct {
 	metav1.TypeMeta   `json:",inline"`
+
+	// metadata contains the object metadata
+	// +optional
 	metav1.ObjectMeta `json:"metadata,omitempty"`
 
+	// spec specifies the desired state of the resource.
+	// +optional
 	Spec   NetworkSpec   `json:"spec,omitempty"`
+
+	// status defines the observed state of the resource.
+	// +optional
 	Status NetworkStatus `json:"status,omitempty"`
 }
 
@@ -139,7 +148,13 @@ type Network struct {
 // NetworkList contains a list of Network.
 type NetworkList struct {
 	metav1.TypeMeta `json:",inline"`
+
+	// metadata contains the list metadata
+	// +optional
 	metav1.ListMeta `json:"metadata,omitempty"`
+
+	// items contains a list of Network.
+	// +required
 	Items           []Network `json:"items"`
 }
 

--- a/api/v1alpha1/zz_generated.port-resource.go
+++ b/api/v1alpha1/zz_generated.port-resource.go
@@ -26,14 +26,14 @@ import (
 // +kubebuilder:validation:MinProperties:=1
 // +kubebuilder:validation:MaxProperties:=1
 type PortImport struct {
-	// ID contains the unique identifier of an existing OpenStack resource. Note
+	// id contains the unique identifier of an existing OpenStack resource. Note
 	// that when specifying an import by ID, the resource MUST already exist.
 	// The ORC object will enter an error state if the resource does not exist.
 	// +optional
 	// +kubebuilder:validation:Format:=uuid
 	ID *string `json:"id,omitempty"`
 
-	// Filter contains a resource query which is expected to return a single
+	// filter contains a resource query which is expected to return a single
 	// result. The controller will continue to retry if filter returns no
 	// results. If filter returns multiple results the controller will set an
 	// error state and will not continue to retry.
@@ -50,20 +50,20 @@ type PortImport struct {
 type PortSpec struct {
 	PortRefs `json:",inline"`
 
-	// Import refers to an existing OpenStack resource which will be imported instead of
+	// import refers to an existing OpenStack resource which will be imported instead of
 	// creating a new one.
 	// +optional
 	Import *PortImport `json:"import,omitempty"`
 
-	// Resource specifies the desired state of the resource.
+	// resource specifies the desired state of the resource.
 	//
-	// Resource may not be specified if the management policy is `unmanaged`.
+	// resource may not be specified if the management policy is `unmanaged`.
 	//
-	// Resource must be specified if the management policy is `managed`.
+	// resource must be specified if the management policy is `managed`.
 	// +optional
 	Resource *PortResourceSpec `json:"resource,omitempty"`
 
-	// ManagementPolicy defines how ORC will treat the object. Valid values are
+	// managementPolicy defines how ORC will treat the object. Valid values are
 	// `managed`: ORC will create, update, and delete the resource; `unmanaged`:
 	// ORC will import an existing resource, and will not apply updates to it or
 	// delete it.
@@ -72,18 +72,18 @@ type PortSpec struct {
 	// +optional
 	ManagementPolicy ManagementPolicy `json:"managementPolicy,omitempty"`
 
-	// ManagedOptions specifies options which may be applied to managed objects.
+	// managedOptions specifies options which may be applied to managed objects.
 	// +optional
 	ManagedOptions *ManagedOptions `json:"managedOptions,omitempty"`
 
-	// CloudCredentialsRef points to a secret containing OpenStack credentials
-	// +kubebuilder:validation:Required
+	// cloudCredentialsRef points to a secret containing OpenStack credentials
+	// +required
 	CloudCredentialsRef CloudCredentialsReference `json:"cloudCredentialsRef"`
 }
 
 // PortStatus defines the observed state of an ORC resource.
 type PortStatus struct {
-	// Conditions represents the observed status of the object.
+	// conditions represents the observed status of the object.
 	// Known .status.conditions.type are: "Available", "Progressing"
 	//
 	// Available represents the availability of the OpenStack resource. If it is
@@ -101,13 +101,14 @@ type PortStatus struct {
 	// +patchStrategy=merge
 	// +listType=map
 	// +listMapKey=type
+	// +optional
 	Conditions []metav1.Condition `json:"conditions,omitempty" patchStrategy:"merge" patchMergeKey:"type"`
 
-	// ID is the unique identifier of the OpenStack resource.
+	// id is the unique identifier of the OpenStack resource.
 	// +optional
 	ID *string `json:"id,omitempty"`
 
-	// Resource contains the observed state of the OpenStack resource.
+	// resource contains the observed state of the OpenStack resource.
 	// +optional
 	Resource *PortResourceStatus `json:"resource,omitempty"`
 }
@@ -130,9 +131,17 @@ func (i *Port) GetConditions() []metav1.Condition {
 // Port is the Schema for an ORC resource.
 type Port struct {
 	metav1.TypeMeta   `json:",inline"`
+
+	// metadata contains the object metadata
+	// +optional
 	metav1.ObjectMeta `json:"metadata,omitempty"`
 
+	// spec specifies the desired state of the resource.
+	// +optional
 	Spec   PortSpec   `json:"spec,omitempty"`
+
+	// status defines the observed state of the resource.
+	// +optional
 	Status PortStatus `json:"status,omitempty"`
 }
 
@@ -141,7 +150,13 @@ type Port struct {
 // PortList contains a list of Port.
 type PortList struct {
 	metav1.TypeMeta `json:",inline"`
+
+	// metadata contains the list metadata
+	// +optional
 	metav1.ListMeta `json:"metadata,omitempty"`
+
+	// items contains a list of Port.
+	// +required
 	Items           []Port `json:"items"`
 }
 

--- a/api/v1alpha1/zz_generated.router-resource.go
+++ b/api/v1alpha1/zz_generated.router-resource.go
@@ -26,14 +26,14 @@ import (
 // +kubebuilder:validation:MinProperties:=1
 // +kubebuilder:validation:MaxProperties:=1
 type RouterImport struct {
-	// ID contains the unique identifier of an existing OpenStack resource. Note
+	// id contains the unique identifier of an existing OpenStack resource. Note
 	// that when specifying an import by ID, the resource MUST already exist.
 	// The ORC object will enter an error state if the resource does not exist.
 	// +optional
 	// +kubebuilder:validation:Format:=uuid
 	ID *string `json:"id,omitempty"`
 
-	// Filter contains a resource query which is expected to return a single
+	// filter contains a resource query which is expected to return a single
 	// result. The controller will continue to retry if filter returns no
 	// results. If filter returns multiple results the controller will set an
 	// error state and will not continue to retry.
@@ -48,20 +48,20 @@ type RouterImport struct {
 // +kubebuilder:validation:XValidation:rule="self.managementPolicy == 'unmanaged' ? has(self.__import__) : true",message="import must be specified when policy is unmanaged"
 // +kubebuilder:validation:XValidation:rule="has(self.managedOptions) ? self.managementPolicy == 'managed' : true",message="managedOptions may only be provided when policy is managed"
 type RouterSpec struct {
-	// Import refers to an existing OpenStack resource which will be imported instead of
+	// import refers to an existing OpenStack resource which will be imported instead of
 	// creating a new one.
 	// +optional
 	Import *RouterImport `json:"import,omitempty"`
 
-	// Resource specifies the desired state of the resource.
+	// resource specifies the desired state of the resource.
 	//
-	// Resource may not be specified if the management policy is `unmanaged`.
+	// resource may not be specified if the management policy is `unmanaged`.
 	//
-	// Resource must be specified if the management policy is `managed`.
+	// resource must be specified if the management policy is `managed`.
 	// +optional
 	Resource *RouterResourceSpec `json:"resource,omitempty"`
 
-	// ManagementPolicy defines how ORC will treat the object. Valid values are
+	// managementPolicy defines how ORC will treat the object. Valid values are
 	// `managed`: ORC will create, update, and delete the resource; `unmanaged`:
 	// ORC will import an existing resource, and will not apply updates to it or
 	// delete it.
@@ -70,18 +70,18 @@ type RouterSpec struct {
 	// +optional
 	ManagementPolicy ManagementPolicy `json:"managementPolicy,omitempty"`
 
-	// ManagedOptions specifies options which may be applied to managed objects.
+	// managedOptions specifies options which may be applied to managed objects.
 	// +optional
 	ManagedOptions *ManagedOptions `json:"managedOptions,omitempty"`
 
-	// CloudCredentialsRef points to a secret containing OpenStack credentials
-	// +kubebuilder:validation:Required
+	// cloudCredentialsRef points to a secret containing OpenStack credentials
+	// +required
 	CloudCredentialsRef CloudCredentialsReference `json:"cloudCredentialsRef"`
 }
 
 // RouterStatus defines the observed state of an ORC resource.
 type RouterStatus struct {
-	// Conditions represents the observed status of the object.
+	// conditions represents the observed status of the object.
 	// Known .status.conditions.type are: "Available", "Progressing"
 	//
 	// Available represents the availability of the OpenStack resource. If it is
@@ -99,13 +99,14 @@ type RouterStatus struct {
 	// +patchStrategy=merge
 	// +listType=map
 	// +listMapKey=type
+	// +optional
 	Conditions []metav1.Condition `json:"conditions,omitempty" patchStrategy:"merge" patchMergeKey:"type"`
 
-	// ID is the unique identifier of the OpenStack resource.
+	// id is the unique identifier of the OpenStack resource.
 	// +optional
 	ID *string `json:"id,omitempty"`
 
-	// Resource contains the observed state of the OpenStack resource.
+	// resource contains the observed state of the OpenStack resource.
 	// +optional
 	Resource *RouterResourceStatus `json:"resource,omitempty"`
 }
@@ -128,9 +129,17 @@ func (i *Router) GetConditions() []metav1.Condition {
 // Router is the Schema for an ORC resource.
 type Router struct {
 	metav1.TypeMeta   `json:",inline"`
+
+	// metadata contains the object metadata
+	// +optional
 	metav1.ObjectMeta `json:"metadata,omitempty"`
 
+	// spec specifies the desired state of the resource.
+	// +optional
 	Spec   RouterSpec   `json:"spec,omitempty"`
+
+	// status defines the observed state of the resource.
+	// +optional
 	Status RouterStatus `json:"status,omitempty"`
 }
 
@@ -139,7 +148,13 @@ type Router struct {
 // RouterList contains a list of Router.
 type RouterList struct {
 	metav1.TypeMeta `json:",inline"`
+
+	// metadata contains the list metadata
+	// +optional
 	metav1.ListMeta `json:"metadata,omitempty"`
+
+	// items contains a list of Router.
+	// +required
 	Items           []Router `json:"items"`
 }
 

--- a/api/v1alpha1/zz_generated.securitygroup-resource.go
+++ b/api/v1alpha1/zz_generated.securitygroup-resource.go
@@ -26,14 +26,14 @@ import (
 // +kubebuilder:validation:MinProperties:=1
 // +kubebuilder:validation:MaxProperties:=1
 type SecurityGroupImport struct {
-	// ID contains the unique identifier of an existing OpenStack resource. Note
+	// id contains the unique identifier of an existing OpenStack resource. Note
 	// that when specifying an import by ID, the resource MUST already exist.
 	// The ORC object will enter an error state if the resource does not exist.
 	// +optional
 	// +kubebuilder:validation:Format:=uuid
 	ID *string `json:"id,omitempty"`
 
-	// Filter contains a resource query which is expected to return a single
+	// filter contains a resource query which is expected to return a single
 	// result. The controller will continue to retry if filter returns no
 	// results. If filter returns multiple results the controller will set an
 	// error state and will not continue to retry.
@@ -48,20 +48,20 @@ type SecurityGroupImport struct {
 // +kubebuilder:validation:XValidation:rule="self.managementPolicy == 'unmanaged' ? has(self.__import__) : true",message="import must be specified when policy is unmanaged"
 // +kubebuilder:validation:XValidation:rule="has(self.managedOptions) ? self.managementPolicy == 'managed' : true",message="managedOptions may only be provided when policy is managed"
 type SecurityGroupSpec struct {
-	// Import refers to an existing OpenStack resource which will be imported instead of
+	// import refers to an existing OpenStack resource which will be imported instead of
 	// creating a new one.
 	// +optional
 	Import *SecurityGroupImport `json:"import,omitempty"`
 
-	// Resource specifies the desired state of the resource.
+	// resource specifies the desired state of the resource.
 	//
-	// Resource may not be specified if the management policy is `unmanaged`.
+	// resource may not be specified if the management policy is `unmanaged`.
 	//
-	// Resource must be specified if the management policy is `managed`.
+	// resource must be specified if the management policy is `managed`.
 	// +optional
 	Resource *SecurityGroupResourceSpec `json:"resource,omitempty"`
 
-	// ManagementPolicy defines how ORC will treat the object. Valid values are
+	// managementPolicy defines how ORC will treat the object. Valid values are
 	// `managed`: ORC will create, update, and delete the resource; `unmanaged`:
 	// ORC will import an existing resource, and will not apply updates to it or
 	// delete it.
@@ -70,18 +70,18 @@ type SecurityGroupSpec struct {
 	// +optional
 	ManagementPolicy ManagementPolicy `json:"managementPolicy,omitempty"`
 
-	// ManagedOptions specifies options which may be applied to managed objects.
+	// managedOptions specifies options which may be applied to managed objects.
 	// +optional
 	ManagedOptions *ManagedOptions `json:"managedOptions,omitempty"`
 
-	// CloudCredentialsRef points to a secret containing OpenStack credentials
-	// +kubebuilder:validation:Required
+	// cloudCredentialsRef points to a secret containing OpenStack credentials
+	// +required
 	CloudCredentialsRef CloudCredentialsReference `json:"cloudCredentialsRef"`
 }
 
 // SecurityGroupStatus defines the observed state of an ORC resource.
 type SecurityGroupStatus struct {
-	// Conditions represents the observed status of the object.
+	// conditions represents the observed status of the object.
 	// Known .status.conditions.type are: "Available", "Progressing"
 	//
 	// Available represents the availability of the OpenStack resource. If it is
@@ -99,13 +99,14 @@ type SecurityGroupStatus struct {
 	// +patchStrategy=merge
 	// +listType=map
 	// +listMapKey=type
+	// +optional
 	Conditions []metav1.Condition `json:"conditions,omitempty" patchStrategy:"merge" patchMergeKey:"type"`
 
-	// ID is the unique identifier of the OpenStack resource.
+	// id is the unique identifier of the OpenStack resource.
 	// +optional
 	ID *string `json:"id,omitempty"`
 
-	// Resource contains the observed state of the OpenStack resource.
+	// resource contains the observed state of the OpenStack resource.
 	// +optional
 	Resource *SecurityGroupResourceStatus `json:"resource,omitempty"`
 }
@@ -128,9 +129,17 @@ func (i *SecurityGroup) GetConditions() []metav1.Condition {
 // SecurityGroup is the Schema for an ORC resource.
 type SecurityGroup struct {
 	metav1.TypeMeta   `json:",inline"`
+
+	// metadata contains the object metadata
+	// +optional
 	metav1.ObjectMeta `json:"metadata,omitempty"`
 
+	// spec specifies the desired state of the resource.
+	// +optional
 	Spec   SecurityGroupSpec   `json:"spec,omitempty"`
+
+	// status defines the observed state of the resource.
+	// +optional
 	Status SecurityGroupStatus `json:"status,omitempty"`
 }
 
@@ -139,7 +148,13 @@ type SecurityGroup struct {
 // SecurityGroupList contains a list of SecurityGroup.
 type SecurityGroupList struct {
 	metav1.TypeMeta `json:",inline"`
+
+	// metadata contains the list metadata
+	// +optional
 	metav1.ListMeta `json:"metadata,omitempty"`
+
+	// items contains a list of SecurityGroup.
+	// +required
 	Items           []SecurityGroup `json:"items"`
 }
 

--- a/api/v1alpha1/zz_generated.server-resource.go
+++ b/api/v1alpha1/zz_generated.server-resource.go
@@ -26,14 +26,14 @@ import (
 // +kubebuilder:validation:MinProperties:=1
 // +kubebuilder:validation:MaxProperties:=1
 type ServerImport struct {
-	// ID contains the unique identifier of an existing OpenStack resource. Note
+	// id contains the unique identifier of an existing OpenStack resource. Note
 	// that when specifying an import by ID, the resource MUST already exist.
 	// The ORC object will enter an error state if the resource does not exist.
 	// +optional
 	// +kubebuilder:validation:Format:=uuid
 	ID *string `json:"id,omitempty"`
 
-	// Filter contains a resource query which is expected to return a single
+	// filter contains a resource query which is expected to return a single
 	// result. The controller will continue to retry if filter returns no
 	// results. If filter returns multiple results the controller will set an
 	// error state and will not continue to retry.
@@ -48,20 +48,20 @@ type ServerImport struct {
 // +kubebuilder:validation:XValidation:rule="self.managementPolicy == 'unmanaged' ? has(self.__import__) : true",message="import must be specified when policy is unmanaged"
 // +kubebuilder:validation:XValidation:rule="has(self.managedOptions) ? self.managementPolicy == 'managed' : true",message="managedOptions may only be provided when policy is managed"
 type ServerSpec struct {
-	// Import refers to an existing OpenStack resource which will be imported instead of
+	// import refers to an existing OpenStack resource which will be imported instead of
 	// creating a new one.
 	// +optional
 	Import *ServerImport `json:"import,omitempty"`
 
-	// Resource specifies the desired state of the resource.
+	// resource specifies the desired state of the resource.
 	//
-	// Resource may not be specified if the management policy is `unmanaged`.
+	// resource may not be specified if the management policy is `unmanaged`.
 	//
-	// Resource must be specified if the management policy is `managed`.
+	// resource must be specified if the management policy is `managed`.
 	// +optional
 	Resource *ServerResourceSpec `json:"resource,omitempty"`
 
-	// ManagementPolicy defines how ORC will treat the object. Valid values are
+	// managementPolicy defines how ORC will treat the object. Valid values are
 	// `managed`: ORC will create, update, and delete the resource; `unmanaged`:
 	// ORC will import an existing resource, and will not apply updates to it or
 	// delete it.
@@ -70,18 +70,18 @@ type ServerSpec struct {
 	// +optional
 	ManagementPolicy ManagementPolicy `json:"managementPolicy,omitempty"`
 
-	// ManagedOptions specifies options which may be applied to managed objects.
+	// managedOptions specifies options which may be applied to managed objects.
 	// +optional
 	ManagedOptions *ManagedOptions `json:"managedOptions,omitempty"`
 
-	// CloudCredentialsRef points to a secret containing OpenStack credentials
-	// +kubebuilder:validation:Required
+	// cloudCredentialsRef points to a secret containing OpenStack credentials
+	// +required
 	CloudCredentialsRef CloudCredentialsReference `json:"cloudCredentialsRef"`
 }
 
 // ServerStatus defines the observed state of an ORC resource.
 type ServerStatus struct {
-	// Conditions represents the observed status of the object.
+	// conditions represents the observed status of the object.
 	// Known .status.conditions.type are: "Available", "Progressing"
 	//
 	// Available represents the availability of the OpenStack resource. If it is
@@ -99,13 +99,14 @@ type ServerStatus struct {
 	// +patchStrategy=merge
 	// +listType=map
 	// +listMapKey=type
+	// +optional
 	Conditions []metav1.Condition `json:"conditions,omitempty" patchStrategy:"merge" patchMergeKey:"type"`
 
-	// ID is the unique identifier of the OpenStack resource.
+	// id is the unique identifier of the OpenStack resource.
 	// +optional
 	ID *string `json:"id,omitempty"`
 
-	// Resource contains the observed state of the OpenStack resource.
+	// resource contains the observed state of the OpenStack resource.
 	// +optional
 	Resource *ServerResourceStatus `json:"resource,omitempty"`
 }
@@ -128,9 +129,17 @@ func (i *Server) GetConditions() []metav1.Condition {
 // Server is the Schema for an ORC resource.
 type Server struct {
 	metav1.TypeMeta   `json:",inline"`
+
+	// metadata contains the object metadata
+	// +optional
 	metav1.ObjectMeta `json:"metadata,omitempty"`
 
+	// spec specifies the desired state of the resource.
+	// +optional
 	Spec   ServerSpec   `json:"spec,omitempty"`
+
+	// status defines the observed state of the resource.
+	// +optional
 	Status ServerStatus `json:"status,omitempty"`
 }
 
@@ -139,7 +148,13 @@ type Server struct {
 // ServerList contains a list of Server.
 type ServerList struct {
 	metav1.TypeMeta `json:",inline"`
+
+	// metadata contains the list metadata
+	// +optional
 	metav1.ListMeta `json:"metadata,omitempty"`
+
+	// items contains a list of Server.
+	// +required
 	Items           []Server `json:"items"`
 }
 

--- a/api/v1alpha1/zz_generated.subnet-resource.go
+++ b/api/v1alpha1/zz_generated.subnet-resource.go
@@ -26,14 +26,14 @@ import (
 // +kubebuilder:validation:MinProperties:=1
 // +kubebuilder:validation:MaxProperties:=1
 type SubnetImport struct {
-	// ID contains the unique identifier of an existing OpenStack resource. Note
+	// id contains the unique identifier of an existing OpenStack resource. Note
 	// that when specifying an import by ID, the resource MUST already exist.
 	// The ORC object will enter an error state if the resource does not exist.
 	// +optional
 	// +kubebuilder:validation:Format:=uuid
 	ID *string `json:"id,omitempty"`
 
-	// Filter contains a resource query which is expected to return a single
+	// filter contains a resource query which is expected to return a single
 	// result. The controller will continue to retry if filter returns no
 	// results. If filter returns multiple results the controller will set an
 	// error state and will not continue to retry.
@@ -50,20 +50,20 @@ type SubnetImport struct {
 type SubnetSpec struct {
 	SubnetRefs `json:",inline"`
 
-	// Import refers to an existing OpenStack resource which will be imported instead of
+	// import refers to an existing OpenStack resource which will be imported instead of
 	// creating a new one.
 	// +optional
 	Import *SubnetImport `json:"import,omitempty"`
 
-	// Resource specifies the desired state of the resource.
+	// resource specifies the desired state of the resource.
 	//
-	// Resource may not be specified if the management policy is `unmanaged`.
+	// resource may not be specified if the management policy is `unmanaged`.
 	//
-	// Resource must be specified if the management policy is `managed`.
+	// resource must be specified if the management policy is `managed`.
 	// +optional
 	Resource *SubnetResourceSpec `json:"resource,omitempty"`
 
-	// ManagementPolicy defines how ORC will treat the object. Valid values are
+	// managementPolicy defines how ORC will treat the object. Valid values are
 	// `managed`: ORC will create, update, and delete the resource; `unmanaged`:
 	// ORC will import an existing resource, and will not apply updates to it or
 	// delete it.
@@ -72,18 +72,18 @@ type SubnetSpec struct {
 	// +optional
 	ManagementPolicy ManagementPolicy `json:"managementPolicy,omitempty"`
 
-	// ManagedOptions specifies options which may be applied to managed objects.
+	// managedOptions specifies options which may be applied to managed objects.
 	// +optional
 	ManagedOptions *ManagedOptions `json:"managedOptions,omitempty"`
 
-	// CloudCredentialsRef points to a secret containing OpenStack credentials
-	// +kubebuilder:validation:Required
+	// cloudCredentialsRef points to a secret containing OpenStack credentials
+	// +required
 	CloudCredentialsRef CloudCredentialsReference `json:"cloudCredentialsRef"`
 }
 
 // SubnetStatus defines the observed state of an ORC resource.
 type SubnetStatus struct {
-	// Conditions represents the observed status of the object.
+	// conditions represents the observed status of the object.
 	// Known .status.conditions.type are: "Available", "Progressing"
 	//
 	// Available represents the availability of the OpenStack resource. If it is
@@ -101,13 +101,14 @@ type SubnetStatus struct {
 	// +patchStrategy=merge
 	// +listType=map
 	// +listMapKey=type
+	// +optional
 	Conditions []metav1.Condition `json:"conditions,omitempty" patchStrategy:"merge" patchMergeKey:"type"`
 
-	// ID is the unique identifier of the OpenStack resource.
+	// id is the unique identifier of the OpenStack resource.
 	// +optional
 	ID *string `json:"id,omitempty"`
 
-	// Resource contains the observed state of the OpenStack resource.
+	// resource contains the observed state of the OpenStack resource.
 	// +optional
 	Resource *SubnetResourceStatus `json:"resource,omitempty"`
 }
@@ -130,9 +131,17 @@ func (i *Subnet) GetConditions() []metav1.Condition {
 // Subnet is the Schema for an ORC resource.
 type Subnet struct {
 	metav1.TypeMeta   `json:",inline"`
+
+	// metadata contains the object metadata
+	// +optional
 	metav1.ObjectMeta `json:"metadata,omitempty"`
 
+	// spec specifies the desired state of the resource.
+	// +optional
 	Spec   SubnetSpec   `json:"spec,omitempty"`
+
+	// status defines the observed state of the resource.
+	// +optional
 	Status SubnetStatus `json:"status,omitempty"`
 }
 
@@ -141,7 +150,13 @@ type Subnet struct {
 // SubnetList contains a list of Subnet.
 type SubnetList struct {
 	metav1.TypeMeta `json:",inline"`
+
+	// metadata contains the list metadata
+	// +optional
 	metav1.ListMeta `json:"metadata,omitempty"`
+
+	// items contains a list of Subnet.
+	// +required
 	Items           []Subnet `json:"items"`
 }
 

--- a/cmd/models-schema/zz_generated.openapi.go
+++ b/cmd/models-schema/zz_generated.openapi.go
@@ -755,20 +755,23 @@ func schema_k_orc_openstack_resource_controller_api_v1alpha1_Flavor(ref common.R
 					},
 					"metadata": {
 						SchemaProps: spec.SchemaProps{
-							Default: map[string]interface{}{},
-							Ref:     ref("k8s.io/apimachinery/pkg/apis/meta/v1.ObjectMeta"),
+							Description: "metadata contains the object metadata",
+							Default:     map[string]interface{}{},
+							Ref:         ref("k8s.io/apimachinery/pkg/apis/meta/v1.ObjectMeta"),
 						},
 					},
 					"spec": {
 						SchemaProps: spec.SchemaProps{
-							Default: map[string]interface{}{},
-							Ref:     ref("github.com/k-orc/openstack-resource-controller/api/v1alpha1.FlavorSpec"),
+							Description: "spec specifies the desired state of the resource.",
+							Default:     map[string]interface{}{},
+							Ref:         ref("github.com/k-orc/openstack-resource-controller/api/v1alpha1.FlavorSpec"),
 						},
 					},
 					"status": {
 						SchemaProps: spec.SchemaProps{
-							Default: map[string]interface{}{},
-							Ref:     ref("github.com/k-orc/openstack-resource-controller/api/v1alpha1.FlavorStatus"),
+							Description: "status defines the observed state of the resource.",
+							Default:     map[string]interface{}{},
+							Ref:         ref("github.com/k-orc/openstack-resource-controller/api/v1alpha1.FlavorStatus"),
 						},
 					},
 				},
@@ -822,14 +825,14 @@ func schema_k_orc_openstack_resource_controller_api_v1alpha1_FlavorImport(ref co
 				Properties: map[string]spec.Schema{
 					"id": {
 						SchemaProps: spec.SchemaProps{
-							Description: "ID contains the unique identifier of an existing OpenStack resource. Note that when specifying an import by ID, the resource MUST already exist. The ORC object will enter an error state if the resource does not exist.",
+							Description: "id contains the unique identifier of an existing OpenStack resource. Note that when specifying an import by ID, the resource MUST already exist. The ORC object will enter an error state if the resource does not exist.",
 							Type:        []string{"string"},
 							Format:      "",
 						},
 					},
 					"filter": {
 						SchemaProps: spec.SchemaProps{
-							Description: "Filter contains a resource query which is expected to return a single result. The controller will continue to retry if filter returns no results. If filter returns multiple results the controller will set an error state and will not continue to retry.",
+							Description: "filter contains a resource query which is expected to return a single result. The controller will continue to retry if filter returns no results. If filter returns multiple results the controller will set an error state and will not continue to retry.",
 							Ref:         ref("github.com/k-orc/openstack-resource-controller/api/v1alpha1.FlavorFilter"),
 						},
 					},
@@ -864,13 +867,15 @@ func schema_k_orc_openstack_resource_controller_api_v1alpha1_FlavorList(ref comm
 					},
 					"metadata": {
 						SchemaProps: spec.SchemaProps{
-							Default: map[string]interface{}{},
-							Ref:     ref("k8s.io/apimachinery/pkg/apis/meta/v1.ListMeta"),
+							Description: "metadata contains the list metadata",
+							Default:     map[string]interface{}{},
+							Ref:         ref("k8s.io/apimachinery/pkg/apis/meta/v1.ListMeta"),
 						},
 					},
 					"items": {
 						SchemaProps: spec.SchemaProps{
-							Type: []string{"array"},
+							Description: "items contains a list of Flavor.",
+							Type:        []string{"array"},
 							Items: &spec.SchemaOrArray{
 								Schema: &spec.Schema{
 									SchemaProps: spec.SchemaProps{
@@ -1040,32 +1045,32 @@ func schema_k_orc_openstack_resource_controller_api_v1alpha1_FlavorSpec(ref comm
 				Properties: map[string]spec.Schema{
 					"import": {
 						SchemaProps: spec.SchemaProps{
-							Description: "Import refers to an existing OpenStack resource which will be imported instead of creating a new one.",
+							Description: "import refers to an existing OpenStack resource which will be imported instead of creating a new one.",
 							Ref:         ref("github.com/k-orc/openstack-resource-controller/api/v1alpha1.FlavorImport"),
 						},
 					},
 					"resource": {
 						SchemaProps: spec.SchemaProps{
-							Description: "Resource specifies the desired state of the resource.\n\nResource may not be specified if the management policy is `unmanaged`.\n\nResource must be specified if the management policy is `managed`.",
+							Description: "resource specifies the desired state of the resource.\n\nresource may not be specified if the management policy is `unmanaged`.\n\nresource must be specified if the management policy is `managed`.",
 							Ref:         ref("github.com/k-orc/openstack-resource-controller/api/v1alpha1.FlavorResourceSpec"),
 						},
 					},
 					"managementPolicy": {
 						SchemaProps: spec.SchemaProps{
-							Description: "ManagementPolicy defines how ORC will treat the object. Valid values are `managed`: ORC will create, update, and delete the resource; `unmanaged`: ORC will import an existing resource, and will not apply updates to it or delete it.",
+							Description: "managementPolicy defines how ORC will treat the object. Valid values are `managed`: ORC will create, update, and delete the resource; `unmanaged`: ORC will import an existing resource, and will not apply updates to it or delete it.",
 							Type:        []string{"string"},
 							Format:      "",
 						},
 					},
 					"managedOptions": {
 						SchemaProps: spec.SchemaProps{
-							Description: "ManagedOptions specifies options which may be applied to managed objects.",
+							Description: "managedOptions specifies options which may be applied to managed objects.",
 							Ref:         ref("github.com/k-orc/openstack-resource-controller/api/v1alpha1.ManagedOptions"),
 						},
 					},
 					"cloudCredentialsRef": {
 						SchemaProps: spec.SchemaProps{
-							Description: "CloudCredentialsRef points to a secret containing OpenStack credentials",
+							Description: "cloudCredentialsRef points to a secret containing OpenStack credentials",
 							Default:     map[string]interface{}{},
 							Ref:         ref("github.com/k-orc/openstack-resource-controller/api/v1alpha1.CloudCredentialsReference"),
 						},
@@ -1098,7 +1103,7 @@ func schema_k_orc_openstack_resource_controller_api_v1alpha1_FlavorStatus(ref co
 							},
 						},
 						SchemaProps: spec.SchemaProps{
-							Description: "Conditions represents the observed status of the object. Known .status.conditions.type are: \"Available\", \"Progressing\"\n\nAvailable represents the availability of the OpenStack resource. If it is true then the resource is ready for use.\n\nProgressing indicates whether the controller is still attempting to reconcile the current state of the OpenStack resource to the desired state. Progressing will be False either because the desired state has been achieved, or because some terminal error prevents it from ever being achieved and the controller is no longer attempting to reconcile. If Progressing is True, an observer waiting on the resource should continue to wait.",
+							Description: "conditions represents the observed status of the object. Known .status.conditions.type are: \"Available\", \"Progressing\"\n\nAvailable represents the availability of the OpenStack resource. If it is true then the resource is ready for use.\n\nProgressing indicates whether the controller is still attempting to reconcile the current state of the OpenStack resource to the desired state. Progressing will be False either because the desired state has been achieved, or because some terminal error prevents it from ever being achieved and the controller is no longer attempting to reconcile. If Progressing is True, an observer waiting on the resource should continue to wait.",
 							Type:        []string{"array"},
 							Items: &spec.SchemaOrArray{
 								Schema: &spec.Schema{
@@ -1112,14 +1117,14 @@ func schema_k_orc_openstack_resource_controller_api_v1alpha1_FlavorStatus(ref co
 					},
 					"id": {
 						SchemaProps: spec.SchemaProps{
-							Description: "ID is the unique identifier of the OpenStack resource.",
+							Description: "id is the unique identifier of the OpenStack resource.",
 							Type:        []string{"string"},
 							Format:      "",
 						},
 					},
 					"resource": {
 						SchemaProps: spec.SchemaProps{
-							Description: "Resource contains the observed state of the OpenStack resource.",
+							Description: "resource contains the observed state of the OpenStack resource.",
 							Ref:         ref("github.com/k-orc/openstack-resource-controller/api/v1alpha1.FlavorResourceStatus"),
 						},
 					},
@@ -1234,20 +1239,23 @@ func schema_k_orc_openstack_resource_controller_api_v1alpha1_Image(ref common.Re
 					},
 					"metadata": {
 						SchemaProps: spec.SchemaProps{
-							Default: map[string]interface{}{},
-							Ref:     ref("k8s.io/apimachinery/pkg/apis/meta/v1.ObjectMeta"),
+							Description: "metadata contains the object metadata",
+							Default:     map[string]interface{}{},
+							Ref:         ref("k8s.io/apimachinery/pkg/apis/meta/v1.ObjectMeta"),
 						},
 					},
 					"spec": {
 						SchemaProps: spec.SchemaProps{
-							Default: map[string]interface{}{},
-							Ref:     ref("github.com/k-orc/openstack-resource-controller/api/v1alpha1.ImageSpec"),
+							Description: "spec specifies the desired state of the resource.",
+							Default:     map[string]interface{}{},
+							Ref:         ref("github.com/k-orc/openstack-resource-controller/api/v1alpha1.ImageSpec"),
 						},
 					},
 					"status": {
 						SchemaProps: spec.SchemaProps{
-							Default: map[string]interface{}{},
-							Ref:     ref("github.com/k-orc/openstack-resource-controller/api/v1alpha1.ImageStatus"),
+							Description: "status defines the observed state of the resource.",
+							Default:     map[string]interface{}{},
+							Ref:         ref("github.com/k-orc/openstack-resource-controller/api/v1alpha1.ImageStatus"),
 						},
 					},
 				},
@@ -1388,14 +1396,14 @@ func schema_k_orc_openstack_resource_controller_api_v1alpha1_ImageImport(ref com
 				Properties: map[string]spec.Schema{
 					"id": {
 						SchemaProps: spec.SchemaProps{
-							Description: "ID contains the unique identifier of an existing OpenStack resource. Note that when specifying an import by ID, the resource MUST already exist. The ORC object will enter an error state if the resource does not exist.",
+							Description: "id contains the unique identifier of an existing OpenStack resource. Note that when specifying an import by ID, the resource MUST already exist. The ORC object will enter an error state if the resource does not exist.",
 							Type:        []string{"string"},
 							Format:      "",
 						},
 					},
 					"filter": {
 						SchemaProps: spec.SchemaProps{
-							Description: "Filter contains a resource query which is expected to return a single result. The controller will continue to retry if filter returns no results. If filter returns multiple results the controller will set an error state and will not continue to retry.",
+							Description: "filter contains a resource query which is expected to return a single result. The controller will continue to retry if filter returns no results. If filter returns multiple results the controller will set an error state and will not continue to retry.",
 							Ref:         ref("github.com/k-orc/openstack-resource-controller/api/v1alpha1.ImageFilter"),
 						},
 					},
@@ -1430,13 +1438,15 @@ func schema_k_orc_openstack_resource_controller_api_v1alpha1_ImageList(ref commo
 					},
 					"metadata": {
 						SchemaProps: spec.SchemaProps{
-							Default: map[string]interface{}{},
-							Ref:     ref("k8s.io/apimachinery/pkg/apis/meta/v1.ListMeta"),
+							Description: "metadata contains the list metadata",
+							Default:     map[string]interface{}{},
+							Ref:         ref("k8s.io/apimachinery/pkg/apis/meta/v1.ListMeta"),
 						},
 					},
 					"items": {
 						SchemaProps: spec.SchemaProps{
-							Type: []string{"array"},
+							Description: "items contains a list of Image.",
+							Type:        []string{"array"},
 							Items: &spec.SchemaOrArray{
 								Schema: &spec.Schema{
 									SchemaProps: spec.SchemaProps{
@@ -1684,32 +1694,32 @@ func schema_k_orc_openstack_resource_controller_api_v1alpha1_ImageSpec(ref commo
 				Properties: map[string]spec.Schema{
 					"import": {
 						SchemaProps: spec.SchemaProps{
-							Description: "Import refers to an existing OpenStack resource which will be imported instead of creating a new one.",
+							Description: "import refers to an existing OpenStack resource which will be imported instead of creating a new one.",
 							Ref:         ref("github.com/k-orc/openstack-resource-controller/api/v1alpha1.ImageImport"),
 						},
 					},
 					"resource": {
 						SchemaProps: spec.SchemaProps{
-							Description: "Resource specifies the desired state of the resource.\n\nResource may not be specified if the management policy is `unmanaged`.\n\nResource must be specified if the management policy is `managed`.",
+							Description: "resource specifies the desired state of the resource.\n\nresource may not be specified if the management policy is `unmanaged`.\n\nresource must be specified if the management policy is `managed`.",
 							Ref:         ref("github.com/k-orc/openstack-resource-controller/api/v1alpha1.ImageResourceSpec"),
 						},
 					},
 					"managementPolicy": {
 						SchemaProps: spec.SchemaProps{
-							Description: "ManagementPolicy defines how ORC will treat the object. Valid values are `managed`: ORC will create, update, and delete the resource; `unmanaged`: ORC will import an existing resource, and will not apply updates to it or delete it.",
+							Description: "managementPolicy defines how ORC will treat the object. Valid values are `managed`: ORC will create, update, and delete the resource; `unmanaged`: ORC will import an existing resource, and will not apply updates to it or delete it.",
 							Type:        []string{"string"},
 							Format:      "",
 						},
 					},
 					"managedOptions": {
 						SchemaProps: spec.SchemaProps{
-							Description: "ManagedOptions specifies options which may be applied to managed objects.",
+							Description: "managedOptions specifies options which may be applied to managed objects.",
 							Ref:         ref("github.com/k-orc/openstack-resource-controller/api/v1alpha1.ManagedOptions"),
 						},
 					},
 					"cloudCredentialsRef": {
 						SchemaProps: spec.SchemaProps{
-							Description: "CloudCredentialsRef points to a secret containing OpenStack credentials",
+							Description: "cloudCredentialsRef points to a secret containing OpenStack credentials",
 							Default:     map[string]interface{}{},
 							Ref:         ref("github.com/k-orc/openstack-resource-controller/api/v1alpha1.CloudCredentialsReference"),
 						},
@@ -1742,7 +1752,7 @@ func schema_k_orc_openstack_resource_controller_api_v1alpha1_ImageStatus(ref com
 							},
 						},
 						SchemaProps: spec.SchemaProps{
-							Description: "Conditions represents the observed status of the object. Known .status.conditions.type are: \"Available\", \"Progressing\"\n\nAvailable represents the availability of the OpenStack resource. If it is true then the resource is ready for use.\n\nProgressing indicates whether the controller is still attempting to reconcile the current state of the OpenStack resource to the desired state. Progressing will be False either because the desired state has been achieved, or because some terminal error prevents it from ever being achieved and the controller is no longer attempting to reconcile. If Progressing is True, an observer waiting on the resource should continue to wait.",
+							Description: "conditions represents the observed status of the object. Known .status.conditions.type are: \"Available\", \"Progressing\"\n\nAvailable represents the availability of the OpenStack resource. If it is true then the resource is ready for use.\n\nProgressing indicates whether the controller is still attempting to reconcile the current state of the OpenStack resource to the desired state. Progressing will be False either because the desired state has been achieved, or because some terminal error prevents it from ever being achieved and the controller is no longer attempting to reconcile. If Progressing is True, an observer waiting on the resource should continue to wait.",
 							Type:        []string{"array"},
 							Items: &spec.SchemaOrArray{
 								Schema: &spec.Schema{
@@ -1756,14 +1766,14 @@ func schema_k_orc_openstack_resource_controller_api_v1alpha1_ImageStatus(ref com
 					},
 					"id": {
 						SchemaProps: spec.SchemaProps{
-							Description: "ID is the unique identifier of the OpenStack resource.",
+							Description: "id is the unique identifier of the OpenStack resource.",
 							Type:        []string{"string"},
 							Format:      "",
 						},
 					},
 					"resource": {
 						SchemaProps: spec.SchemaProps{
-							Description: "Resource contains the observed state of the OpenStack resource.",
+							Description: "resource contains the observed state of the OpenStack resource.",
 							Ref:         ref("github.com/k-orc/openstack-resource-controller/api/v1alpha1.ImageResourceStatus"),
 						},
 					},
@@ -1843,20 +1853,23 @@ func schema_k_orc_openstack_resource_controller_api_v1alpha1_Network(ref common.
 					},
 					"metadata": {
 						SchemaProps: spec.SchemaProps{
-							Default: map[string]interface{}{},
-							Ref:     ref("k8s.io/apimachinery/pkg/apis/meta/v1.ObjectMeta"),
+							Description: "metadata contains the object metadata",
+							Default:     map[string]interface{}{},
+							Ref:         ref("k8s.io/apimachinery/pkg/apis/meta/v1.ObjectMeta"),
 						},
 					},
 					"spec": {
 						SchemaProps: spec.SchemaProps{
-							Default: map[string]interface{}{},
-							Ref:     ref("github.com/k-orc/openstack-resource-controller/api/v1alpha1.NetworkSpec"),
+							Description: "spec specifies the desired state of the resource.",
+							Default:     map[string]interface{}{},
+							Ref:         ref("github.com/k-orc/openstack-resource-controller/api/v1alpha1.NetworkSpec"),
 						},
 					},
 					"status": {
 						SchemaProps: spec.SchemaProps{
-							Default: map[string]interface{}{},
-							Ref:     ref("github.com/k-orc/openstack-resource-controller/api/v1alpha1.NetworkStatus"),
+							Description: "status defines the observed state of the resource.",
+							Default:     map[string]interface{}{},
+							Ref:         ref("github.com/k-orc/openstack-resource-controller/api/v1alpha1.NetworkStatus"),
 						},
 					},
 				},
@@ -1997,14 +2010,14 @@ func schema_k_orc_openstack_resource_controller_api_v1alpha1_NetworkImport(ref c
 				Properties: map[string]spec.Schema{
 					"id": {
 						SchemaProps: spec.SchemaProps{
-							Description: "ID contains the unique identifier of an existing OpenStack resource. Note that when specifying an import by ID, the resource MUST already exist. The ORC object will enter an error state if the resource does not exist.",
+							Description: "id contains the unique identifier of an existing OpenStack resource. Note that when specifying an import by ID, the resource MUST already exist. The ORC object will enter an error state if the resource does not exist.",
 							Type:        []string{"string"},
 							Format:      "",
 						},
 					},
 					"filter": {
 						SchemaProps: spec.SchemaProps{
-							Description: "Filter contains a resource query which is expected to return a single result. The controller will continue to retry if filter returns no results. If filter returns multiple results the controller will set an error state and will not continue to retry.",
+							Description: "filter contains a resource query which is expected to return a single result. The controller will continue to retry if filter returns no results. If filter returns multiple results the controller will set an error state and will not continue to retry.",
 							Ref:         ref("github.com/k-orc/openstack-resource-controller/api/v1alpha1.NetworkFilter"),
 						},
 					},
@@ -2039,13 +2052,15 @@ func schema_k_orc_openstack_resource_controller_api_v1alpha1_NetworkList(ref com
 					},
 					"metadata": {
 						SchemaProps: spec.SchemaProps{
-							Default: map[string]interface{}{},
-							Ref:     ref("k8s.io/apimachinery/pkg/apis/meta/v1.ListMeta"),
+							Description: "metadata contains the list metadata",
+							Default:     map[string]interface{}{},
+							Ref:         ref("k8s.io/apimachinery/pkg/apis/meta/v1.ListMeta"),
 						},
 					},
 					"items": {
 						SchemaProps: spec.SchemaProps{
-							Type: []string{"array"},
+							Description: "items contains a list of Network.",
+							Type:        []string{"array"},
 							Items: &spec.SchemaOrArray{
 								Schema: &spec.Schema{
 									SchemaProps: spec.SchemaProps{
@@ -2352,32 +2367,32 @@ func schema_k_orc_openstack_resource_controller_api_v1alpha1_NetworkSpec(ref com
 				Properties: map[string]spec.Schema{
 					"import": {
 						SchemaProps: spec.SchemaProps{
-							Description: "Import refers to an existing OpenStack resource which will be imported instead of creating a new one.",
+							Description: "import refers to an existing OpenStack resource which will be imported instead of creating a new one.",
 							Ref:         ref("github.com/k-orc/openstack-resource-controller/api/v1alpha1.NetworkImport"),
 						},
 					},
 					"resource": {
 						SchemaProps: spec.SchemaProps{
-							Description: "Resource specifies the desired state of the resource.\n\nResource may not be specified if the management policy is `unmanaged`.\n\nResource must be specified if the management policy is `managed`.",
+							Description: "resource specifies the desired state of the resource.\n\nresource may not be specified if the management policy is `unmanaged`.\n\nresource must be specified if the management policy is `managed`.",
 							Ref:         ref("github.com/k-orc/openstack-resource-controller/api/v1alpha1.NetworkResourceSpec"),
 						},
 					},
 					"managementPolicy": {
 						SchemaProps: spec.SchemaProps{
-							Description: "ManagementPolicy defines how ORC will treat the object. Valid values are `managed`: ORC will create, update, and delete the resource; `unmanaged`: ORC will import an existing resource, and will not apply updates to it or delete it.",
+							Description: "managementPolicy defines how ORC will treat the object. Valid values are `managed`: ORC will create, update, and delete the resource; `unmanaged`: ORC will import an existing resource, and will not apply updates to it or delete it.",
 							Type:        []string{"string"},
 							Format:      "",
 						},
 					},
 					"managedOptions": {
 						SchemaProps: spec.SchemaProps{
-							Description: "ManagedOptions specifies options which may be applied to managed objects.",
+							Description: "managedOptions specifies options which may be applied to managed objects.",
 							Ref:         ref("github.com/k-orc/openstack-resource-controller/api/v1alpha1.ManagedOptions"),
 						},
 					},
 					"cloudCredentialsRef": {
 						SchemaProps: spec.SchemaProps{
-							Description: "CloudCredentialsRef points to a secret containing OpenStack credentials",
+							Description: "cloudCredentialsRef points to a secret containing OpenStack credentials",
 							Default:     map[string]interface{}{},
 							Ref:         ref("github.com/k-orc/openstack-resource-controller/api/v1alpha1.CloudCredentialsReference"),
 						},
@@ -2410,7 +2425,7 @@ func schema_k_orc_openstack_resource_controller_api_v1alpha1_NetworkStatus(ref c
 							},
 						},
 						SchemaProps: spec.SchemaProps{
-							Description: "Conditions represents the observed status of the object. Known .status.conditions.type are: \"Available\", \"Progressing\"\n\nAvailable represents the availability of the OpenStack resource. If it is true then the resource is ready for use.\n\nProgressing indicates whether the controller is still attempting to reconcile the current state of the OpenStack resource to the desired state. Progressing will be False either because the desired state has been achieved, or because some terminal error prevents it from ever being achieved and the controller is no longer attempting to reconcile. If Progressing is True, an observer waiting on the resource should continue to wait.",
+							Description: "conditions represents the observed status of the object. Known .status.conditions.type are: \"Available\", \"Progressing\"\n\nAvailable represents the availability of the OpenStack resource. If it is true then the resource is ready for use.\n\nProgressing indicates whether the controller is still attempting to reconcile the current state of the OpenStack resource to the desired state. Progressing will be False either because the desired state has been achieved, or because some terminal error prevents it from ever being achieved and the controller is no longer attempting to reconcile. If Progressing is True, an observer waiting on the resource should continue to wait.",
 							Type:        []string{"array"},
 							Items: &spec.SchemaOrArray{
 								Schema: &spec.Schema{
@@ -2424,14 +2439,14 @@ func schema_k_orc_openstack_resource_controller_api_v1alpha1_NetworkStatus(ref c
 					},
 					"id": {
 						SchemaProps: spec.SchemaProps{
-							Description: "ID is the unique identifier of the OpenStack resource.",
+							Description: "id is the unique identifier of the OpenStack resource.",
 							Type:        []string{"string"},
 							Format:      "",
 						},
 					},
 					"resource": {
 						SchemaProps: spec.SchemaProps{
-							Description: "Resource contains the observed state of the OpenStack resource.",
+							Description: "resource contains the observed state of the OpenStack resource.",
 							Ref:         ref("github.com/k-orc/openstack-resource-controller/api/v1alpha1.NetworkResourceStatus"),
 						},
 					},
@@ -2499,20 +2514,23 @@ func schema_k_orc_openstack_resource_controller_api_v1alpha1_Port(ref common.Ref
 					},
 					"metadata": {
 						SchemaProps: spec.SchemaProps{
-							Default: map[string]interface{}{},
-							Ref:     ref("k8s.io/apimachinery/pkg/apis/meta/v1.ObjectMeta"),
+							Description: "metadata contains the object metadata",
+							Default:     map[string]interface{}{},
+							Ref:         ref("k8s.io/apimachinery/pkg/apis/meta/v1.ObjectMeta"),
 						},
 					},
 					"spec": {
 						SchemaProps: spec.SchemaProps{
-							Default: map[string]interface{}{},
-							Ref:     ref("github.com/k-orc/openstack-resource-controller/api/v1alpha1.PortSpec"),
+							Description: "spec specifies the desired state of the resource.",
+							Default:     map[string]interface{}{},
+							Ref:         ref("github.com/k-orc/openstack-resource-controller/api/v1alpha1.PortSpec"),
 						},
 					},
 					"status": {
 						SchemaProps: spec.SchemaProps{
-							Default: map[string]interface{}{},
-							Ref:     ref("github.com/k-orc/openstack-resource-controller/api/v1alpha1.PortStatus"),
+							Description: "status defines the observed state of the resource.",
+							Default:     map[string]interface{}{},
+							Ref:         ref("github.com/k-orc/openstack-resource-controller/api/v1alpha1.PortStatus"),
 						},
 					},
 				},
@@ -2643,14 +2661,14 @@ func schema_k_orc_openstack_resource_controller_api_v1alpha1_PortImport(ref comm
 				Properties: map[string]spec.Schema{
 					"id": {
 						SchemaProps: spec.SchemaProps{
-							Description: "ID contains the unique identifier of an existing OpenStack resource. Note that when specifying an import by ID, the resource MUST already exist. The ORC object will enter an error state if the resource does not exist.",
+							Description: "id contains the unique identifier of an existing OpenStack resource. Note that when specifying an import by ID, the resource MUST already exist. The ORC object will enter an error state if the resource does not exist.",
 							Type:        []string{"string"},
 							Format:      "",
 						},
 					},
 					"filter": {
 						SchemaProps: spec.SchemaProps{
-							Description: "Filter contains a resource query which is expected to return a single result. The controller will continue to retry if filter returns no results. If filter returns multiple results the controller will set an error state and will not continue to retry.",
+							Description: "filter contains a resource query which is expected to return a single result. The controller will continue to retry if filter returns no results. If filter returns multiple results the controller will set an error state and will not continue to retry.",
 							Ref:         ref("github.com/k-orc/openstack-resource-controller/api/v1alpha1.PortFilter"),
 						},
 					},
@@ -2685,13 +2703,15 @@ func schema_k_orc_openstack_resource_controller_api_v1alpha1_PortList(ref common
 					},
 					"metadata": {
 						SchemaProps: spec.SchemaProps{
-							Default: map[string]interface{}{},
-							Ref:     ref("k8s.io/apimachinery/pkg/apis/meta/v1.ListMeta"),
+							Description: "metadata contains the list metadata",
+							Default:     map[string]interface{}{},
+							Ref:         ref("k8s.io/apimachinery/pkg/apis/meta/v1.ListMeta"),
 						},
 					},
 					"items": {
 						SchemaProps: spec.SchemaProps{
-							Type: []string{"array"},
+							Description: "items contains a list of Port.",
+							Type:        []string{"array"},
 							Items: &spec.SchemaOrArray{
 								Schema: &spec.Schema{
 									SchemaProps: spec.SchemaProps{
@@ -3093,32 +3113,32 @@ func schema_k_orc_openstack_resource_controller_api_v1alpha1_PortSpec(ref common
 					},
 					"import": {
 						SchemaProps: spec.SchemaProps{
-							Description: "Import refers to an existing OpenStack resource which will be imported instead of creating a new one.",
+							Description: "import refers to an existing OpenStack resource which will be imported instead of creating a new one.",
 							Ref:         ref("github.com/k-orc/openstack-resource-controller/api/v1alpha1.PortImport"),
 						},
 					},
 					"resource": {
 						SchemaProps: spec.SchemaProps{
-							Description: "Resource specifies the desired state of the resource.\n\nResource may not be specified if the management policy is `unmanaged`.\n\nResource must be specified if the management policy is `managed`.",
+							Description: "resource specifies the desired state of the resource.\n\nresource may not be specified if the management policy is `unmanaged`.\n\nresource must be specified if the management policy is `managed`.",
 							Ref:         ref("github.com/k-orc/openstack-resource-controller/api/v1alpha1.PortResourceSpec"),
 						},
 					},
 					"managementPolicy": {
 						SchemaProps: spec.SchemaProps{
-							Description: "ManagementPolicy defines how ORC will treat the object. Valid values are `managed`: ORC will create, update, and delete the resource; `unmanaged`: ORC will import an existing resource, and will not apply updates to it or delete it.",
+							Description: "managementPolicy defines how ORC will treat the object. Valid values are `managed`: ORC will create, update, and delete the resource; `unmanaged`: ORC will import an existing resource, and will not apply updates to it or delete it.",
 							Type:        []string{"string"},
 							Format:      "",
 						},
 					},
 					"managedOptions": {
 						SchemaProps: spec.SchemaProps{
-							Description: "ManagedOptions specifies options which may be applied to managed objects.",
+							Description: "managedOptions specifies options which may be applied to managed objects.",
 							Ref:         ref("github.com/k-orc/openstack-resource-controller/api/v1alpha1.ManagedOptions"),
 						},
 					},
 					"cloudCredentialsRef": {
 						SchemaProps: spec.SchemaProps{
-							Description: "CloudCredentialsRef points to a secret containing OpenStack credentials",
+							Description: "cloudCredentialsRef points to a secret containing OpenStack credentials",
 							Default:     map[string]interface{}{},
 							Ref:         ref("github.com/k-orc/openstack-resource-controller/api/v1alpha1.CloudCredentialsReference"),
 						},
@@ -3151,7 +3171,7 @@ func schema_k_orc_openstack_resource_controller_api_v1alpha1_PortStatus(ref comm
 							},
 						},
 						SchemaProps: spec.SchemaProps{
-							Description: "Conditions represents the observed status of the object. Known .status.conditions.type are: \"Available\", \"Progressing\"\n\nAvailable represents the availability of the OpenStack resource. If it is true then the resource is ready for use.\n\nProgressing indicates whether the controller is still attempting to reconcile the current state of the OpenStack resource to the desired state. Progressing will be False either because the desired state has been achieved, or because some terminal error prevents it from ever being achieved and the controller is no longer attempting to reconcile. If Progressing is True, an observer waiting on the resource should continue to wait.",
+							Description: "conditions represents the observed status of the object. Known .status.conditions.type are: \"Available\", \"Progressing\"\n\nAvailable represents the availability of the OpenStack resource. If it is true then the resource is ready for use.\n\nProgressing indicates whether the controller is still attempting to reconcile the current state of the OpenStack resource to the desired state. Progressing will be False either because the desired state has been achieved, or because some terminal error prevents it from ever being achieved and the controller is no longer attempting to reconcile. If Progressing is True, an observer waiting on the resource should continue to wait.",
 							Type:        []string{"array"},
 							Items: &spec.SchemaOrArray{
 								Schema: &spec.Schema{
@@ -3165,14 +3185,14 @@ func schema_k_orc_openstack_resource_controller_api_v1alpha1_PortStatus(ref comm
 					},
 					"id": {
 						SchemaProps: spec.SchemaProps{
-							Description: "ID is the unique identifier of the OpenStack resource.",
+							Description: "id is the unique identifier of the OpenStack resource.",
 							Type:        []string{"string"},
 							Format:      "",
 						},
 					},
 					"resource": {
 						SchemaProps: spec.SchemaProps{
-							Description: "Resource contains the observed state of the OpenStack resource.",
+							Description: "resource contains the observed state of the OpenStack resource.",
 							Ref:         ref("github.com/k-orc/openstack-resource-controller/api/v1alpha1.PortResourceStatus"),
 						},
 					},
@@ -3241,20 +3261,23 @@ func schema_k_orc_openstack_resource_controller_api_v1alpha1_Router(ref common.R
 					},
 					"metadata": {
 						SchemaProps: spec.SchemaProps{
-							Default: map[string]interface{}{},
-							Ref:     ref("k8s.io/apimachinery/pkg/apis/meta/v1.ObjectMeta"),
+							Description: "metadata contains the object metadata",
+							Default:     map[string]interface{}{},
+							Ref:         ref("k8s.io/apimachinery/pkg/apis/meta/v1.ObjectMeta"),
 						},
 					},
 					"spec": {
 						SchemaProps: spec.SchemaProps{
-							Default: map[string]interface{}{},
-							Ref:     ref("github.com/k-orc/openstack-resource-controller/api/v1alpha1.RouterSpec"),
+							Description: "spec specifies the desired state of the resource.",
+							Default:     map[string]interface{}{},
+							Ref:         ref("github.com/k-orc/openstack-resource-controller/api/v1alpha1.RouterSpec"),
 						},
 					},
 					"status": {
 						SchemaProps: spec.SchemaProps{
-							Default: map[string]interface{}{},
-							Ref:     ref("github.com/k-orc/openstack-resource-controller/api/v1alpha1.RouterStatus"),
+							Description: "status defines the observed state of the resource.",
+							Default:     map[string]interface{}{},
+							Ref:         ref("github.com/k-orc/openstack-resource-controller/api/v1alpha1.RouterStatus"),
 						},
 					},
 				},
@@ -3385,14 +3408,14 @@ func schema_k_orc_openstack_resource_controller_api_v1alpha1_RouterImport(ref co
 				Properties: map[string]spec.Schema{
 					"id": {
 						SchemaProps: spec.SchemaProps{
-							Description: "ID contains the unique identifier of an existing OpenStack resource. Note that when specifying an import by ID, the resource MUST already exist. The ORC object will enter an error state if the resource does not exist.",
+							Description: "id contains the unique identifier of an existing OpenStack resource. Note that when specifying an import by ID, the resource MUST already exist. The ORC object will enter an error state if the resource does not exist.",
 							Type:        []string{"string"},
 							Format:      "",
 						},
 					},
 					"filter": {
 						SchemaProps: spec.SchemaProps{
-							Description: "Filter contains a resource query which is expected to return a single result. The controller will continue to retry if filter returns no results. If filter returns multiple results the controller will set an error state and will not continue to retry.",
+							Description: "filter contains a resource query which is expected to return a single result. The controller will continue to retry if filter returns no results. If filter returns multiple results the controller will set an error state and will not continue to retry.",
 							Ref:         ref("github.com/k-orc/openstack-resource-controller/api/v1alpha1.RouterFilter"),
 						},
 					},
@@ -3601,13 +3624,15 @@ func schema_k_orc_openstack_resource_controller_api_v1alpha1_RouterList(ref comm
 					},
 					"metadata": {
 						SchemaProps: spec.SchemaProps{
-							Default: map[string]interface{}{},
-							Ref:     ref("k8s.io/apimachinery/pkg/apis/meta/v1.ListMeta"),
+							Description: "metadata contains the list metadata",
+							Default:     map[string]interface{}{},
+							Ref:         ref("k8s.io/apimachinery/pkg/apis/meta/v1.ListMeta"),
 						},
 					},
 					"items": {
 						SchemaProps: spec.SchemaProps{
-							Type: []string{"array"},
+							Description: "items contains a list of Router.",
+							Type:        []string{"array"},
 							Items: &spec.SchemaOrArray{
 								Schema: &spec.Schema{
 									SchemaProps: spec.SchemaProps{
@@ -3859,32 +3884,32 @@ func schema_k_orc_openstack_resource_controller_api_v1alpha1_RouterSpec(ref comm
 				Properties: map[string]spec.Schema{
 					"import": {
 						SchemaProps: spec.SchemaProps{
-							Description: "Import refers to an existing OpenStack resource which will be imported instead of creating a new one.",
+							Description: "import refers to an existing OpenStack resource which will be imported instead of creating a new one.",
 							Ref:         ref("github.com/k-orc/openstack-resource-controller/api/v1alpha1.RouterImport"),
 						},
 					},
 					"resource": {
 						SchemaProps: spec.SchemaProps{
-							Description: "Resource specifies the desired state of the resource.\n\nResource may not be specified if the management policy is `unmanaged`.\n\nResource must be specified if the management policy is `managed`.",
+							Description: "resource specifies the desired state of the resource.\n\nresource may not be specified if the management policy is `unmanaged`.\n\nresource must be specified if the management policy is `managed`.",
 							Ref:         ref("github.com/k-orc/openstack-resource-controller/api/v1alpha1.RouterResourceSpec"),
 						},
 					},
 					"managementPolicy": {
 						SchemaProps: spec.SchemaProps{
-							Description: "ManagementPolicy defines how ORC will treat the object. Valid values are `managed`: ORC will create, update, and delete the resource; `unmanaged`: ORC will import an existing resource, and will not apply updates to it or delete it.",
+							Description: "managementPolicy defines how ORC will treat the object. Valid values are `managed`: ORC will create, update, and delete the resource; `unmanaged`: ORC will import an existing resource, and will not apply updates to it or delete it.",
 							Type:        []string{"string"},
 							Format:      "",
 						},
 					},
 					"managedOptions": {
 						SchemaProps: spec.SchemaProps{
-							Description: "ManagedOptions specifies options which may be applied to managed objects.",
+							Description: "managedOptions specifies options which may be applied to managed objects.",
 							Ref:         ref("github.com/k-orc/openstack-resource-controller/api/v1alpha1.ManagedOptions"),
 						},
 					},
 					"cloudCredentialsRef": {
 						SchemaProps: spec.SchemaProps{
-							Description: "CloudCredentialsRef points to a secret containing OpenStack credentials",
+							Description: "cloudCredentialsRef points to a secret containing OpenStack credentials",
 							Default:     map[string]interface{}{},
 							Ref:         ref("github.com/k-orc/openstack-resource-controller/api/v1alpha1.CloudCredentialsReference"),
 						},
@@ -3917,7 +3942,7 @@ func schema_k_orc_openstack_resource_controller_api_v1alpha1_RouterStatus(ref co
 							},
 						},
 						SchemaProps: spec.SchemaProps{
-							Description: "Conditions represents the observed status of the object. Known .status.conditions.type are: \"Available\", \"Progressing\"\n\nAvailable represents the availability of the OpenStack resource. If it is true then the resource is ready for use.\n\nProgressing indicates whether the controller is still attempting to reconcile the current state of the OpenStack resource to the desired state. Progressing will be False either because the desired state has been achieved, or because some terminal error prevents it from ever being achieved and the controller is no longer attempting to reconcile. If Progressing is True, an observer waiting on the resource should continue to wait.",
+							Description: "conditions represents the observed status of the object. Known .status.conditions.type are: \"Available\", \"Progressing\"\n\nAvailable represents the availability of the OpenStack resource. If it is true then the resource is ready for use.\n\nProgressing indicates whether the controller is still attempting to reconcile the current state of the OpenStack resource to the desired state. Progressing will be False either because the desired state has been achieved, or because some terminal error prevents it from ever being achieved and the controller is no longer attempting to reconcile. If Progressing is True, an observer waiting on the resource should continue to wait.",
 							Type:        []string{"array"},
 							Items: &spec.SchemaOrArray{
 								Schema: &spec.Schema{
@@ -3931,14 +3956,14 @@ func schema_k_orc_openstack_resource_controller_api_v1alpha1_RouterStatus(ref co
 					},
 					"id": {
 						SchemaProps: spec.SchemaProps{
-							Description: "ID is the unique identifier of the OpenStack resource.",
+							Description: "id is the unique identifier of the OpenStack resource.",
 							Type:        []string{"string"},
 							Format:      "",
 						},
 					},
 					"resource": {
 						SchemaProps: spec.SchemaProps{
-							Description: "Resource contains the observed state of the OpenStack resource.",
+							Description: "resource contains the observed state of the OpenStack resource.",
 							Ref:         ref("github.com/k-orc/openstack-resource-controller/api/v1alpha1.RouterResourceStatus"),
 						},
 					},
@@ -3973,20 +3998,23 @@ func schema_k_orc_openstack_resource_controller_api_v1alpha1_SecurityGroup(ref c
 					},
 					"metadata": {
 						SchemaProps: spec.SchemaProps{
-							Default: map[string]interface{}{},
-							Ref:     ref("k8s.io/apimachinery/pkg/apis/meta/v1.ObjectMeta"),
+							Description: "metadata contains the object metadata",
+							Default:     map[string]interface{}{},
+							Ref:         ref("k8s.io/apimachinery/pkg/apis/meta/v1.ObjectMeta"),
 						},
 					},
 					"spec": {
 						SchemaProps: spec.SchemaProps{
-							Default: map[string]interface{}{},
-							Ref:     ref("github.com/k-orc/openstack-resource-controller/api/v1alpha1.SecurityGroupSpec"),
+							Description: "spec specifies the desired state of the resource.",
+							Default:     map[string]interface{}{},
+							Ref:         ref("github.com/k-orc/openstack-resource-controller/api/v1alpha1.SecurityGroupSpec"),
 						},
 					},
 					"status": {
 						SchemaProps: spec.SchemaProps{
-							Default: map[string]interface{}{},
-							Ref:     ref("github.com/k-orc/openstack-resource-controller/api/v1alpha1.SecurityGroupStatus"),
+							Description: "status defines the observed state of the resource.",
+							Default:     map[string]interface{}{},
+							Ref:         ref("github.com/k-orc/openstack-resource-controller/api/v1alpha1.SecurityGroupStatus"),
 						},
 					},
 				},
@@ -4120,14 +4148,14 @@ func schema_k_orc_openstack_resource_controller_api_v1alpha1_SecurityGroupImport
 				Properties: map[string]spec.Schema{
 					"id": {
 						SchemaProps: spec.SchemaProps{
-							Description: "ID contains the unique identifier of an existing OpenStack resource. Note that when specifying an import by ID, the resource MUST already exist. The ORC object will enter an error state if the resource does not exist.",
+							Description: "id contains the unique identifier of an existing OpenStack resource. Note that when specifying an import by ID, the resource MUST already exist. The ORC object will enter an error state if the resource does not exist.",
 							Type:        []string{"string"},
 							Format:      "",
 						},
 					},
 					"filter": {
 						SchemaProps: spec.SchemaProps{
-							Description: "Filter contains a resource query which is expected to return a single result. The controller will continue to retry if filter returns no results. If filter returns multiple results the controller will set an error state and will not continue to retry.",
+							Description: "filter contains a resource query which is expected to return a single result. The controller will continue to retry if filter returns no results. If filter returns multiple results the controller will set an error state and will not continue to retry.",
 							Ref:         ref("github.com/k-orc/openstack-resource-controller/api/v1alpha1.SecurityGroupFilter"),
 						},
 					},
@@ -4162,13 +4190,15 @@ func schema_k_orc_openstack_resource_controller_api_v1alpha1_SecurityGroupList(r
 					},
 					"metadata": {
 						SchemaProps: spec.SchemaProps{
-							Default: map[string]interface{}{},
-							Ref:     ref("k8s.io/apimachinery/pkg/apis/meta/v1.ListMeta"),
+							Description: "metadata contains the list metadata",
+							Default:     map[string]interface{}{},
+							Ref:         ref("k8s.io/apimachinery/pkg/apis/meta/v1.ListMeta"),
 						},
 					},
 					"items": {
 						SchemaProps: spec.SchemaProps{
-							Type: []string{"array"},
+							Description: "items contains a list of SecurityGroup.",
+							Type:        []string{"array"},
 							Items: &spec.SchemaOrArray{
 								Schema: &spec.Schema{
 									SchemaProps: spec.SchemaProps{
@@ -4499,32 +4529,32 @@ func schema_k_orc_openstack_resource_controller_api_v1alpha1_SecurityGroupSpec(r
 				Properties: map[string]spec.Schema{
 					"import": {
 						SchemaProps: spec.SchemaProps{
-							Description: "Import refers to an existing OpenStack resource which will be imported instead of creating a new one.",
+							Description: "import refers to an existing OpenStack resource which will be imported instead of creating a new one.",
 							Ref:         ref("github.com/k-orc/openstack-resource-controller/api/v1alpha1.SecurityGroupImport"),
 						},
 					},
 					"resource": {
 						SchemaProps: spec.SchemaProps{
-							Description: "Resource specifies the desired state of the resource.\n\nResource may not be specified if the management policy is `unmanaged`.\n\nResource must be specified if the management policy is `managed`.",
+							Description: "resource specifies the desired state of the resource.\n\nresource may not be specified if the management policy is `unmanaged`.\n\nresource must be specified if the management policy is `managed`.",
 							Ref:         ref("github.com/k-orc/openstack-resource-controller/api/v1alpha1.SecurityGroupResourceSpec"),
 						},
 					},
 					"managementPolicy": {
 						SchemaProps: spec.SchemaProps{
-							Description: "ManagementPolicy defines how ORC will treat the object. Valid values are `managed`: ORC will create, update, and delete the resource; `unmanaged`: ORC will import an existing resource, and will not apply updates to it or delete it.",
+							Description: "managementPolicy defines how ORC will treat the object. Valid values are `managed`: ORC will create, update, and delete the resource; `unmanaged`: ORC will import an existing resource, and will not apply updates to it or delete it.",
 							Type:        []string{"string"},
 							Format:      "",
 						},
 					},
 					"managedOptions": {
 						SchemaProps: spec.SchemaProps{
-							Description: "ManagedOptions specifies options which may be applied to managed objects.",
+							Description: "managedOptions specifies options which may be applied to managed objects.",
 							Ref:         ref("github.com/k-orc/openstack-resource-controller/api/v1alpha1.ManagedOptions"),
 						},
 					},
 					"cloudCredentialsRef": {
 						SchemaProps: spec.SchemaProps{
-							Description: "CloudCredentialsRef points to a secret containing OpenStack credentials",
+							Description: "cloudCredentialsRef points to a secret containing OpenStack credentials",
 							Default:     map[string]interface{}{},
 							Ref:         ref("github.com/k-orc/openstack-resource-controller/api/v1alpha1.CloudCredentialsReference"),
 						},
@@ -4557,7 +4587,7 @@ func schema_k_orc_openstack_resource_controller_api_v1alpha1_SecurityGroupStatus
 							},
 						},
 						SchemaProps: spec.SchemaProps{
-							Description: "Conditions represents the observed status of the object. Known .status.conditions.type are: \"Available\", \"Progressing\"\n\nAvailable represents the availability of the OpenStack resource. If it is true then the resource is ready for use.\n\nProgressing indicates whether the controller is still attempting to reconcile the current state of the OpenStack resource to the desired state. Progressing will be False either because the desired state has been achieved, or because some terminal error prevents it from ever being achieved and the controller is no longer attempting to reconcile. If Progressing is True, an observer waiting on the resource should continue to wait.",
+							Description: "conditions represents the observed status of the object. Known .status.conditions.type are: \"Available\", \"Progressing\"\n\nAvailable represents the availability of the OpenStack resource. If it is true then the resource is ready for use.\n\nProgressing indicates whether the controller is still attempting to reconcile the current state of the OpenStack resource to the desired state. Progressing will be False either because the desired state has been achieved, or because some terminal error prevents it from ever being achieved and the controller is no longer attempting to reconcile. If Progressing is True, an observer waiting on the resource should continue to wait.",
 							Type:        []string{"array"},
 							Items: &spec.SchemaOrArray{
 								Schema: &spec.Schema{
@@ -4571,14 +4601,14 @@ func schema_k_orc_openstack_resource_controller_api_v1alpha1_SecurityGroupStatus
 					},
 					"id": {
 						SchemaProps: spec.SchemaProps{
-							Description: "ID is the unique identifier of the OpenStack resource.",
+							Description: "id is the unique identifier of the OpenStack resource.",
 							Type:        []string{"string"},
 							Format:      "",
 						},
 					},
 					"resource": {
 						SchemaProps: spec.SchemaProps{
-							Description: "Resource contains the observed state of the OpenStack resource.",
+							Description: "resource contains the observed state of the OpenStack resource.",
 							Ref:         ref("github.com/k-orc/openstack-resource-controller/api/v1alpha1.SecurityGroupResourceStatus"),
 						},
 					},
@@ -4613,20 +4643,23 @@ func schema_k_orc_openstack_resource_controller_api_v1alpha1_Server(ref common.R
 					},
 					"metadata": {
 						SchemaProps: spec.SchemaProps{
-							Default: map[string]interface{}{},
-							Ref:     ref("k8s.io/apimachinery/pkg/apis/meta/v1.ObjectMeta"),
+							Description: "metadata contains the object metadata",
+							Default:     map[string]interface{}{},
+							Ref:         ref("k8s.io/apimachinery/pkg/apis/meta/v1.ObjectMeta"),
 						},
 					},
 					"spec": {
 						SchemaProps: spec.SchemaProps{
-							Default: map[string]interface{}{},
-							Ref:     ref("github.com/k-orc/openstack-resource-controller/api/v1alpha1.ServerSpec"),
+							Description: "spec specifies the desired state of the resource.",
+							Default:     map[string]interface{}{},
+							Ref:         ref("github.com/k-orc/openstack-resource-controller/api/v1alpha1.ServerSpec"),
 						},
 					},
 					"status": {
 						SchemaProps: spec.SchemaProps{
-							Default: map[string]interface{}{},
-							Ref:     ref("github.com/k-orc/openstack-resource-controller/api/v1alpha1.ServerStatus"),
+							Description: "status defines the observed state of the resource.",
+							Default:     map[string]interface{}{},
+							Ref:         ref("github.com/k-orc/openstack-resource-controller/api/v1alpha1.ServerStatus"),
 						},
 					},
 				},
@@ -4666,14 +4699,14 @@ func schema_k_orc_openstack_resource_controller_api_v1alpha1_ServerImport(ref co
 				Properties: map[string]spec.Schema{
 					"id": {
 						SchemaProps: spec.SchemaProps{
-							Description: "ID contains the unique identifier of an existing OpenStack resource. Note that when specifying an import by ID, the resource MUST already exist. The ORC object will enter an error state if the resource does not exist.",
+							Description: "id contains the unique identifier of an existing OpenStack resource. Note that when specifying an import by ID, the resource MUST already exist. The ORC object will enter an error state if the resource does not exist.",
 							Type:        []string{"string"},
 							Format:      "",
 						},
 					},
 					"filter": {
 						SchemaProps: spec.SchemaProps{
-							Description: "Filter contains a resource query which is expected to return a single result. The controller will continue to retry if filter returns no results. If filter returns multiple results the controller will set an error state and will not continue to retry.",
+							Description: "filter contains a resource query which is expected to return a single result. The controller will continue to retry if filter returns no results. If filter returns multiple results the controller will set an error state and will not continue to retry.",
 							Ref:         ref("github.com/k-orc/openstack-resource-controller/api/v1alpha1.ServerFilter"),
 						},
 					},
@@ -4708,13 +4741,15 @@ func schema_k_orc_openstack_resource_controller_api_v1alpha1_ServerList(ref comm
 					},
 					"metadata": {
 						SchemaProps: spec.SchemaProps{
-							Default: map[string]interface{}{},
-							Ref:     ref("k8s.io/apimachinery/pkg/apis/meta/v1.ListMeta"),
+							Description: "metadata contains the list metadata",
+							Default:     map[string]interface{}{},
+							Ref:         ref("k8s.io/apimachinery/pkg/apis/meta/v1.ListMeta"),
 						},
 					},
 					"items": {
 						SchemaProps: spec.SchemaProps{
-							Type: []string{"array"},
+							Description: "items contains a list of Server.",
+							Type:        []string{"array"},
 							Items: &spec.SchemaOrArray{
 								Schema: &spec.Schema{
 									SchemaProps: spec.SchemaProps{
@@ -4906,32 +4941,32 @@ func schema_k_orc_openstack_resource_controller_api_v1alpha1_ServerSpec(ref comm
 				Properties: map[string]spec.Schema{
 					"import": {
 						SchemaProps: spec.SchemaProps{
-							Description: "Import refers to an existing OpenStack resource which will be imported instead of creating a new one.",
+							Description: "import refers to an existing OpenStack resource which will be imported instead of creating a new one.",
 							Ref:         ref("github.com/k-orc/openstack-resource-controller/api/v1alpha1.ServerImport"),
 						},
 					},
 					"resource": {
 						SchemaProps: spec.SchemaProps{
-							Description: "Resource specifies the desired state of the resource.\n\nResource may not be specified if the management policy is `unmanaged`.\n\nResource must be specified if the management policy is `managed`.",
+							Description: "resource specifies the desired state of the resource.\n\nresource may not be specified if the management policy is `unmanaged`.\n\nresource must be specified if the management policy is `managed`.",
 							Ref:         ref("github.com/k-orc/openstack-resource-controller/api/v1alpha1.ServerResourceSpec"),
 						},
 					},
 					"managementPolicy": {
 						SchemaProps: spec.SchemaProps{
-							Description: "ManagementPolicy defines how ORC will treat the object. Valid values are `managed`: ORC will create, update, and delete the resource; `unmanaged`: ORC will import an existing resource, and will not apply updates to it or delete it.",
+							Description: "managementPolicy defines how ORC will treat the object. Valid values are `managed`: ORC will create, update, and delete the resource; `unmanaged`: ORC will import an existing resource, and will not apply updates to it or delete it.",
 							Type:        []string{"string"},
 							Format:      "",
 						},
 					},
 					"managedOptions": {
 						SchemaProps: spec.SchemaProps{
-							Description: "ManagedOptions specifies options which may be applied to managed objects.",
+							Description: "managedOptions specifies options which may be applied to managed objects.",
 							Ref:         ref("github.com/k-orc/openstack-resource-controller/api/v1alpha1.ManagedOptions"),
 						},
 					},
 					"cloudCredentialsRef": {
 						SchemaProps: spec.SchemaProps{
-							Description: "CloudCredentialsRef points to a secret containing OpenStack credentials",
+							Description: "cloudCredentialsRef points to a secret containing OpenStack credentials",
 							Default:     map[string]interface{}{},
 							Ref:         ref("github.com/k-orc/openstack-resource-controller/api/v1alpha1.CloudCredentialsReference"),
 						},
@@ -4964,7 +4999,7 @@ func schema_k_orc_openstack_resource_controller_api_v1alpha1_ServerStatus(ref co
 							},
 						},
 						SchemaProps: spec.SchemaProps{
-							Description: "Conditions represents the observed status of the object. Known .status.conditions.type are: \"Available\", \"Progressing\"\n\nAvailable represents the availability of the OpenStack resource. If it is true then the resource is ready for use.\n\nProgressing indicates whether the controller is still attempting to reconcile the current state of the OpenStack resource to the desired state. Progressing will be False either because the desired state has been achieved, or because some terminal error prevents it from ever being achieved and the controller is no longer attempting to reconcile. If Progressing is True, an observer waiting on the resource should continue to wait.",
+							Description: "conditions represents the observed status of the object. Known .status.conditions.type are: \"Available\", \"Progressing\"\n\nAvailable represents the availability of the OpenStack resource. If it is true then the resource is ready for use.\n\nProgressing indicates whether the controller is still attempting to reconcile the current state of the OpenStack resource to the desired state. Progressing will be False either because the desired state has been achieved, or because some terminal error prevents it from ever being achieved and the controller is no longer attempting to reconcile. If Progressing is True, an observer waiting on the resource should continue to wait.",
 							Type:        []string{"array"},
 							Items: &spec.SchemaOrArray{
 								Schema: &spec.Schema{
@@ -4978,14 +5013,14 @@ func schema_k_orc_openstack_resource_controller_api_v1alpha1_ServerStatus(ref co
 					},
 					"id": {
 						SchemaProps: spec.SchemaProps{
-							Description: "ID is the unique identifier of the OpenStack resource.",
+							Description: "id is the unique identifier of the OpenStack resource.",
 							Type:        []string{"string"},
 							Format:      "",
 						},
 					},
 					"resource": {
 						SchemaProps: spec.SchemaProps{
-							Description: "Resource contains the observed state of the OpenStack resource.",
+							Description: "resource contains the observed state of the OpenStack resource.",
 							Ref:         ref("github.com/k-orc/openstack-resource-controller/api/v1alpha1.ServerResourceStatus"),
 						},
 					},
@@ -5020,20 +5055,23 @@ func schema_k_orc_openstack_resource_controller_api_v1alpha1_Subnet(ref common.R
 					},
 					"metadata": {
 						SchemaProps: spec.SchemaProps{
-							Default: map[string]interface{}{},
-							Ref:     ref("k8s.io/apimachinery/pkg/apis/meta/v1.ObjectMeta"),
+							Description: "metadata contains the object metadata",
+							Default:     map[string]interface{}{},
+							Ref:         ref("k8s.io/apimachinery/pkg/apis/meta/v1.ObjectMeta"),
 						},
 					},
 					"spec": {
 						SchemaProps: spec.SchemaProps{
-							Default: map[string]interface{}{},
-							Ref:     ref("github.com/k-orc/openstack-resource-controller/api/v1alpha1.SubnetSpec"),
+							Description: "spec specifies the desired state of the resource.",
+							Default:     map[string]interface{}{},
+							Ref:         ref("github.com/k-orc/openstack-resource-controller/api/v1alpha1.SubnetSpec"),
 						},
 					},
 					"status": {
 						SchemaProps: spec.SchemaProps{
-							Default: map[string]interface{}{},
-							Ref:     ref("github.com/k-orc/openstack-resource-controller/api/v1alpha1.SubnetStatus"),
+							Description: "status defines the observed state of the resource.",
+							Default:     map[string]interface{}{},
+							Ref:         ref("github.com/k-orc/openstack-resource-controller/api/v1alpha1.SubnetStatus"),
 						},
 					},
 				},
@@ -5217,14 +5255,14 @@ func schema_k_orc_openstack_resource_controller_api_v1alpha1_SubnetImport(ref co
 				Properties: map[string]spec.Schema{
 					"id": {
 						SchemaProps: spec.SchemaProps{
-							Description: "ID contains the unique identifier of an existing OpenStack resource. Note that when specifying an import by ID, the resource MUST already exist. The ORC object will enter an error state if the resource does not exist.",
+							Description: "id contains the unique identifier of an existing OpenStack resource. Note that when specifying an import by ID, the resource MUST already exist. The ORC object will enter an error state if the resource does not exist.",
 							Type:        []string{"string"},
 							Format:      "",
 						},
 					},
 					"filter": {
 						SchemaProps: spec.SchemaProps{
-							Description: "Filter contains a resource query which is expected to return a single result. The controller will continue to retry if filter returns no results. If filter returns multiple results the controller will set an error state and will not continue to retry.",
+							Description: "filter contains a resource query which is expected to return a single result. The controller will continue to retry if filter returns no results. If filter returns multiple results the controller will set an error state and will not continue to retry.",
 							Ref:         ref("github.com/k-orc/openstack-resource-controller/api/v1alpha1.SubnetFilter"),
 						},
 					},
@@ -5259,13 +5297,15 @@ func schema_k_orc_openstack_resource_controller_api_v1alpha1_SubnetList(ref comm
 					},
 					"metadata": {
 						SchemaProps: spec.SchemaProps{
-							Default: map[string]interface{}{},
-							Ref:     ref("k8s.io/apimachinery/pkg/apis/meta/v1.ListMeta"),
+							Description: "metadata contains the list metadata",
+							Default:     map[string]interface{}{},
+							Ref:         ref("k8s.io/apimachinery/pkg/apis/meta/v1.ListMeta"),
 						},
 					},
 					"items": {
 						SchemaProps: spec.SchemaProps{
-							Type: []string{"array"},
+							Description: "items contains a list of Subnet.",
+							Type:        []string{"array"},
 							Items: &spec.SchemaOrArray{
 								Schema: &spec.Schema{
 									SchemaProps: spec.SchemaProps{
@@ -5680,32 +5720,32 @@ func schema_k_orc_openstack_resource_controller_api_v1alpha1_SubnetSpec(ref comm
 					},
 					"import": {
 						SchemaProps: spec.SchemaProps{
-							Description: "Import refers to an existing OpenStack resource which will be imported instead of creating a new one.",
+							Description: "import refers to an existing OpenStack resource which will be imported instead of creating a new one.",
 							Ref:         ref("github.com/k-orc/openstack-resource-controller/api/v1alpha1.SubnetImport"),
 						},
 					},
 					"resource": {
 						SchemaProps: spec.SchemaProps{
-							Description: "Resource specifies the desired state of the resource.\n\nResource may not be specified if the management policy is `unmanaged`.\n\nResource must be specified if the management policy is `managed`.",
+							Description: "resource specifies the desired state of the resource.\n\nresource may not be specified if the management policy is `unmanaged`.\n\nresource must be specified if the management policy is `managed`.",
 							Ref:         ref("github.com/k-orc/openstack-resource-controller/api/v1alpha1.SubnetResourceSpec"),
 						},
 					},
 					"managementPolicy": {
 						SchemaProps: spec.SchemaProps{
-							Description: "ManagementPolicy defines how ORC will treat the object. Valid values are `managed`: ORC will create, update, and delete the resource; `unmanaged`: ORC will import an existing resource, and will not apply updates to it or delete it.",
+							Description: "managementPolicy defines how ORC will treat the object. Valid values are `managed`: ORC will create, update, and delete the resource; `unmanaged`: ORC will import an existing resource, and will not apply updates to it or delete it.",
 							Type:        []string{"string"},
 							Format:      "",
 						},
 					},
 					"managedOptions": {
 						SchemaProps: spec.SchemaProps{
-							Description: "ManagedOptions specifies options which may be applied to managed objects.",
+							Description: "managedOptions specifies options which may be applied to managed objects.",
 							Ref:         ref("github.com/k-orc/openstack-resource-controller/api/v1alpha1.ManagedOptions"),
 						},
 					},
 					"cloudCredentialsRef": {
 						SchemaProps: spec.SchemaProps{
-							Description: "CloudCredentialsRef points to a secret containing OpenStack credentials",
+							Description: "cloudCredentialsRef points to a secret containing OpenStack credentials",
 							Default:     map[string]interface{}{},
 							Ref:         ref("github.com/k-orc/openstack-resource-controller/api/v1alpha1.CloudCredentialsReference"),
 						},
@@ -5738,7 +5778,7 @@ func schema_k_orc_openstack_resource_controller_api_v1alpha1_SubnetStatus(ref co
 							},
 						},
 						SchemaProps: spec.SchemaProps{
-							Description: "Conditions represents the observed status of the object. Known .status.conditions.type are: \"Available\", \"Progressing\"\n\nAvailable represents the availability of the OpenStack resource. If it is true then the resource is ready for use.\n\nProgressing indicates whether the controller is still attempting to reconcile the current state of the OpenStack resource to the desired state. Progressing will be False either because the desired state has been achieved, or because some terminal error prevents it from ever being achieved and the controller is no longer attempting to reconcile. If Progressing is True, an observer waiting on the resource should continue to wait.",
+							Description: "conditions represents the observed status of the object. Known .status.conditions.type are: \"Available\", \"Progressing\"\n\nAvailable represents the availability of the OpenStack resource. If it is true then the resource is ready for use.\n\nProgressing indicates whether the controller is still attempting to reconcile the current state of the OpenStack resource to the desired state. Progressing will be False either because the desired state has been achieved, or because some terminal error prevents it from ever being achieved and the controller is no longer attempting to reconcile. If Progressing is True, an observer waiting on the resource should continue to wait.",
 							Type:        []string{"array"},
 							Items: &spec.SchemaOrArray{
 								Schema: &spec.Schema{
@@ -5752,14 +5792,14 @@ func schema_k_orc_openstack_resource_controller_api_v1alpha1_SubnetStatus(ref co
 					},
 					"id": {
 						SchemaProps: spec.SchemaProps{
-							Description: "ID is the unique identifier of the OpenStack resource.",
+							Description: "id is the unique identifier of the OpenStack resource.",
 							Type:        []string{"string"},
 							Format:      "",
 						},
 					},
 					"resource": {
 						SchemaProps: spec.SchemaProps{
-							Description: "Resource contains the observed state of the OpenStack resource.",
+							Description: "resource contains the observed state of the OpenStack resource.",
 							Ref:         ref("github.com/k-orc/openstack-resource-controller/api/v1alpha1.SubnetResourceStatus"),
 						},
 					},

--- a/cmd/resource-generator/data/api.template
+++ b/cmd/resource-generator/data/api.template
@@ -25,14 +25,14 @@ import (
 // +kubebuilder:validation:MinProperties:=1
 // +kubebuilder:validation:MaxProperties:=1
 type {{ .Name }}Import struct {
-	// ID contains the unique identifier of an existing OpenStack resource. Note
+	// id contains the unique identifier of an existing OpenStack resource. Note
 	// that when specifying an import by ID, the resource MUST already exist.
 	// The ORC object will enter an error state if the resource does not exist.
 	// +optional
 	// +kubebuilder:validation:Format:=uuid
 	ID *string `json:"id,omitempty"`
 
-	// Filter contains a resource query which is expected to return a single
+	// filter contains a resource query which is expected to return a single
 	// result. The controller will continue to retry if filter returns no
 	// results. If filter returns multiple results the controller will set an
 	// error state and will not continue to retry.
@@ -53,20 +53,20 @@ type {{ .Name }}Spec struct {
 {{- if .SpecExtraType }}
 	{{ .SpecExtraType }} `json:",inline"`
 {{ end }}
-	// Import refers to an existing OpenStack resource which will be imported instead of
+	// import refers to an existing OpenStack resource which will be imported instead of
 	// creating a new one.
 	// +optional
 	Import *{{ .Name }}Import `json:"import,omitempty"`
 
-	// Resource specifies the desired state of the resource.
+	// resource specifies the desired state of the resource.
 	//
-	// Resource may not be specified if the management policy is `unmanaged`.
+	// resource may not be specified if the management policy is `unmanaged`.
 	//
-	// Resource must be specified if the management policy is `managed`.
+	// resource must be specified if the management policy is `managed`.
 	// +optional
 	Resource *{{ .Name }}ResourceSpec `json:"resource,omitempty"`
 
-	// ManagementPolicy defines how ORC will treat the object. Valid values are
+	// managementPolicy defines how ORC will treat the object. Valid values are
 	// `managed`: ORC will create, update, and delete the resource; `unmanaged`:
 	// ORC will import an existing resource, and will not apply updates to it or
 	// delete it.
@@ -75,18 +75,18 @@ type {{ .Name }}Spec struct {
 	// +optional
 	ManagementPolicy ManagementPolicy `json:"managementPolicy,omitempty"`
 
-	// ManagedOptions specifies options which may be applied to managed objects.
+	// managedOptions specifies options which may be applied to managed objects.
 	// +optional
 	ManagedOptions *ManagedOptions `json:"managedOptions,omitempty"`
 
-	// CloudCredentialsRef points to a secret containing OpenStack credentials
-	// +kubebuilder:validation:Required
+	// cloudCredentialsRef points to a secret containing OpenStack credentials
+	// +required
 	CloudCredentialsRef CloudCredentialsReference `json:"cloudCredentialsRef"`
 }
 
 // {{ .Name }}Status defines the observed state of an ORC resource.
 type {{ .Name }}Status struct {
-	// Conditions represents the observed status of the object.
+	// conditions represents the observed status of the object.
 	// Known .status.conditions.type are: "Available", "Progressing"
 	//
 	// Available represents the availability of the OpenStack resource. If it is
@@ -104,13 +104,14 @@ type {{ .Name }}Status struct {
 	// +patchStrategy=merge
 	// +listType=map
 	// +listMapKey=type
+	// +optional
 	Conditions []metav1.Condition `json:"conditions,omitempty" patchStrategy:"merge" patchMergeKey:"type"`
 
-	// ID is the unique identifier of the OpenStack resource.
+	// id is the unique identifier of the OpenStack resource.
 	// +optional
 	ID *string `json:"id,omitempty"`
 
-	// Resource contains the observed state of the OpenStack resource.
+	// resource contains the observed state of the OpenStack resource.
 	// +optional
 	Resource *{{ .Name }}ResourceStatus `json:"resource,omitempty"`
 {{- if .StatusExtraType }}
@@ -137,9 +138,17 @@ func (i *{{ .Name }}) GetConditions() []metav1.Condition {
 // {{ .Name }} is the Schema for an ORC resource.
 type {{ .Name }} struct {
 	metav1.TypeMeta   `json:",inline"`
+
+	// metadata contains the object metadata
+	// +optional
 	metav1.ObjectMeta `json:"metadata,omitempty"`
 
+	// spec specifies the desired state of the resource.
+	// +optional
 	Spec   {{ .Name }}Spec   `json:"spec,omitempty"`
+
+	// status defines the observed state of the resource.
+	// +optional
 	Status {{ .Name }}Status `json:"status,omitempty"`
 }
 
@@ -148,7 +157,13 @@ type {{ .Name }} struct {
 // {{ .Name }}List contains a list of {{ .Name }}.
 type {{ .Name }}List struct {
 	metav1.TypeMeta `json:",inline"`
+
+	// metadata contains the list metadata
+	// +optional
 	metav1.ListMeta `json:"metadata,omitempty"`
+
+	// items contains a list of {{ .Name }}.
+	// +required
 	Items           []{{ .Name }} `json:"items"`
 }
 

--- a/config/crd/bases/openstack.k-orc.cloud_flavors.yaml
+++ b/config/crd/bases/openstack.k-orc.cloud_flavors.yaml
@@ -56,10 +56,10 @@ spec:
           metadata:
             type: object
           spec:
-            description: FlavorSpec defines the desired state of an ORC object.
+            description: spec specifies the desired state of the resource.
             properties:
               cloudCredentialsRef:
-                description: CloudCredentialsRef points to a secret containing OpenStack
+                description: cloudCredentialsRef points to a secret containing OpenStack
                   credentials
                 properties:
                   cloudName:
@@ -82,14 +82,14 @@ spec:
                 type: object
               import:
                 description: |-
-                  Import refers to an existing OpenStack resource which will be imported instead of
+                  import refers to an existing OpenStack resource which will be imported instead of
                   creating a new one.
                 maxProperties: 1
                 minProperties: 1
                 properties:
                   filter:
                     description: |-
-                      Filter contains a resource query which is expected to return a single
+                      filter contains a resource query which is expected to return a single
                       result. The controller will continue to retry if filter returns no
                       results. If filter returns multiple results the controller will set an
                       error state and will not continue to retry.
@@ -112,14 +112,14 @@ spec:
                     type: object
                   id:
                     description: |-
-                      ID contains the unique identifier of an existing OpenStack resource. Note
+                      id contains the unique identifier of an existing OpenStack resource. Note
                       that when specifying an import by ID, the resource MUST already exist.
                       The ORC object will enter an error state if the resource does not exist.
                     format: uuid
                     type: string
                 type: object
               managedOptions:
-                description: ManagedOptions specifies options which may be applied
+                description: managedOptions specifies options which may be applied
                   to managed objects.
                 properties:
                   onDelete:
@@ -137,7 +137,7 @@ spec:
               managementPolicy:
                 default: managed
                 description: |-
-                  ManagementPolicy defines how ORC will treat the object. Valid values are
+                  managementPolicy defines how ORC will treat the object. Valid values are
                   `managed`: ORC will create, update, and delete the resource; `unmanaged`:
                   ORC will import an existing resource, and will not apply updates to it or
                   delete it.
@@ -150,11 +150,11 @@ spec:
                   rule: self == oldSelf
               resource:
                 description: |-
-                  Resource specifies the desired state of the resource.
+                  resource specifies the desired state of the resource.
 
-                  Resource may not be specified if the management policy is `unmanaged`.
+                  resource may not be specified if the management policy is `unmanaged`.
 
-                  Resource must be specified if the management policy is `managed`.
+                  resource must be specified if the management policy is `managed`.
                 properties:
                   description:
                     description: description is the description of the server
@@ -231,11 +231,11 @@ spec:
               rule: 'has(self.managedOptions) ? self.managementPolicy == ''managed''
                 : true'
           status:
-            description: FlavorStatus defines the observed state of an ORC resource.
+            description: status defines the observed state of the resource.
             properties:
               conditions:
                 description: |-
-                  Conditions represents the observed status of the object.
+                  conditions represents the observed status of the object.
                   Known .status.conditions.type are: "Available", "Progressing"
 
                   Available represents the availability of the OpenStack resource. If it is
@@ -307,10 +307,10 @@ spec:
                 - type
                 x-kubernetes-list-type: map
               id:
-                description: ID is the unique identifier of the OpenStack resource.
+                description: id is the unique identifier of the OpenStack resource.
                 type: string
               resource:
-                description: Resource contains the observed state of the OpenStack
+                description: resource contains the observed state of the OpenStack
                   resource.
                 properties:
                   description:

--- a/config/crd/bases/openstack.k-orc.cloud_images.yaml
+++ b/config/crd/bases/openstack.k-orc.cloud_images.yaml
@@ -56,10 +56,10 @@ spec:
           metadata:
             type: object
           spec:
-            description: ImageSpec defines the desired state of an ORC object.
+            description: spec specifies the desired state of the resource.
             properties:
               cloudCredentialsRef:
-                description: CloudCredentialsRef points to a secret containing OpenStack
+                description: cloudCredentialsRef points to a secret containing OpenStack
                   credentials
                 properties:
                   cloudName:
@@ -82,14 +82,14 @@ spec:
                 type: object
               import:
                 description: |-
-                  Import refers to an existing OpenStack resource which will be imported instead of
+                  import refers to an existing OpenStack resource which will be imported instead of
                   creating a new one.
                 maxProperties: 1
                 minProperties: 1
                 properties:
                   filter:
                     description: |-
-                      Filter contains a resource query which is expected to return a single
+                      filter contains a resource query which is expected to return a single
                       result. The controller will continue to retry if filter returns no
                       results. If filter returns multiple results the controller will set an
                       error state and will not continue to retry.
@@ -103,14 +103,14 @@ spec:
                     type: object
                   id:
                     description: |-
-                      ID contains the unique identifier of an existing OpenStack resource. Note
+                      id contains the unique identifier of an existing OpenStack resource. Note
                       that when specifying an import by ID, the resource MUST already exist.
                       The ORC object will enter an error state if the resource does not exist.
                     format: uuid
                     type: string
                 type: object
               managedOptions:
-                description: ManagedOptions specifies options which may be applied
+                description: managedOptions specifies options which may be applied
                   to managed objects.
                 properties:
                   onDelete:
@@ -128,7 +128,7 @@ spec:
               managementPolicy:
                 default: managed
                 description: |-
-                  ManagementPolicy defines how ORC will treat the object. Valid values are
+                  managementPolicy defines how ORC will treat the object. Valid values are
                   `managed`: ORC will create, update, and delete the resource; `unmanaged`:
                   ORC will import an existing resource, and will not apply updates to it or
                   delete it.
@@ -141,11 +141,11 @@ spec:
                   rule: self == oldSelf
               resource:
                 description: |-
-                  Resource specifies the desired state of the resource.
+                  resource specifies the desired state of the resource.
 
-                  Resource may not be specified if the management policy is `unmanaged`.
+                  resource may not be specified if the management policy is `unmanaged`.
 
-                  Resource must be specified if the management policy is `managed`.
+                  resource must be specified if the management policy is `managed`.
                 properties:
                   content:
                     description: content specifies how to obtain the image content.
@@ -455,11 +455,11 @@ spec:
             - message: resource content must be specified when not importing
               rule: '!has(self.__import__) ? has(self.resource.content) : true'
           status:
-            description: ImageStatus defines the observed state of an ORC resource.
+            description: status defines the observed state of the resource.
             properties:
               conditions:
                 description: |-
-                  Conditions represents the observed status of the object.
+                  conditions represents the observed status of the object.
                   Known .status.conditions.type are: "Available", "Progressing"
 
                   Available represents the availability of the OpenStack resource. If it is
@@ -535,10 +535,10 @@ spec:
                   has attempted to download the image contents
                 type: integer
               id:
-                description: ID is the unique identifier of the OpenStack resource.
+                description: id is the unique identifier of the OpenStack resource.
                 type: string
               resource:
-                description: Resource contains the observed state of the OpenStack
+                description: resource contains the observed state of the OpenStack
                   resource.
                 properties:
                   hash:

--- a/config/crd/bases/openstack.k-orc.cloud_networks.yaml
+++ b/config/crd/bases/openstack.k-orc.cloud_networks.yaml
@@ -56,10 +56,10 @@ spec:
           metadata:
             type: object
           spec:
-            description: NetworkSpec defines the desired state of an ORC object.
+            description: spec specifies the desired state of the resource.
             properties:
               cloudCredentialsRef:
-                description: CloudCredentialsRef points to a secret containing OpenStack
+                description: cloudCredentialsRef points to a secret containing OpenStack
                   credentials
                 properties:
                   cloudName:
@@ -82,14 +82,14 @@ spec:
                 type: object
               import:
                 description: |-
-                  Import refers to an existing OpenStack resource which will be imported instead of
+                  import refers to an existing OpenStack resource which will be imported instead of
                   creating a new one.
                 maxProperties: 1
                 minProperties: 1
                 properties:
                   filter:
                     description: |-
-                      Filter contains a resource query which is expected to return a single
+                      filter contains a resource query which is expected to return a single
                       result. The controller will continue to retry if filter returns no
                       results. If filter returns multiple results the controller will set an
                       error state and will not continue to retry.
@@ -176,14 +176,14 @@ spec:
                     type: object
                   id:
                     description: |-
-                      ID contains the unique identifier of an existing OpenStack resource. Note
+                      id contains the unique identifier of an existing OpenStack resource. Note
                       that when specifying an import by ID, the resource MUST already exist.
                       The ORC object will enter an error state if the resource does not exist.
                     format: uuid
                     type: string
                 type: object
               managedOptions:
-                description: ManagedOptions specifies options which may be applied
+                description: managedOptions specifies options which may be applied
                   to managed objects.
                 properties:
                   onDelete:
@@ -201,7 +201,7 @@ spec:
               managementPolicy:
                 default: managed
                 description: |-
-                  ManagementPolicy defines how ORC will treat the object. Valid values are
+                  managementPolicy defines how ORC will treat the object. Valid values are
                   `managed`: ORC will create, update, and delete the resource; `unmanaged`:
                   ORC will import an existing resource, and will not apply updates to it or
                   delete it.
@@ -214,11 +214,11 @@ spec:
                   rule: self == oldSelf
               resource:
                 description: |-
-                  Resource specifies the desired state of the resource.
+                  resource specifies the desired state of the resource.
 
-                  Resource may not be specified if the management policy is `unmanaged`.
+                  resource may not be specified if the management policy is `unmanaged`.
 
-                  Resource must be specified if the management policy is `managed`.
+                  resource must be specified if the management policy is `managed`.
                 properties:
                   adminStateUp:
                     description: adminStateUp is the administrative state of the network,
@@ -307,11 +307,11 @@ spec:
               rule: 'has(self.managedOptions) ? self.managementPolicy == ''managed''
                 : true'
           status:
-            description: NetworkStatus defines the observed state of an ORC resource.
+            description: status defines the observed state of the resource.
             properties:
               conditions:
                 description: |-
-                  Conditions represents the observed status of the object.
+                  conditions represents the observed status of the object.
                   Known .status.conditions.type are: "Available", "Progressing"
 
                   Available represents the availability of the OpenStack resource. If it is
@@ -383,10 +383,10 @@ spec:
                 - type
                 x-kubernetes-list-type: map
               id:
-                description: ID is the unique identifier of the OpenStack resource.
+                description: id is the unique identifier of the OpenStack resource.
                 type: string
               resource:
-                description: Resource contains the observed state of the OpenStack
+                description: resource contains the observed state of the OpenStack
                   resource.
                 properties:
                   adminStateUp:

--- a/config/crd/bases/openstack.k-orc.cloud_ports.yaml
+++ b/config/crd/bases/openstack.k-orc.cloud_ports.yaml
@@ -56,10 +56,10 @@ spec:
           metadata:
             type: object
           spec:
-            description: PortSpec defines the desired state of an ORC object.
+            description: spec specifies the desired state of the resource.
             properties:
               cloudCredentialsRef:
-                description: CloudCredentialsRef points to a secret containing OpenStack
+                description: cloudCredentialsRef points to a secret containing OpenStack
                   credentials
                 properties:
                   cloudName:
@@ -82,14 +82,14 @@ spec:
                 type: object
               import:
                 description: |-
-                  Import refers to an existing OpenStack resource which will be imported instead of
+                  import refers to an existing OpenStack resource which will be imported instead of
                   creating a new one.
                 maxProperties: 1
                 minProperties: 1
                 properties:
                   filter:
                     description: |-
-                      Filter contains a resource query which is expected to return a single
+                      filter contains a resource query which is expected to return a single
                       result. The controller will continue to retry if filter returns no
                       results. If filter returns multiple results the controller will set an
                       error state and will not continue to retry.
@@ -167,14 +167,14 @@ spec:
                     type: object
                   id:
                     description: |-
-                      ID contains the unique identifier of an existing OpenStack resource. Note
+                      id contains the unique identifier of an existing OpenStack resource. Note
                       that when specifying an import by ID, the resource MUST already exist.
                       The ORC object will enter an error state if the resource does not exist.
                     format: uuid
                     type: string
                 type: object
               managedOptions:
-                description: ManagedOptions specifies options which may be applied
+                description: managedOptions specifies options which may be applied
                   to managed objects.
                 properties:
                   onDelete:
@@ -192,7 +192,7 @@ spec:
               managementPolicy:
                 default: managed
                 description: |-
-                  ManagementPolicy defines how ORC will treat the object. Valid values are
+                  managementPolicy defines how ORC will treat the object. Valid values are
                   `managed`: ORC will create, update, and delete the resource; `unmanaged`:
                   ORC will import an existing resource, and will not apply updates to it or
                   delete it.
@@ -211,11 +211,11 @@ spec:
                 type: string
               resource:
                 description: |-
-                  Resource specifies the desired state of the resource.
+                  resource specifies the desired state of the resource.
 
-                  Resource may not be specified if the management policy is `unmanaged`.
+                  resource may not be specified if the management policy is `unmanaged`.
 
-                  Resource must be specified if the management policy is `managed`.
+                  resource must be specified if the management policy is `managed`.
                 properties:
                   addresses:
                     description: addresses are the IP addresses for the port.
@@ -316,11 +316,11 @@ spec:
               rule: 'has(self.managedOptions) ? self.managementPolicy == ''managed''
                 : true'
           status:
-            description: PortStatus defines the observed state of an ORC resource.
+            description: status defines the observed state of the resource.
             properties:
               conditions:
                 description: |-
-                  Conditions represents the observed status of the object.
+                  conditions represents the observed status of the object.
                   Known .status.conditions.type are: "Available", "Progressing"
 
                   Available represents the availability of the OpenStack resource. If it is
@@ -392,10 +392,10 @@ spec:
                 - type
                 x-kubernetes-list-type: map
               id:
-                description: ID is the unique identifier of the OpenStack resource.
+                description: id is the unique identifier of the OpenStack resource.
                 type: string
               resource:
-                description: Resource contains the observed state of the OpenStack
+                description: resource contains the observed state of the OpenStack
                   resource.
                 properties:
                   adminStateUp:

--- a/config/crd/bases/openstack.k-orc.cloud_routers.yaml
+++ b/config/crd/bases/openstack.k-orc.cloud_routers.yaml
@@ -56,10 +56,10 @@ spec:
           metadata:
             type: object
           spec:
-            description: RouterSpec defines the desired state of an ORC object.
+            description: spec specifies the desired state of the resource.
             properties:
               cloudCredentialsRef:
-                description: CloudCredentialsRef points to a secret containing OpenStack
+                description: cloudCredentialsRef points to a secret containing OpenStack
                   credentials
                 properties:
                   cloudName:
@@ -82,14 +82,14 @@ spec:
                 type: object
               import:
                 description: |-
-                  Import refers to an existing OpenStack resource which will be imported instead of
+                  import refers to an existing OpenStack resource which will be imported instead of
                   creating a new one.
                 maxProperties: 1
                 minProperties: 1
                 properties:
                   filter:
                     description: |-
-                      Filter contains a resource query which is expected to return a single
+                      filter contains a resource query which is expected to return a single
                       result. The controller will continue to retry if filter returns no
                       results. If filter returns multiple results the controller will set an
                       error state and will not continue to retry.
@@ -167,14 +167,14 @@ spec:
                     type: object
                   id:
                     description: |-
-                      ID contains the unique identifier of an existing OpenStack resource. Note
+                      id contains the unique identifier of an existing OpenStack resource. Note
                       that when specifying an import by ID, the resource MUST already exist.
                       The ORC object will enter an error state if the resource does not exist.
                     format: uuid
                     type: string
                 type: object
               managedOptions:
-                description: ManagedOptions specifies options which may be applied
+                description: managedOptions specifies options which may be applied
                   to managed objects.
                 properties:
                   onDelete:
@@ -192,7 +192,7 @@ spec:
               managementPolicy:
                 default: managed
                 description: |-
-                  ManagementPolicy defines how ORC will treat the object. Valid values are
+                  managementPolicy defines how ORC will treat the object. Valid values are
                   `managed`: ORC will create, update, and delete the resource; `unmanaged`:
                   ORC will import an existing resource, and will not apply updates to it or
                   delete it.
@@ -205,11 +205,11 @@ spec:
                   rule: self == oldSelf
               resource:
                 description: |-
-                  Resource specifies the desired state of the resource.
+                  resource specifies the desired state of the resource.
 
-                  Resource may not be specified if the management policy is `unmanaged`.
+                  resource may not be specified if the management policy is `unmanaged`.
 
-                  Resource must be specified if the management policy is `managed`.
+                  resource must be specified if the management policy is `managed`.
                 properties:
                   adminStateUp:
                     type: boolean
@@ -290,11 +290,11 @@ spec:
               rule: 'has(self.managedOptions) ? self.managementPolicy == ''managed''
                 : true'
           status:
-            description: RouterStatus defines the observed state of an ORC resource.
+            description: status defines the observed state of the resource.
             properties:
               conditions:
                 description: |-
-                  Conditions represents the observed status of the object.
+                  conditions represents the observed status of the object.
                   Known .status.conditions.type are: "Available", "Progressing"
 
                   Available represents the availability of the OpenStack resource. If it is
@@ -366,10 +366,10 @@ spec:
                 - type
                 x-kubernetes-list-type: map
               id:
-                description: ID is the unique identifier of the OpenStack resource.
+                description: id is the unique identifier of the OpenStack resource.
                 type: string
               resource:
-                description: Resource contains the observed state of the OpenStack
+                description: resource contains the observed state of the OpenStack
                   resource.
                 properties:
                   adminStateUp:

--- a/config/crd/bases/openstack.k-orc.cloud_securitygroups.yaml
+++ b/config/crd/bases/openstack.k-orc.cloud_securitygroups.yaml
@@ -56,10 +56,10 @@ spec:
           metadata:
             type: object
           spec:
-            description: SecurityGroupSpec defines the desired state of an ORC object.
+            description: spec specifies the desired state of the resource.
             properties:
               cloudCredentialsRef:
-                description: CloudCredentialsRef points to a secret containing OpenStack
+                description: cloudCredentialsRef points to a secret containing OpenStack
                   credentials
                 properties:
                   cloudName:
@@ -82,14 +82,14 @@ spec:
                 type: object
               import:
                 description: |-
-                  Import refers to an existing OpenStack resource which will be imported instead of
+                  import refers to an existing OpenStack resource which will be imported instead of
                   creating a new one.
                 maxProperties: 1
                 minProperties: 1
                 properties:
                   filter:
                     description: |-
-                      Filter contains a resource query which is expected to return a single
+                      filter contains a resource query which is expected to return a single
                       result. The controller will continue to retry if filter returns no
                       results. If filter returns multiple results the controller will set an
                       error state and will not continue to retry.
@@ -171,14 +171,14 @@ spec:
                     type: object
                   id:
                     description: |-
-                      ID contains the unique identifier of an existing OpenStack resource. Note
+                      id contains the unique identifier of an existing OpenStack resource. Note
                       that when specifying an import by ID, the resource MUST already exist.
                       The ORC object will enter an error state if the resource does not exist.
                     format: uuid
                     type: string
                 type: object
               managedOptions:
-                description: ManagedOptions specifies options which may be applied
+                description: managedOptions specifies options which may be applied
                   to managed objects.
                 properties:
                   onDelete:
@@ -196,7 +196,7 @@ spec:
               managementPolicy:
                 default: managed
                 description: |-
-                  ManagementPolicy defines how ORC will treat the object. Valid values are
+                  managementPolicy defines how ORC will treat the object. Valid values are
                   `managed`: ORC will create, update, and delete the resource; `unmanaged`:
                   ORC will import an existing resource, and will not apply updates to it or
                   delete it.
@@ -209,11 +209,11 @@ spec:
                   rule: self == oldSelf
               resource:
                 description: |-
-                  Resource specifies the desired state of the resource.
+                  resource specifies the desired state of the resource.
 
-                  Resource may not be specified if the management policy is `unmanaged`.
+                  resource may not be specified if the management policy is `unmanaged`.
 
-                  Resource must be specified if the management policy is `managed`.
+                  resource must be specified if the management policy is `managed`.
                 properties:
                   description:
                     maxLength: 1024
@@ -384,12 +384,11 @@ spec:
               rule: 'has(self.managedOptions) ? self.managementPolicy == ''managed''
                 : true'
           status:
-            description: SecurityGroupStatus defines the observed state of an ORC
-              resource.
+            description: status defines the observed state of the resource.
             properties:
               conditions:
                 description: |-
-                  Conditions represents the observed status of the object.
+                  conditions represents the observed status of the object.
                   Known .status.conditions.type are: "Available", "Progressing"
 
                   Available represents the availability of the OpenStack resource. If it is
@@ -461,10 +460,10 @@ spec:
                 - type
                 x-kubernetes-list-type: map
               id:
-                description: ID is the unique identifier of the OpenStack resource.
+                description: id is the unique identifier of the OpenStack resource.
                 type: string
               resource:
-                description: Resource contains the observed state of the OpenStack
+                description: resource contains the observed state of the OpenStack
                   resource.
                 properties:
                   createdAt:

--- a/config/crd/bases/openstack.k-orc.cloud_servers.yaml
+++ b/config/crd/bases/openstack.k-orc.cloud_servers.yaml
@@ -56,10 +56,10 @@ spec:
           metadata:
             type: object
           spec:
-            description: ServerSpec defines the desired state of an ORC object.
+            description: spec specifies the desired state of the resource.
             properties:
               cloudCredentialsRef:
-                description: CloudCredentialsRef points to a secret containing OpenStack
+                description: cloudCredentialsRef points to a secret containing OpenStack
                   credentials
                 properties:
                   cloudName:
@@ -82,14 +82,14 @@ spec:
                 type: object
               import:
                 description: |-
-                  Import refers to an existing OpenStack resource which will be imported instead of
+                  import refers to an existing OpenStack resource which will be imported instead of
                   creating a new one.
                 maxProperties: 1
                 minProperties: 1
                 properties:
                   filter:
                     description: |-
-                      Filter contains a resource query which is expected to return a single
+                      filter contains a resource query which is expected to return a single
                       result. The controller will continue to retry if filter returns no
                       results. If filter returns multiple results the controller will set an
                       error state and will not continue to retry.
@@ -103,14 +103,14 @@ spec:
                     type: object
                   id:
                     description: |-
-                      ID contains the unique identifier of an existing OpenStack resource. Note
+                      id contains the unique identifier of an existing OpenStack resource. Note
                       that when specifying an import by ID, the resource MUST already exist.
                       The ORC object will enter an error state if the resource does not exist.
                     format: uuid
                     type: string
                 type: object
               managedOptions:
-                description: ManagedOptions specifies options which may be applied
+                description: managedOptions specifies options which may be applied
                   to managed objects.
                 properties:
                   onDelete:
@@ -128,7 +128,7 @@ spec:
               managementPolicy:
                 default: managed
                 description: |-
-                  ManagementPolicy defines how ORC will treat the object. Valid values are
+                  managementPolicy defines how ORC will treat the object. Valid values are
                   `managed`: ORC will create, update, and delete the resource; `unmanaged`:
                   ORC will import an existing resource, and will not apply updates to it or
                   delete it.
@@ -141,11 +141,11 @@ spec:
                   rule: self == oldSelf
               resource:
                 description: |-
-                  Resource specifies the desired state of the resource.
+                  resource specifies the desired state of the resource.
 
-                  Resource may not be specified if the management policy is `unmanaged`.
+                  resource may not be specified if the management policy is `unmanaged`.
 
-                  Resource must be specified if the management policy is `managed`.
+                  resource must be specified if the management policy is `managed`.
                 properties:
                   flavorRef:
                     maxLength: 253
@@ -218,11 +218,11 @@ spec:
               rule: 'has(self.managedOptions) ? self.managementPolicy == ''managed''
                 : true'
           status:
-            description: ServerStatus defines the observed state of an ORC resource.
+            description: status defines the observed state of the resource.
             properties:
               conditions:
                 description: |-
-                  Conditions represents the observed status of the object.
+                  conditions represents the observed status of the object.
                   Known .status.conditions.type are: "Available", "Progressing"
 
                   Available represents the availability of the OpenStack resource. If it is
@@ -294,10 +294,10 @@ spec:
                 - type
                 x-kubernetes-list-type: map
               id:
-                description: ID is the unique identifier of the OpenStack resource.
+                description: id is the unique identifier of the OpenStack resource.
                 type: string
               resource:
-                description: Resource contains the observed state of the OpenStack
+                description: resource contains the observed state of the OpenStack
                   resource.
                 properties:
                   accessIPv4:

--- a/config/crd/bases/openstack.k-orc.cloud_subnets.yaml
+++ b/config/crd/bases/openstack.k-orc.cloud_subnets.yaml
@@ -56,10 +56,10 @@ spec:
           metadata:
             type: object
           spec:
-            description: SubnetSpec defines the desired state of an ORC object.
+            description: spec specifies the desired state of the resource.
             properties:
               cloudCredentialsRef:
-                description: CloudCredentialsRef points to a secret containing OpenStack
+                description: cloudCredentialsRef points to a secret containing OpenStack
                   credentials
                 properties:
                   cloudName:
@@ -82,14 +82,14 @@ spec:
                 type: object
               import:
                 description: |-
-                  Import refers to an existing OpenStack resource which will be imported instead of
+                  import refers to an existing OpenStack resource which will be imported instead of
                   creating a new one.
                 maxProperties: 1
                 minProperties: 1
                 properties:
                   filter:
                     description: |-
-                      Filter contains a resource query which is expected to return a single
+                      filter contains a resource query which is expected to return a single
                       result. The controller will continue to retry if filter returns no
                       results. If filter returns multiple results the controller will set an
                       error state and will not continue to retry.
@@ -202,14 +202,14 @@ spec:
                     type: object
                   id:
                     description: |-
-                      ID contains the unique identifier of an existing OpenStack resource. Note
+                      id contains the unique identifier of an existing OpenStack resource. Note
                       that when specifying an import by ID, the resource MUST already exist.
                       The ORC object will enter an error state if the resource does not exist.
                     format: uuid
                     type: string
                 type: object
               managedOptions:
-                description: ManagedOptions specifies options which may be applied
+                description: managedOptions specifies options which may be applied
                   to managed objects.
                 properties:
                   onDelete:
@@ -227,7 +227,7 @@ spec:
               managementPolicy:
                 default: managed
                 description: |-
-                  ManagementPolicy defines how ORC will treat the object. Valid values are
+                  managementPolicy defines how ORC will treat the object. Valid values are
                   `managed`: ORC will create, update, and delete the resource; `unmanaged`:
                   ORC will import an existing resource, and will not apply updates to it or
                   delete it.
@@ -246,11 +246,11 @@ spec:
                 type: string
               resource:
                 description: |-
-                  Resource specifies the desired state of the resource.
+                  resource specifies the desired state of the resource.
 
-                  Resource may not be specified if the management policy is `unmanaged`.
+                  resource may not be specified if the management policy is `unmanaged`.
 
-                  Resource must be specified if the management policy is `managed`.
+                  resource must be specified if the management policy is `managed`.
                 properties:
                   allocationPools:
                     description: |-
@@ -439,11 +439,11 @@ spec:
               rule: 'has(self.managedOptions) ? self.managementPolicy == ''managed''
                 : true'
           status:
-            description: SubnetStatus defines the observed state of an ORC resource.
+            description: status defines the observed state of the resource.
             properties:
               conditions:
                 description: |-
-                  Conditions represents the observed status of the object.
+                  conditions represents the observed status of the object.
                   Known .status.conditions.type are: "Available", "Progressing"
 
                   Available represents the availability of the OpenStack resource. If it is
@@ -515,10 +515,10 @@ spec:
                 - type
                 x-kubernetes-list-type: map
               id:
-                description: ID is the unique identifier of the OpenStack resource.
+                description: id is the unique identifier of the OpenStack resource.
                 type: string
               resource:
-                description: Resource contains the observed state of the OpenStack
+                description: resource contains the observed state of the OpenStack
                   resource.
                 properties:
                   allocationPools:


### PR DESCRIPTION
Mainly add necessary godoc where missing and change the first word to be the json tag it's describing.

This fixes all offenses found by KAL in generated API. We'll handle the rest as we do a overall review of the API.