### PR TITLE
Fix build and run targets

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -108,11 +108,11 @@ lint-fix: golangci-lint ## Run golangci-lint linter and perform fixes
 
 .PHONY: build
 build: manifests generate fmt vet ## Build manager binary.
-	go build -o bin/manager cmd/main.go
+	go build -o bin/manager cmd/manager/main.go
 
 .PHONY: run
 run: manifests generate fmt vet ## Run a controller from your host.
-	go run ./cmd/main.go
+	go run ./cmd/manager/main.go
 
 # If you wish to build the manager image targeting other platforms you can use the --platform flag.
 # (i.e. docker build --platform linux/arm64). However, you must enable docker buildKit for it.


### PR DESCRIPTION
We forgot to update the `build` and `run` targets after 690b760f49dfb61b173755e91cb51ed42472c7f3.