### PR TITLE
e2e test with kuttl

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -33,3 +33,6 @@ __pycache__/
 /openapi.json
 /.custom-deploy
 /.custom-gcl.yml
+
+# kuttl generates a kubeconfig
+/kubeconfig

--- a/Makefile
+++ b/Makefile
@@ -92,7 +92,7 @@ test: envtest
 
 # Utilize Kind or modify the e2e tests to load the image locally, enabling compatibility with other vendors.
 .PHONY: test-e2e  # Run the e2e tests against a Kind k8s instance that is spun up.
-test-e2e:
+test-e2e: kuttl
 	# go test ./test/e2e/ -v -ginkgo.v
 	./hack/e2e.sh
 

--- a/Makefile
+++ b/Makefile
@@ -216,6 +216,7 @@ ENVTEST ?= $(LOCALBIN)/setup-envtest
 GOLANGCI_LINT = $(LOCALBIN)/golangci-lint
 GOLANGCI_KAL = $(LOCALBIN)/golangci-kal
 MOCKGEN = $(LOCALBIN)/mockgen
+KUTTL = $(LOCALBIN)/kubectl-kuttl
 
 ## Tool Versions
 KUSTOMIZE_VERSION ?= v5.4.2
@@ -224,6 +225,7 @@ ENVTEST_VERSION ?= release-0.19
 GOLANGCI_LINT_VERSION ?= v1.63.4
 KAL_VERSION ?= v0.0.0-20250120175744-495588b8c987
 MOCKGEN_VERSION ?= v0.4.0
+KUTTL_VERSION ?= v0.20.0
 
 .PHONY: kustomize
 kustomize: $(KUSTOMIZE) ## Download kustomize locally if necessary.
@@ -267,6 +269,11 @@ $(GOLANGCI_KAL): $(LOCALBIN) $(GOLANGCI_LINT)
 mockgen: $(MOCKGEN) ## Download mockgen locally if necessary.
 $(MOCKGEN): $(LOCALBIN)
 	$(call go-install-tool,$(MOCKGEN),go.uber.org/mock/mockgen,$(MOCKGEN_VERSION))
+
+.PHONY: kuttl
+kuttl: $(KUTTL) ## Download kuttl locally if necessary.
+$(KUTTL): $(LOCALBIN)
+	$(call go-install-tool,$(KUTTL),github.com/kudobuilder/kuttl/cmd/kubectl-kuttl,$(KUTTL_VERSION))
 
 # go-install-tool will 'go install' any package with custom target and name of binary, if it doesn't exist
 # $1 - target path with name of binary

--- a/hack/e2e.sh
+++ b/hack/e2e.sh
@@ -2,6 +2,8 @@
 
 set -euo pipefail
 
+kubectl kuttl test
+
 # HACK: Update the devstack default provider network name to match the one
 # hardcoded in the cirros example
 export OS_CLOUD=devstack-admin

--- a/internal/controllers/flavor/tests/create-full/00-assert.yaml
+++ b/internal/controllers/flavor/tests/create-full/00-assert.yaml
@@ -1,0 +1,15 @@
+---
+apiVersion: openstack.k-orc.cloud/v1alpha1
+kind: Flavor
+metadata:
+  name: create-full
+status:
+  resource:
+    name: create-full-override
+    description: Flavor from "create full" test
+    ram: 8
+    vcpus: 4
+    disk: 20
+    swap: 2
+    isPublic: false
+    ephemeral: 1

--- a/internal/controllers/flavor/tests/create-full/00-flavor.yaml
+++ b/internal/controllers/flavor/tests/create-full/00-flavor.yaml
@@ -1,0 +1,19 @@
+---
+apiVersion: openstack.k-orc.cloud/v1alpha1
+kind: Flavor
+metadata:
+  name: create-full
+spec:
+  cloudCredentialsRef:
+    cloudName: devstack-admin-demo
+    secretName: openstack-clouds
+  managementPolicy: managed
+  resource:
+    name: create-full-override
+    description: Flavor from "create full" test
+    ram: 8
+    vcpus: 4
+    disk: 20
+    swap: 2
+    isPublic: false
+    ephemeral: 1

--- a/internal/controllers/flavor/tests/create-full/00-secret.yaml
+++ b/internal/controllers/flavor/tests/create-full/00-secret.yaml
@@ -1,0 +1,5 @@
+apiVersion: kuttl.dev/v1beta1
+kind: TestStep
+commands:
+  - command: kubectl create secret generic openstack-clouds --from-file=clouds.yaml=/etc/openstack/clouds.yaml
+    namespaced: true

--- a/internal/controllers/flavor/tests/create-full/01-assert.yaml
+++ b/internal/controllers/flavor/tests/create-full/01-assert.yaml
@@ -1,0 +1,5 @@
+apiVersion: kuttl.dev/v1beta1
+kind: TestAssert
+commands:
+- script: "! kubectl get flavor create-full --namespace $NAMESPACE"
+  skipLogOutput: true

--- a/internal/controllers/flavor/tests/create-full/01-cleanup.yaml
+++ b/internal/controllers/flavor/tests/create-full/01-cleanup.yaml
@@ -1,0 +1,6 @@
+apiVersion: kuttl.dev/v1beta1
+kind: TestStep
+delete:
+- apiVersion: openstack.k-orc.cloud/v1alpha1
+  kind: Flavor
+  name: create-full

--- a/internal/controllers/flavor/tests/create-full/README.md
+++ b/internal/controllers/flavor/tests/create-full/README.md
@@ -1,0 +1,7 @@
+# Create a flavor with all the options
+
+## Step 00
+
+Create a flavor using all available fields, and verify that the observed state corresponds to the spec.
+
+Also validate that the OpenStack resource uses the name from the spec when it is specified.

--- a/internal/controllers/flavor/tests/create-full/README.md
+++ b/internal/controllers/flavor/tests/create-full/README.md
@@ -5,3 +5,8 @@
 Create a flavor using all available fields, and verify that the observed state corresponds to the spec.
 
 Also validate that the OpenStack resource uses the name from the spec when it is specified.
+
+## Step 01
+
+Validate we're able to delete resources.
+Cleaning up resources also avoids a race where kuttl could delete the secret before the other resources.

--- a/internal/controllers/flavor/tests/create-minimal/00-assert.yaml
+++ b/internal/controllers/flavor/tests/create-minimal/00-assert.yaml
@@ -1,0 +1,15 @@
+---
+apiVersion: openstack.k-orc.cloud/v1alpha1
+kind: Flavor
+metadata:
+  name: create-minimal
+status:
+  resource:
+    name: create-minimal
+    description: ""
+    ram: 1
+    vcpus: 2
+    disk: 0
+    swap: 0
+    isPublic: true
+    ephemeral: 0

--- a/internal/controllers/flavor/tests/create-minimal/00-flavor.yaml
+++ b/internal/controllers/flavor/tests/create-minimal/00-flavor.yaml
@@ -1,0 +1,14 @@
+---
+apiVersion: openstack.k-orc.cloud/v1alpha1
+kind: Flavor
+metadata:
+  name: create-minimal
+spec:
+  cloudCredentialsRef:
+    cloudName: devstack-admin-demo
+    secretName: openstack-clouds
+  managementPolicy: managed
+  resource:
+    ram: 1
+    vcpus: 2
+    disk: 0

--- a/internal/controllers/flavor/tests/create-minimal/00-secret.yaml
+++ b/internal/controllers/flavor/tests/create-minimal/00-secret.yaml
@@ -1,0 +1,5 @@
+apiVersion: kuttl.dev/v1beta1
+kind: TestStep
+commands:
+  - command: kubectl create secret generic openstack-clouds --from-file=clouds.yaml=/etc/openstack/clouds.yaml
+    namespaced: true

--- a/internal/controllers/flavor/tests/create-minimal/01-assert.yaml
+++ b/internal/controllers/flavor/tests/create-minimal/01-assert.yaml
@@ -1,0 +1,5 @@
+apiVersion: kuttl.dev/v1beta1
+kind: TestAssert
+commands:
+- script: "! kubectl get flavor create-minimal --namespace $NAMESPACE"
+  skipLogOutput: true

--- a/internal/controllers/flavor/tests/create-minimal/01-cleanup.yaml
+++ b/internal/controllers/flavor/tests/create-minimal/01-cleanup.yaml
@@ -1,0 +1,6 @@
+apiVersion: kuttl.dev/v1beta1
+kind: TestStep
+delete:
+- apiVersion: openstack.k-orc.cloud/v1alpha1
+  kind: Flavor
+  name: create-minimal

--- a/internal/controllers/flavor/tests/create-minimal/README.md
+++ b/internal/controllers/flavor/tests/create-minimal/README.md
@@ -5,3 +5,8 @@
 Create a minimal flavor, that sets only the required fields, and verify that the observed state corresponds to the spec.
 
 Also validate that the OpenStack resource uses the name of the ORC object when it is not specified.
+
+## Step 01
+
+Validate we're able to delete resources.
+Cleaning up resources also avoids a race where kuttl could delete the secret before the other resources.

--- a/internal/controllers/flavor/tests/create-minimal/README.md
+++ b/internal/controllers/flavor/tests/create-minimal/README.md
@@ -1,0 +1,7 @@
+# Create a flavor with the minimum options
+
+## Step 00
+
+Create a minimal flavor, that sets only the required fields, and verify that the observed state corresponds to the spec.
+
+Also validate that the OpenStack resource uses the name of the ORC object when it is not specified.

--- a/internal/controllers/flavor/tests/import-error/00-assert.yaml
+++ b/internal/controllers/flavor/tests/import-error/00-assert.yaml
@@ -1,0 +1,30 @@
+---
+apiVersion: openstack.k-orc.cloud/v1alpha1
+kind: Flavor
+metadata:
+  name: import-error-external-1
+status:
+  conditions:
+    - type: Available
+      message: OpenStack resource is available
+      status: "True"
+      reason: Success
+    - type: Progressing
+      message: OpenStack resource is up to date
+      status: "False"
+      reason: Success
+---
+apiVersion: openstack.k-orc.cloud/v1alpha1
+kind: Flavor
+metadata:
+  name: import-error-external-2
+status:
+  conditions:
+    - type: Available
+      message: OpenStack resource is available
+      status: "True"
+      reason: Success
+    - type: Progressing
+      message: OpenStack resource is up to date
+      status: "False"
+      reason: Success

--- a/internal/controllers/flavor/tests/import-error/00-create-flavors.yaml
+++ b/internal/controllers/flavor/tests/import-error/00-create-flavors.yaml
@@ -1,0 +1,32 @@
+---
+apiVersion: openstack.k-orc.cloud/v1alpha1
+kind: Flavor
+metadata:
+  name: import-error-external-1
+spec:
+  cloudCredentialsRef:
+    cloudName: devstack-admin-demo
+    secretName: openstack-clouds
+  managementPolicy: managed
+  resource:
+    name: import-error-external-1
+    ram: 22
+    vcpus: 23
+    disk: 24
+---
+apiVersion: openstack.k-orc.cloud/v1alpha1
+kind: Flavor
+metadata:
+  name: import-error-external-2
+spec:
+  cloudCredentialsRef:
+    cloudName: devstack-admin-demo
+    secretName: openstack-clouds
+  managementPolicy: managed
+  resource:
+    # FIXME: name shouldn't be necessary
+    # https://github.com/k-orc/openstack-resource-controller/issues/185
+    name: import-error-external-2
+    ram: 22
+    vcpus: 23
+    disk: 24

--- a/internal/controllers/flavor/tests/import-error/00-secret.yaml
+++ b/internal/controllers/flavor/tests/import-error/00-secret.yaml
@@ -1,0 +1,5 @@
+apiVersion: kuttl.dev/v1beta1
+kind: TestStep
+commands:
+  - command: kubectl create secret generic openstack-clouds --from-file=clouds.yaml=/etc/openstack/clouds.yaml
+    namespaced: true

--- a/internal/controllers/flavor/tests/import-error/01-assert.yaml
+++ b/internal/controllers/flavor/tests/import-error/01-assert.yaml
@@ -1,0 +1,17 @@
+---
+apiVersion: openstack.k-orc.cloud/v1alpha1
+kind: Flavor
+metadata:
+  name: import-error
+status:
+  conditions:
+    - type: Available
+      # FIXME: message is not consistent with other resources
+      # https://github.com/k-orc/openstack-resource-controller/issues/186
+      message: found more than one matching flavor in OpenStack
+      status: "False"
+      reason: InvalidConfiguration
+    - type: Progressing
+      message: found more than one matching flavor in OpenStack
+      status: "False"
+      reason: InvalidConfiguration

--- a/internal/controllers/flavor/tests/import-error/01-import-flavor.yaml
+++ b/internal/controllers/flavor/tests/import-error/01-import-flavor.yaml
@@ -1,0 +1,16 @@
+---
+apiVersion: openstack.k-orc.cloud/v1alpha1
+kind: Flavor
+metadata:
+  name: import-error
+spec:
+  cloudCredentialsRef:
+    # Import does not require admin creds
+    cloudName: devstack
+    secretName: openstack-clouds
+  managementPolicy: unmanaged
+  import:
+    filter:
+      ram: 22
+      vcpus: 23
+      disk: 24

--- a/internal/controllers/flavor/tests/import-error/02-assert.yaml
+++ b/internal/controllers/flavor/tests/import-error/02-assert.yaml
@@ -1,0 +1,9 @@
+apiVersion: kuttl.dev/v1beta1
+kind: TestAssert
+commands:
+- script: "! kubectl get flavor import-error --namespace $NAMESPACE"
+  skipLogOutput: true
+- script: "! kubectl get flavor import-error-external-1 --namespace $NAMESPACE"
+  skipLogOutput: true
+- script: "! kubectl get flavor import-error-external-2 --namespace $NAMESPACE"
+  skipLogOutput: true

--- a/internal/controllers/flavor/tests/import-error/02-cleanup.yaml
+++ b/internal/controllers/flavor/tests/import-error/02-cleanup.yaml
@@ -1,0 +1,12 @@
+apiVersion: kuttl.dev/v1beta1
+kind: TestStep
+delete:
+- apiVersion: openstack.k-orc.cloud/v1alpha1
+  kind: Flavor
+  name: import-error
+- apiVersion: openstack.k-orc.cloud/v1alpha1
+  kind: Flavor
+  name: import-error-external-1
+- apiVersion: openstack.k-orc.cloud/v1alpha1
+  kind: Flavor
+  name: import-error-external-2

--- a/internal/controllers/flavor/tests/import-error/README.md
+++ b/internal/controllers/flavor/tests/import-error/README.md
@@ -1,0 +1,9 @@
+# Import Flavor with more than one matching resources
+
+## Step 00
+
+Create two flavors with identical specs.
+
+## Step 01
+
+Ensure that an imported flavor with a filter matching the resources returns an error.

--- a/internal/controllers/flavor/tests/import-error/README.md
+++ b/internal/controllers/flavor/tests/import-error/README.md
@@ -7,3 +7,8 @@ Create two flavors with identical specs.
 ## Step 01
 
 Ensure that an imported flavor with a filter matching the resources returns an error.
+
+## Step 02
+
+Validate we're able to delete resources.
+Cleaning up resources also avoids a race where kuttl could delete the secret before the other resources.

--- a/internal/controllers/flavor/tests/import/00-assert.yaml
+++ b/internal/controllers/flavor/tests/import/00-assert.yaml
@@ -1,0 +1,15 @@
+---
+apiVersion: openstack.k-orc.cloud/v1alpha1
+kind: Flavor
+metadata:
+  name: import
+status:
+  conditions:
+    - type: Available
+      message: Waiting for OpenStack resource to be created externally
+      status: "False"
+      reason: Progressing
+    - type: Progressing
+      message: Waiting for OpenStack resource to be created externally
+      status: "True"
+      reason: Progressing

--- a/internal/controllers/flavor/tests/import/00-import-flavor.yaml
+++ b/internal/controllers/flavor/tests/import/00-import-flavor.yaml
@@ -1,0 +1,17 @@
+---
+apiVersion: openstack.k-orc.cloud/v1alpha1
+kind: Flavor
+metadata:
+  name: import
+spec:
+  cloudCredentialsRef:
+    # Import does not require admin creds
+    cloudName: devstack
+    secretName: openstack-clouds
+  managementPolicy: unmanaged
+  import:
+    filter:
+      name: import-external
+      ram: 12
+      vcpus: 13
+      disk: 14

--- a/internal/controllers/flavor/tests/import/00-secret.yaml
+++ b/internal/controllers/flavor/tests/import/00-secret.yaml
@@ -1,0 +1,5 @@
+apiVersion: kuttl.dev/v1beta1
+kind: TestStep
+commands:
+  - command: kubectl create secret generic openstack-clouds --from-file=clouds.yaml=/etc/openstack/clouds.yaml
+    namespaced: true

--- a/internal/controllers/flavor/tests/import/01-assert.yaml
+++ b/internal/controllers/flavor/tests/import/01-assert.yaml
@@ -1,0 +1,24 @@
+---
+apiVersion: openstack.k-orc.cloud/v1alpha1
+kind: Flavor
+metadata:
+  name: import
+status:
+  conditions:
+    - type: Available
+      message: OpenStack resource is available
+      status: "True"
+      reason: Success
+    - type: Progressing
+      message: OpenStack resource is up to date
+      status: "False"
+      reason: Success
+  resource:
+    name: import-external
+    description: ""
+    ram: 12
+    vcpus: 13
+    disk: 14
+    swap: 0
+    isPublic: true
+    ephemeral: 0

--- a/internal/controllers/flavor/tests/import/01-create-flavor.yaml
+++ b/internal/controllers/flavor/tests/import/01-create-flavor.yaml
@@ -1,0 +1,14 @@
+---
+apiVersion: openstack.k-orc.cloud/v1alpha1
+kind: Flavor
+metadata:
+  name: import-external
+spec:
+  cloudCredentialsRef:
+    cloudName: devstack-admin-demo
+    secretName: openstack-clouds
+  managementPolicy: managed
+  resource:
+    ram: 12
+    vcpus: 13
+    disk: 14

--- a/internal/controllers/flavor/tests/import/02-assert.yaml
+++ b/internal/controllers/flavor/tests/import/02-assert.yaml
@@ -1,0 +1,7 @@
+apiVersion: kuttl.dev/v1beta1
+kind: TestAssert
+commands:
+- script: "! kubectl get flavor import --namespace $NAMESPACE"
+  skipLogOutput: true
+- script: "! kubectl get flavor import-external --namespace $NAMESPACE"
+  skipLogOutput: true

--- a/internal/controllers/flavor/tests/import/02-cleanup.yaml
+++ b/internal/controllers/flavor/tests/import/02-cleanup.yaml
@@ -1,0 +1,9 @@
+apiVersion: kuttl.dev/v1beta1
+kind: TestStep
+delete:
+- apiVersion: openstack.k-orc.cloud/v1alpha1
+  kind: Flavor
+  name: import
+- apiVersion: openstack.k-orc.cloud/v1alpha1
+  kind: Flavor
+  name: import-external

--- a/internal/controllers/flavor/tests/import/README.md
+++ b/internal/controllers/flavor/tests/import/README.md
@@ -1,0 +1,13 @@
+# Import Flavor
+
+## Step 00
+
+Import a flavor using non-admin credentials, matching all of the available filter's fields, and verify it is waiting for the external resource to be created.
+
+## Step 01
+
+Create a flavor matching the filter and verify that the observed status on the imported flavor corresponds to the spec of the created flavor.
+
+## TODO
+
+Possibly check that adding a new flavor matching the import filter does not cause issues after it successfully imported the first one.

--- a/internal/controllers/flavor/tests/import/README.md
+++ b/internal/controllers/flavor/tests/import/README.md
@@ -8,6 +8,11 @@ Import a flavor using non-admin credentials, matching all of the available filte
 
 Create a flavor matching the filter and verify that the observed status on the imported flavor corresponds to the spec of the created flavor.
 
+## Step 02
+
+Validate we're able to delete resources.
+Cleaning up resources also avoids a race where kuttl could delete the secret before the other resources.
+
 ## TODO
 
 Possibly check that adding a new flavor matching the import filter does not cause issues after it successfully imported the first one.

--- a/internal/controllers/subnet/tests/create-full-v4/00-assert.yaml
+++ b/internal/controllers/subnet/tests/create-full-v4/00-assert.yaml
@@ -1,0 +1,38 @@
+---
+apiVersion: openstack.k-orc.cloud/v1alpha1
+kind: Subnet
+metadata:
+  name: create-full-v4
+status:
+  resource:
+    name: create-full-v4-override
+    description: Subnet from "create full v4" test
+    tags:
+      - tag1
+      - tag2
+    ipVersion: 4
+    cidr: 192.168.1.0/24
+    allocationPools:
+      - start: 192.168.1.10
+        end: 192.168.1.15
+      # NOTE: kuttl frequently complains about the items order. Is it a bug?
+      # - start: 192.168.1.20
+      #   end: 192.168.1.25
+    enableDHCP: false
+    # FIXME: we should not have a gateway
+    # https://github.com/k-orc/openstack-resource-controller/issues/190
+    gatewayIP: 192.168.1.1
+    enableDHCP: false
+    dnsNameservers:
+      - 1.1.1.1
+      - 8.8.8.8
+    # FIXME: dnsPublishFixedIP is not honored
+    # https://github.com/k-orc/openstack-resource-controller/issues/189
+    dnsPublishFixedIP: false
+    hostRoutes:
+      - destination: 192.168.3.0/24
+        nextHop: 192.168.4.1
+      - destination: 192.168.5.0/24
+        nextHop: 192.168.6.1
+    ipv6AddressMode: ""
+    ipv6RAMode: ""

--- a/internal/controllers/subnet/tests/create-full-v4/00-assert.yaml
+++ b/internal/controllers/subnet/tests/create-full-v4/00-assert.yaml
@@ -36,3 +36,22 @@ status:
         nextHop: 192.168.6.1
     ipv6AddressMode: ""
     ipv6RAMode: ""
+---
+apiVersion: openstack.k-orc.cloud/v1alpha1
+kind: RouterInterface
+metadata:
+  name: create-full-v4-subnet
+spec:
+  routerRef: create-full-v4
+  subnetRef: create-full-v4
+  type: Subnet
+status:
+  conditions:
+    - type: Available
+      message: OpenStack resource is available
+      status: "True"
+      reason: Success
+    - type: Progressing
+      message: OpenStack resource is up to date
+      status: "False"
+      reason: Success

--- a/internal/controllers/subnet/tests/create-full-v4/00-secret.yaml
+++ b/internal/controllers/subnet/tests/create-full-v4/00-secret.yaml
@@ -1,0 +1,5 @@
+apiVersion: kuttl.dev/v1beta1
+kind: TestStep
+commands:
+  - command: kubectl create secret generic openstack-clouds --from-file=clouds.yaml=/etc/openstack/clouds.yaml
+    namespaced: true

--- a/internal/controllers/subnet/tests/create-full-v4/00-subnet.yaml
+++ b/internal/controllers/subnet/tests/create-full-v4/00-subnet.yaml
@@ -1,0 +1,50 @@
+apiVersion: openstack.k-orc.cloud/v1alpha1
+kind: Network
+metadata:
+  name: create-full-v4
+spec:
+  cloudCredentialsRef:
+    cloudName: devstack
+    secretName: openstack-clouds
+  managementPolicy: managed
+  resource:
+    # FIXME: just having the name causes a panic
+    # https://github.com/k-orc/openstack-resource-controller/issues/187
+    description: create-full-v4
+---
+apiVersion: openstack.k-orc.cloud/v1alpha1
+kind: Subnet
+metadata:
+  name: create-full-v4
+spec:
+  cloudCredentialsRef:
+    cloudName: devstack
+    secretName: openstack-clouds
+  managementPolicy: managed
+  networkRef: create-full-v4
+  resource:
+    name: create-full-v4-override
+    description: Subnet from "create full v4" test
+    tags:
+      - tag1
+      - tag2
+    ipVersion: 4
+    cidr: 192.168.1.0/24
+    allocationPools:
+      - start: 192.168.1.10
+        end: 192.168.1.15
+      # NOTE: it works to add more than one allocation pool, but we fail to
+      # reliably validate it with kuttl
+      # - start: 192.168.1.20
+      #   end: 192.168.1.25
+    gateway:
+    enableDHCP: false
+    dnsNameservers:
+      - 1.1.1.1
+      - 8.8.8.8
+    dnsPublishFixedIP: true
+    hostRoutes:
+      - destination: 192.168.3.0/24
+        nextHop: 192.168.4.1
+      - destination: 192.168.5.0/24
+        nextHop: 192.168.6.1

--- a/internal/controllers/subnet/tests/create-full-v4/00-subnet.yaml
+++ b/internal/controllers/subnet/tests/create-full-v4/00-subnet.yaml
@@ -13,6 +13,48 @@ spec:
     description: create-full-v4
 ---
 apiVersion: openstack.k-orc.cloud/v1alpha1
+kind: Network
+metadata:
+  name: create-full-v4-gateway
+spec:
+  cloudCredentialsRef:
+    cloudName: devstack-admin-demo
+    secretName: openstack-clouds
+  managementPolicy: managed
+  resource:
+    # FIXME: just having the name causes a panic
+    # https://github.com/k-orc/openstack-resource-controller/issues/187
+    description: create-full-v4-gateway
+    external: true
+---
+apiVersion: openstack.k-orc.cloud/v1alpha1
+kind: Subnet
+metadata:
+  name: create-full-v4-gateway
+spec:
+  cloudCredentialsRef:
+    cloudName: devstack
+    secretName: openstack-clouds
+  managementPolicy: managed
+  networkRef: create-full-v4-gateway
+  resource:
+    ipVersion: 4
+    cidr: 192.168.200.0/24
+---
+apiVersion: openstack.k-orc.cloud/v1alpha1
+kind: Router
+metadata:
+  name: create-full-v4
+spec:
+  cloudCredentialsRef:
+    cloudName: devstack
+    secretName: openstack-clouds
+  managementPolicy: managed
+  resource:
+    externalGateways:
+    - networkRef: create-full-v4-gateway
+---
+apiVersion: openstack.k-orc.cloud/v1alpha1
 kind: Subnet
 metadata:
   name: create-full-v4
@@ -48,3 +90,4 @@ spec:
         nextHop: 192.168.4.1
       - destination: 192.168.5.0/24
         nextHop: 192.168.6.1
+    routerRef: create-full-v4

--- a/internal/controllers/subnet/tests/create-full-v4/01-assert.yaml
+++ b/internal/controllers/subnet/tests/create-full-v4/01-assert.yaml
@@ -1,0 +1,7 @@
+apiVersion: kuttl.dev/v1beta1
+kind: TestAssert
+commands:
+- script: "! kubectl get subnet create-full-v4 --namespace $NAMESPACE"
+  skipLogOutput: true
+- script: "! kubectl get network create-full-v4 --namespace $NAMESPACE"
+  skipLogOutput: true

--- a/internal/controllers/subnet/tests/create-full-v4/01-assert.yaml
+++ b/internal/controllers/subnet/tests/create-full-v4/01-assert.yaml
@@ -1,7 +1,15 @@
 apiVersion: kuttl.dev/v1beta1
 kind: TestAssert
 commands:
+- script: "! kubectl get router create-full-v4 --namespace $NAMESPACE"
+  skipLogOutput: true
+- script: "! kubectl get routerinterface create-full-v4-subnet --namespace $NAMESPACE"
+  skipLogOutput: true
 - script: "! kubectl get subnet create-full-v4 --namespace $NAMESPACE"
   skipLogOutput: true
+- script: "! kubectl get subnet create-full-v4-gateway --namespace $NAMESPACE"
+  skipLogOutput: true
 - script: "! kubectl get network create-full-v4 --namespace $NAMESPACE"
+  skipLogOutput: true
+- script: "! kubectl get network create-full-v4-gateway --namespace $NAMESPACE"
   skipLogOutput: true

--- a/internal/controllers/subnet/tests/create-full-v4/01-cleanup.yaml
+++ b/internal/controllers/subnet/tests/create-full-v4/01-cleanup.yaml
@@ -1,0 +1,9 @@
+apiVersion: kuttl.dev/v1beta1
+kind: TestStep
+delete:
+- apiVersion: openstack.k-orc.cloud/v1alpha1
+  kind: Subnet
+  name: create-full-v4
+- apiVersion: openstack.k-orc.cloud/v1alpha1
+  kind: Network
+  name: create-full-v4

--- a/internal/controllers/subnet/tests/create-full-v4/01-cleanup.yaml
+++ b/internal/controllers/subnet/tests/create-full-v4/01-cleanup.yaml
@@ -2,8 +2,17 @@ apiVersion: kuttl.dev/v1beta1
 kind: TestStep
 delete:
 - apiVersion: openstack.k-orc.cloud/v1alpha1
+  kind: Router
+  name: create-full-v4
+- apiVersion: openstack.k-orc.cloud/v1alpha1
   kind: Subnet
   name: create-full-v4
 - apiVersion: openstack.k-orc.cloud/v1alpha1
+  kind: Subnet
+  name: create-full-v4-gateway
+- apiVersion: openstack.k-orc.cloud/v1alpha1
   kind: Network
   name: create-full-v4
+- apiVersion: openstack.k-orc.cloud/v1alpha1
+  kind: Network
+  name: create-full-v4-gateway

--- a/internal/controllers/subnet/tests/create-full-v4/README.md
+++ b/internal/controllers/subnet/tests/create-full-v4/README.md
@@ -10,7 +10,3 @@ Also validate that the OpenStack resource uses the name from the spec when it is
 
 Validate we're able to delete resources.
 Cleaning up resources also avoids a race where kuttl could delete the secret before the other resources.
-
-## TODO
-
-- Validate `routerRef`

--- a/internal/controllers/subnet/tests/create-full-v4/README.md
+++ b/internal/controllers/subnet/tests/create-full-v4/README.md
@@ -1,0 +1,16 @@
+# Create an IPv4 subnet with all the options
+
+## Step 00
+
+Create a subnet using all available fields, and verify that the observed state corresponds to the spec.
+
+Also validate that the OpenStack resource uses the name from the spec when it is specified.
+
+## Step 01
+
+Validate we're able to delete resources.
+Cleaning up resources also avoids a race where kuttl could delete the secret before the other resources.
+
+## TODO
+
+- Validate `routerRef`

--- a/internal/controllers/subnet/tests/create-full-v6/00-assert.yaml
+++ b/internal/controllers/subnet/tests/create-full-v6/00-assert.yaml
@@ -36,3 +36,22 @@ status:
     enableDHCP: true
     ipv6AddressMode: slaac
     ipv6RAMode: slaac
+---
+apiVersion: openstack.k-orc.cloud/v1alpha1
+kind: RouterInterface
+metadata:
+  name: create-full-v6-subnet
+spec:
+  routerRef: create-full-v6
+  subnetRef: create-full-v6
+  type: Subnet
+status:
+  conditions:
+    - type: Available
+      message: OpenStack resource is available
+      status: "True"
+      reason: Success
+    - type: Progressing
+      message: OpenStack resource is up to date
+      status: "False"
+      reason: Success

--- a/internal/controllers/subnet/tests/create-full-v6/00-assert.yaml
+++ b/internal/controllers/subnet/tests/create-full-v6/00-assert.yaml
@@ -1,0 +1,38 @@
+---
+apiVersion: openstack.k-orc.cloud/v1alpha1
+kind: Subnet
+metadata:
+  name: create-full-v6
+status:
+  resource:
+    name: create-full-v6-override
+    description: Subnet from "create full v6" test
+    tags:
+      - tag1
+      - tag2
+    ipVersion: 6
+    cidr: fc00:2::/64
+    allocationPools:
+      - start: "fc00:2:0:0:1::"
+        end: "fc00:2::1:ffff:ffff:ffff"
+      # NOTE: kuttl frequently complains about the items order. Is it a bug?
+      # - start: "fc00:2:0:0:2::"
+      #   end: "fc00:2::2:ffff:ffff:ffff"
+    enableDHCP: false
+    # FIXME: we should not have a gateway
+    # https://github.com/k-orc/openstack-resource-controller/issues/190
+    gatewayIP: "fc00:2::"
+    dnsNameservers:
+      - 2606:4700:4700::1111
+      - 2001:4860:4860::8888
+    # FIXME: dnsPublishFixedIP is not honored
+    # https://github.com/k-orc/openstack-resource-controller/issues/189
+    dnsPublishFixedIP: false
+    hostRoutes:
+      - destination: fc00:3::/64
+        nextHop: "fc00:4::1"
+      - destination: fc00:5::/64
+        nextHop: "fc00:6::1"
+    enableDHCP: true
+    ipv6AddressMode: slaac
+    ipv6RAMode: slaac

--- a/internal/controllers/subnet/tests/create-full-v6/00-secret.yaml
+++ b/internal/controllers/subnet/tests/create-full-v6/00-secret.yaml
@@ -1,0 +1,5 @@
+apiVersion: kuttl.dev/v1beta1
+kind: TestStep
+commands:
+  - command: kubectl create secret generic openstack-clouds --from-file=clouds.yaml=/etc/openstack/clouds.yaml
+    namespaced: true

--- a/internal/controllers/subnet/tests/create-full-v6/00-subnet.yaml
+++ b/internal/controllers/subnet/tests/create-full-v6/00-subnet.yaml
@@ -1,0 +1,72 @@
+apiVersion: openstack.k-orc.cloud/v1alpha1
+kind: Network
+metadata:
+  name: create-full-v6
+spec:
+  cloudCredentialsRef:
+    cloudName: devstack-admin-demo
+    secretName: openstack-clouds
+  managementPolicy: managed
+  resource:
+    # FIXME: just having the name causes a panic
+    # https://github.com/k-orc/openstack-resource-controller/issues/187
+    description: create-full-v6
+    external: true
+---
+apiVersion: openstack.k-orc.cloud/v1alpha1
+kind: Router
+metadata:
+  name: create-full-v6
+spec:
+  cloudCredentialsRef:
+    cloudName: devstack
+    secretName: openstack-clouds
+  managementPolicy: managed
+  resource:
+    externalGateways:
+    - networkRef: create-full-v6
+---
+apiVersion: openstack.k-orc.cloud/v1alpha1
+kind: Subnet
+metadata:
+  name: create-full-v6
+spec:
+  cloudCredentialsRef:
+    cloudName: devstack
+    secretName: openstack-clouds
+  managementPolicy: managed
+  networkRef: create-full-v6
+  resource:
+    name: create-full-v6-override
+    description: Subnet from "create full v6" test
+    tags:
+      - tag1
+      - tag2
+    ipVersion: 6
+    cidr: fc00:2::/64
+    allocationPools:
+      - start: "fc00:2:0:0:1::"
+        end: "fc00:2:0:0:1:ffff:ffff:ffff"
+      # NOTE: it works to add more than one allocation pool, but we fail to
+      # reliably validate it with kuttl
+      # - start: "fc00:2:0:0:2::"
+      #   end: "fc00:2:0:0:2:ffff:ffff:ffff"
+    gateway:
+    dnsNameservers:
+      - 2606:4700:4700::1111
+      - 2001:4860:4860::8888
+    dnsPublishFixedIP: true
+    hostRoutes:
+      - destination: fc00:3::/64
+        nextHop: "fc00:4::1"
+      - destination: fc00:5::/64
+        nextHop: "fc00:6::1"
+    # NOTE: enable_dhcp must be enabled for setting ipv6_ra_mode or ipv6_address_mode
+    enableDHCP: true
+    # NOTE: when both ipv6_ra_mode and ipv6_address_mode are set they must be identical
+    ipv6:
+      addressMode: slaac
+      raMode: slaac
+    # FIXME: setting routerRef has no effect
+    # https://github.com/k-orc/openstack-resource-controller/issues/191
+    routerkRef: create-full-v6

--- a/internal/controllers/subnet/tests/create-full-v6/00-subnet.yaml
+++ b/internal/controllers/subnet/tests/create-full-v6/00-subnet.yaml
@@ -4,14 +4,42 @@ metadata:
   name: create-full-v6
 spec:
   cloudCredentialsRef:
-    cloudName: devstack-admin-demo
+    cloudName: devstack
     secretName: openstack-clouds
   managementPolicy: managed
   resource:
     # FIXME: just having the name causes a panic
     # https://github.com/k-orc/openstack-resource-controller/issues/187
     description: create-full-v6
+---
+apiVersion: openstack.k-orc.cloud/v1alpha1
+kind: Network
+metadata:
+  name: create-full-v6-gateway
+spec:
+  cloudCredentialsRef:
+    cloudName: devstack-admin-demo
+    secretName: openstack-clouds
+  managementPolicy: managed
+  resource:
+    # FIXME: just having the name causes a panic
+    # https://github.com/k-orc/openstack-resource-controller/issues/187
+    description: create-full-v6-gateway
     external: true
+---
+apiVersion: openstack.k-orc.cloud/v1alpha1
+kind: Subnet
+metadata:
+  name: create-full-v6-gateway
+spec:
+  cloudCredentialsRef:
+    cloudName: devstack
+    secretName: openstack-clouds
+  managementPolicy: managed
+  networkRef: create-full-v6-gateway
+  resource:
+    ipVersion: 6
+    cidr: fc00:8::/64
 ---
 apiVersion: openstack.k-orc.cloud/v1alpha1
 kind: Router
@@ -24,7 +52,7 @@ spec:
   managementPolicy: managed
   resource:
     externalGateways:
-    - networkRef: create-full-v6
+    - networkRef: create-full-v6-gateway
 ---
 apiVersion: openstack.k-orc.cloud/v1alpha1
 kind: Subnet
@@ -67,6 +95,4 @@ spec:
     ipv6:
       addressMode: slaac
       raMode: slaac
-    # FIXME: setting routerRef has no effect
-    # https://github.com/k-orc/openstack-resource-controller/issues/191
-    routerkRef: create-full-v6
+    routerRef: create-full-v6

--- a/internal/controllers/subnet/tests/create-full-v6/01-assert.yaml
+++ b/internal/controllers/subnet/tests/create-full-v6/01-assert.yaml
@@ -1,0 +1,9 @@
+apiVersion: kuttl.dev/v1beta1
+kind: TestAssert
+commands:
+- script: "! kubectl get subnet create-full-v6 --namespace $NAMESPACE"
+  skipLogOutput: true
+- script: "! kubectl get router create-full-v6 --namespace $NAMESPACE"
+  skipLogOutput: true
+- script: "! kubectl get network create-full-v6 --namespace $NAMESPACE"
+  skipLogOutput: true

--- a/internal/controllers/subnet/tests/create-full-v6/01-assert.yaml
+++ b/internal/controllers/subnet/tests/create-full-v6/01-assert.yaml
@@ -1,9 +1,15 @@
 apiVersion: kuttl.dev/v1beta1
 kind: TestAssert
 commands:
-- script: "! kubectl get subnet create-full-v6 --namespace $NAMESPACE"
-  skipLogOutput: true
 - script: "! kubectl get router create-full-v6 --namespace $NAMESPACE"
   skipLogOutput: true
+- script: "! kubectl get routerinterface create-full-v6-subnet --namespace $NAMESPACE"
+  skipLogOutput: true
+- script: "! kubectl get subnet create-full-v6 --namespace $NAMESPACE"
+  skipLogOutput: true
+- script: "! kubectl get subnet create-full-v6-gateway --namespace $NAMESPACE"
+  skipLogOutput: true
 - script: "! kubectl get network create-full-v6 --namespace $NAMESPACE"
+  skipLogOutput: true
+- script: "! kubectl get network create-full-v6-gateway --namespace $NAMESPACE"
   skipLogOutput: true

--- a/internal/controllers/subnet/tests/create-full-v6/01-cleanup.yaml
+++ b/internal/controllers/subnet/tests/create-full-v6/01-cleanup.yaml
@@ -2,11 +2,17 @@ apiVersion: kuttl.dev/v1beta1
 kind: TestStep
 delete:
 - apiVersion: openstack.k-orc.cloud/v1alpha1
-  kind: Subnet
-  name: create-full-v6
-- apiVersion: openstack.k-orc.cloud/v1alpha1
   kind: Router
   name: create-full-v6
 - apiVersion: openstack.k-orc.cloud/v1alpha1
+  kind: Subnet
+  name: create-full-v6
+- apiVersion: openstack.k-orc.cloud/v1alpha1
+  kind: Subnet
+  name: create-full-v6-gateway
+- apiVersion: openstack.k-orc.cloud/v1alpha1
   kind: Network
   name: create-full-v6
+- apiVersion: openstack.k-orc.cloud/v1alpha1
+  kind: Network
+  name: create-full-v6-gateway

--- a/internal/controllers/subnet/tests/create-full-v6/01-cleanup.yaml
+++ b/internal/controllers/subnet/tests/create-full-v6/01-cleanup.yaml
@@ -1,0 +1,12 @@
+apiVersion: kuttl.dev/v1beta1
+kind: TestStep
+delete:
+- apiVersion: openstack.k-orc.cloud/v1alpha1
+  kind: Subnet
+  name: create-full-v6
+- apiVersion: openstack.k-orc.cloud/v1alpha1
+  kind: Router
+  name: create-full-v6
+- apiVersion: openstack.k-orc.cloud/v1alpha1
+  kind: Network
+  name: create-full-v6

--- a/internal/controllers/subnet/tests/create-full-v6/README.md
+++ b/internal/controllers/subnet/tests/create-full-v6/README.md
@@ -10,7 +10,3 @@ Also validate that the OpenStack resource uses the name from the spec when it is
 
 Validate we're able to delete resources.
 Cleaning up resources also avoids a race where kuttl could delete the secret before the other resources.
-
-## TODO
-
-- Validate `routerRef`

--- a/internal/controllers/subnet/tests/create-full-v6/README.md
+++ b/internal/controllers/subnet/tests/create-full-v6/README.md
@@ -1,0 +1,16 @@
+# Create an IPv6 subnet with all the options
+
+## Step 00
+
+Create a subnet using all available fields, and verify that the observed state corresponds to the spec.
+
+Also validate that the OpenStack resource uses the name from the spec when it is specified.
+
+## Step 01
+
+Validate we're able to delete resources.
+Cleaning up resources also avoids a race where kuttl could delete the secret before the other resources.
+
+## TODO
+
+- Validate `routerRef`

--- a/internal/controllers/subnet/tests/create-minimal-v4/00-assert.yaml
+++ b/internal/controllers/subnet/tests/create-minimal-v4/00-assert.yaml
@@ -1,0 +1,21 @@
+---
+apiVersion: openstack.k-orc.cloud/v1alpha1
+kind: Subnet
+metadata:
+  name: create-minimal-v4
+status:
+  resource:
+    name: create-minimal-v4
+    allocationPools:
+      - start: 192.168.0.2
+        end: 192.168.0.254
+    cidr: 192.168.0.0/24
+    dnsPublishFixedIP: false
+    enableDHCP: true
+    gatewayIP: 192.168.0.1
+    ipVersion: 4
+    # FIXME: we shouldn't see empty strings
+    # https://github.com/k-orc/openstack-resource-controller/issues/188
+    description: ""
+    ipv6AddressMode: ""
+    ipv6RAMode: ""

--- a/internal/controllers/subnet/tests/create-minimal-v4/00-secret.yaml
+++ b/internal/controllers/subnet/tests/create-minimal-v4/00-secret.yaml
@@ -1,0 +1,5 @@
+apiVersion: kuttl.dev/v1beta1
+kind: TestStep
+commands:
+  - command: kubectl create secret generic openstack-clouds --from-file=clouds.yaml=/etc/openstack/clouds.yaml
+    namespaced: true

--- a/internal/controllers/subnet/tests/create-minimal-v4/00-subnet.yaml
+++ b/internal/controllers/subnet/tests/create-minimal-v4/00-subnet.yaml
@@ -1,0 +1,27 @@
+apiVersion: openstack.k-orc.cloud/v1alpha1
+kind: Network
+metadata:
+  name: create-minimal-v4
+spec:
+  cloudCredentialsRef:
+    cloudName: devstack
+    secretName: openstack-clouds
+  managementPolicy: managed
+  resource:
+    # FIXME: just having the name causes a panic
+    # https://github.com/k-orc/openstack-resource-controller/issues/187
+    description: create-minimal-v4
+---
+apiVersion: openstack.k-orc.cloud/v1alpha1
+kind: Subnet
+metadata:
+  name: create-minimal-v4
+spec:
+  cloudCredentialsRef:
+    cloudName: devstack
+    secretName: openstack-clouds
+  managementPolicy: managed
+  networkRef: create-minimal-v4
+  resource:
+    ipVersion: 4
+    cidr: 192.168.0.0/24

--- a/internal/controllers/subnet/tests/create-minimal-v4/01-assert.yaml
+++ b/internal/controllers/subnet/tests/create-minimal-v4/01-assert.yaml
@@ -1,0 +1,7 @@
+apiVersion: kuttl.dev/v1beta1
+kind: TestAssert
+commands:
+- script: "! kubectl get subnet create-minimal-v4 --namespace $NAMESPACE"
+  skipLogOutput: true
+- script: "! kubectl get network create-minimal-v4 --namespace $NAMESPACE"
+  skipLogOutput: true

--- a/internal/controllers/subnet/tests/create-minimal-v4/01-cleanup.yaml
+++ b/internal/controllers/subnet/tests/create-minimal-v4/01-cleanup.yaml
@@ -1,0 +1,9 @@
+apiVersion: kuttl.dev/v1beta1
+kind: TestStep
+delete:
+- apiVersion: openstack.k-orc.cloud/v1alpha1
+  kind: Subnet
+  name: create-minimal-v4
+- apiVersion: openstack.k-orc.cloud/v1alpha1
+  kind: Network
+  name: create-minimal-v4

--- a/internal/controllers/subnet/tests/create-minimal-v4/README.md
+++ b/internal/controllers/subnet/tests/create-minimal-v4/README.md
@@ -1,0 +1,12 @@
+# Create an IPv4 subnet with the minimum options
+
+## Step 00
+
+Create a minimal subnet, that sets only the required fields, and verify that the observed state corresponds to the spec.
+
+Also validate that the OpenStack resource uses the name of the ORC object when it is not specified.
+
+## Step 01
+
+Validate we're able to delete resources.
+Cleaning up resources also avoids a race where kuttl could delete the secret before the other resources.

--- a/internal/controllers/subnet/tests/create-minimal-v6/00-assert.yaml
+++ b/internal/controllers/subnet/tests/create-minimal-v6/00-assert.yaml
@@ -1,0 +1,21 @@
+---
+apiVersion: openstack.k-orc.cloud/v1alpha1
+kind: Subnet
+metadata:
+  name: create-minimal-v6
+status:
+  resource:
+    name: create-minimal-v6
+    allocationPools:
+      - start: fc00:1::1
+        end: fc00:1::ffff:ffff:ffff:ffff
+    cidr: fc00:1::/64
+    dnsPublishFixedIP: false
+    enableDHCP: true
+    gatewayIP: "fc00:1::"
+    ipVersion: 6
+    # FIXME: we shouldn't see empty strings
+    # https://github.com/k-orc/openstack-resource-controller/issues/188
+    description: ""
+    ipv6AddressMode: ""
+    ipv6RAMode: ""

--- a/internal/controllers/subnet/tests/create-minimal-v6/00-secret.yaml
+++ b/internal/controllers/subnet/tests/create-minimal-v6/00-secret.yaml
@@ -1,0 +1,5 @@
+apiVersion: kuttl.dev/v1beta1
+kind: TestStep
+commands:
+  - command: kubectl create secret generic openstack-clouds --from-file=clouds.yaml=/etc/openstack/clouds.yaml
+    namespaced: true

--- a/internal/controllers/subnet/tests/create-minimal-v6/00-subnet.yaml
+++ b/internal/controllers/subnet/tests/create-minimal-v6/00-subnet.yaml
@@ -1,0 +1,27 @@
+apiVersion: openstack.k-orc.cloud/v1alpha1
+kind: Network
+metadata:
+  name: create-minimal-v6
+spec:
+  cloudCredentialsRef:
+    cloudName: devstack
+    secretName: openstack-clouds
+  managementPolicy: managed
+  resource:
+    # FIXME: just having the name causes a panic
+    # https://github.com/k-orc/openstack-resource-controller/issues/187
+    description: create-minimal-v6
+---
+apiVersion: openstack.k-orc.cloud/v1alpha1
+kind: Subnet
+metadata:
+  name: create-minimal-v6
+spec:
+  cloudCredentialsRef:
+    cloudName: devstack
+    secretName: openstack-clouds
+  managementPolicy: managed
+  networkRef: create-minimal-v6
+  resource:
+    ipVersion: 6
+    cidr: fc00:1::/64

--- a/internal/controllers/subnet/tests/create-minimal-v6/01-assert.yaml
+++ b/internal/controllers/subnet/tests/create-minimal-v6/01-assert.yaml
@@ -1,0 +1,7 @@
+apiVersion: kuttl.dev/v1beta1
+kind: TestAssert
+commands:
+- script: "! kubectl get subnet create-minimal-v6 --namespace $NAMESPACE"
+  skipLogOutput: true
+- script: "! kubectl get network create-minimal-v6 --namespace $NAMESPACE"
+  skipLogOutput: true

--- a/internal/controllers/subnet/tests/create-minimal-v6/01-cleanup.yaml
+++ b/internal/controllers/subnet/tests/create-minimal-v6/01-cleanup.yaml
@@ -1,0 +1,9 @@
+apiVersion: kuttl.dev/v1beta1
+kind: TestStep
+delete:
+- apiVersion: openstack.k-orc.cloud/v1alpha1
+  kind: Subnet
+  name: create-minimal-v6
+- apiVersion: openstack.k-orc.cloud/v1alpha1
+  kind: Network
+  name: create-minimal-v6

--- a/internal/controllers/subnet/tests/create-minimal-v6/README.md
+++ b/internal/controllers/subnet/tests/create-minimal-v6/README.md
@@ -1,0 +1,12 @@
+# Create an IPv6 subnet with the minimum options
+
+## Step 00
+
+Create a minimal subnet, that sets only the required fields, and verify that the observed state corresponds to the spec.
+
+Also validate that the OpenStack resource uses the name of the ORC object when it is not specified.
+
+## Step 01
+
+Validate we're able to delete resources.
+Cleaning up resources also avoids a race where kuttl could delete the secret before the other resources.

--- a/internal/controllers/subnet/tests/dependency/00-assert.yaml
+++ b/internal/controllers/subnet/tests/dependency/00-assert.yaml
@@ -1,0 +1,15 @@
+---
+apiVersion: openstack.k-orc.cloud/v1alpha1
+kind: Subnet
+metadata:
+  name: dependency
+status:
+  conditions:
+    - type: Available
+      message: Waiting for Network/dependency to be created
+      status: "False"
+      reason: Progressing
+    - type: Progressing
+      message: Waiting for Network/dependency to be created
+      status: "True"
+      reason: Progressing

--- a/internal/controllers/subnet/tests/dependency/00-create-subnet.yaml
+++ b/internal/controllers/subnet/tests/dependency/00-create-subnet.yaml
@@ -1,0 +1,14 @@
+---
+apiVersion: openstack.k-orc.cloud/v1alpha1
+kind: Subnet
+metadata:
+  name: dependency
+spec:
+  cloudCredentialsRef:
+    cloudName: devstack
+    secretName: openstack-clouds
+  managementPolicy: managed
+  networkRef: dependency
+  resource:
+    ipVersion: 4
+    cidr: 192.168.0.0/24

--- a/internal/controllers/subnet/tests/dependency/00-secret.yaml
+++ b/internal/controllers/subnet/tests/dependency/00-secret.yaml
@@ -1,0 +1,5 @@
+apiVersion: kuttl.dev/v1beta1
+kind: TestStep
+commands:
+  - command: kubectl create secret generic openstack-clouds --from-file=clouds.yaml=/etc/openstack/clouds.yaml
+    namespaced: true

--- a/internal/controllers/subnet/tests/dependency/01-assert.yaml
+++ b/internal/controllers/subnet/tests/dependency/01-assert.yaml
@@ -1,0 +1,15 @@
+---
+apiVersion: openstack.k-orc.cloud/v1alpha1
+kind: Subnet
+metadata:
+  name: dependency
+status:
+  conditions:
+    - type: Available
+      message: OpenStack resource is available
+      status: "True"
+      reason: Success
+    - type: Progressing
+      message: OpenStack resource is up to date
+      status: "False"
+      reason: Success

--- a/internal/controllers/subnet/tests/dependency/01-create-network.yaml
+++ b/internal/controllers/subnet/tests/dependency/01-create-network.yaml
@@ -1,0 +1,11 @@
+apiVersion: openstack.k-orc.cloud/v1alpha1
+kind: Network
+metadata:
+  name: dependency
+spec:
+  cloudCredentialsRef:
+    cloudName: devstack
+    secretName: openstack-clouds
+  managementPolicy: managed
+  resource:
+    description: Dependency

--- a/internal/controllers/subnet/tests/dependency/02-assert.yaml
+++ b/internal/controllers/subnet/tests/dependency/02-assert.yaml
@@ -1,0 +1,6 @@
+---
+apiVersion: openstack.k-orc.cloud/v1alpha1
+kind: Network
+metadata:
+  name: dependency
+  deletionGracePeriodSeconds: 0

--- a/internal/controllers/subnet/tests/dependency/02-delete-network.yaml
+++ b/internal/controllers/subnet/tests/dependency/02-delete-network.yaml
@@ -1,0 +1,6 @@
+apiVersion: kuttl.dev/v1beta1
+kind: TestStep
+commands:
+  # We expect the deletion to hang due to the finalizer, so use --wait=false
+  - command: kubectl delete network dependency --wait=false
+    namespaced: true

--- a/internal/controllers/subnet/tests/dependency/03-assert.yaml
+++ b/internal/controllers/subnet/tests/dependency/03-assert.yaml
@@ -1,0 +1,7 @@
+apiVersion: kuttl.dev/v1beta1
+kind: TestAssert
+commands:
+- script: "! kubectl get subnet dependency --namespace $NAMESPACE"
+  skipLogOutput: true
+- script: "! kubectl get network dependency --namespace $NAMESPACE"
+  skipLogOutput: true

--- a/internal/controllers/subnet/tests/dependency/03-delete-subnet.yaml
+++ b/internal/controllers/subnet/tests/dependency/03-delete-subnet.yaml
@@ -1,0 +1,6 @@
+apiVersion: kuttl.dev/v1beta1
+kind: TestStep
+delete:
+- apiVersion: openstack.k-orc.cloud/v1alpha1
+  kind: Subnet
+  name: dependency

--- a/internal/controllers/subnet/tests/dependency/README.md
+++ b/internal/controllers/subnet/tests/dependency/README.md
@@ -1,0 +1,21 @@
+# Creation and deletion dependencies
+
+## Step 00
+
+Create a subnet referencing a non-existing network, and verify that the subnet is waiting for the network to be created externally.
+
+## Step 01
+
+Create the network the subnet depends on, and verify that the subnet is now available.
+
+## Step 02
+
+Delete the network and check that ORC prevents deletion since there is still a resource that depends on it.
+
+## Step 03
+
+Delete the subnet and validate that all resources are gone.
+
+## TODO
+
+- Validate `routerRef`

--- a/internal/controllers/subnet/tests/import-error/00-assert.yaml
+++ b/internal/controllers/subnet/tests/import-error/00-assert.yaml
@@ -1,0 +1,30 @@
+---
+apiVersion: openstack.k-orc.cloud/v1alpha1
+kind: Subnet
+metadata:
+  name: import-error-external-1
+status:
+  conditions:
+    - type: Available
+      message: OpenStack resource is available
+      status: "True"
+      reason: Success
+    - type: Progressing
+      message: OpenStack resource is up to date
+      status: "False"
+      reason: Success
+---
+apiVersion: openstack.k-orc.cloud/v1alpha1
+kind: Subnet
+metadata:
+  name: import-error-external-2
+status:
+  conditions:
+    - type: Available
+      message: OpenStack resource is available
+      status: "True"
+      reason: Success
+    - type: Progressing
+      message: OpenStack resource is up to date
+      status: "False"
+      reason: Success

--- a/internal/controllers/subnet/tests/import-error/00-create-network.yaml
+++ b/internal/controllers/subnet/tests/import-error/00-create-network.yaml
@@ -1,0 +1,13 @@
+apiVersion: openstack.k-orc.cloud/v1alpha1
+kind: Network
+metadata:
+  name: import-error
+spec:
+  cloudCredentialsRef:
+    cloudName: devstack
+    secretName: openstack-clouds
+  managementPolicy: managed
+  resource:
+    # FIXME: just having the name causes a panic
+    # https://github.com/k-orc/openstack-resource-controller/issues/187
+    description: import-error

--- a/internal/controllers/subnet/tests/import-error/00-create-subnets.yaml
+++ b/internal/controllers/subnet/tests/import-error/00-create-subnets.yaml
@@ -1,0 +1,30 @@
+---
+apiVersion: openstack.k-orc.cloud/v1alpha1
+kind: Subnet
+metadata:
+  name: import-error-external-1
+spec:
+  cloudCredentialsRef:
+    cloudName: devstack
+    secretName: openstack-clouds
+  managementPolicy: managed
+  networkRef: import-error
+  resource:
+    description: Subnet from "import error" test
+    ipVersion: 4
+    cidr: 192.168.0.0/24
+---
+apiVersion: openstack.k-orc.cloud/v1alpha1
+kind: Subnet
+metadata:
+  name: import-error-external-2
+spec:
+  cloudCredentialsRef:
+    cloudName: devstack
+    secretName: openstack-clouds
+  managementPolicy: managed
+  networkRef: import-error
+  resource:
+    description: Subnet from "import error" test
+    ipVersion: 4
+    cidr: 192.168.1.0/24

--- a/internal/controllers/subnet/tests/import-error/00-secret.yaml
+++ b/internal/controllers/subnet/tests/import-error/00-secret.yaml
@@ -1,0 +1,5 @@
+apiVersion: kuttl.dev/v1beta1
+kind: TestStep
+commands:
+  - command: kubectl create secret generic openstack-clouds --from-file=clouds.yaml=/etc/openstack/clouds.yaml
+    namespaced: true

--- a/internal/controllers/subnet/tests/import-error/01-assert.yaml
+++ b/internal/controllers/subnet/tests/import-error/01-assert.yaml
@@ -1,0 +1,15 @@
+---
+apiVersion: openstack.k-orc.cloud/v1alpha1
+kind: Subnet
+metadata:
+  name: import-error
+status:
+  conditions:
+    - type: Available
+      message: Expected to find exactly one OpenStack resource to import. Found 2
+      status: "False"
+      reason: InvalidConfiguration
+    - type: Progressing
+      message: Expected to find exactly one OpenStack resource to import. Found 2
+      status: "False"
+      reason: InvalidConfiguration

--- a/internal/controllers/subnet/tests/import-error/01-import-subnet.yaml
+++ b/internal/controllers/subnet/tests/import-error/01-import-subnet.yaml
@@ -1,0 +1,15 @@
+---
+apiVersion: openstack.k-orc.cloud/v1alpha1
+kind: Subnet
+metadata:
+  name: import-error
+spec:
+  cloudCredentialsRef:
+    cloudName: devstack
+    secretName: openstack-clouds
+  managementPolicy: unmanaged
+  networkRef: import-error
+  import:
+    filter:
+      description: Subnet from "import error" test
+      ipVersion: 4

--- a/internal/controllers/subnet/tests/import-error/02-assert.yaml
+++ b/internal/controllers/subnet/tests/import-error/02-assert.yaml
@@ -1,0 +1,11 @@
+apiVersion: kuttl.dev/v1beta1
+kind: TestAssert
+commands:
+- script: "! kubectl get subnet import-error --namespace $NAMESPACE"
+  skipLogOutput: true
+- script: "! kubectl get subnet import-error-external-1 --namespace $NAMESPACE"
+  skipLogOutput: true
+- script: "! kubectl get subnet import-error-external-2 --namespace $NAMESPACE"
+  skipLogOutput: true
+- script: "! kubectl get network import-error --namespace $NAMESPACE"
+  skipLogOutput: true

--- a/internal/controllers/subnet/tests/import-error/02-cleanup.yaml
+++ b/internal/controllers/subnet/tests/import-error/02-cleanup.yaml
@@ -1,0 +1,15 @@
+apiVersion: kuttl.dev/v1beta1
+kind: TestStep
+delete:
+- apiVersion: openstack.k-orc.cloud/v1alpha1
+  kind: Subnet
+  name: import-error
+- apiVersion: openstack.k-orc.cloud/v1alpha1
+  kind: Subnet
+  name: import-error-external-1
+- apiVersion: openstack.k-orc.cloud/v1alpha1
+  kind: Subnet
+  name: import-error-external-2
+- apiVersion: openstack.k-orc.cloud/v1alpha1
+  kind: Network
+  name: import-error

--- a/internal/controllers/subnet/tests/import-error/README.md
+++ b/internal/controllers/subnet/tests/import-error/README.md
@@ -1,0 +1,14 @@
+# Import Subnet with more than one matching resources
+
+## Step 00
+
+Create two subnets with identical specs.
+
+## Step 01
+
+Ensure that an imported subnet with a filter matching the resources returns an error.
+
+## Step 02
+
+Validate we're able to delete resources.
+Cleaning up resources also avoids a race where kuttl could delete the secret before the other resources.

--- a/internal/controllers/subnet/tests/import/00-assert.yaml
+++ b/internal/controllers/subnet/tests/import/00-assert.yaml
@@ -1,0 +1,15 @@
+---
+apiVersion: openstack.k-orc.cloud/v1alpha1
+kind: Subnet
+metadata:
+  name: import
+status:
+  conditions:
+    - type: Available
+      message: Waiting for OpenStack resource to be created externally
+      status: "False"
+      reason: Progressing
+    - type: Progressing
+      message: Waiting for OpenStack resource to be created externally
+      status: "True"
+      reason: Progressing

--- a/internal/controllers/subnet/tests/import/00-create-network.yaml
+++ b/internal/controllers/subnet/tests/import/00-create-network.yaml
@@ -1,0 +1,13 @@
+apiVersion: openstack.k-orc.cloud/v1alpha1
+kind: Network
+metadata:
+  name: import
+spec:
+  cloudCredentialsRef:
+    cloudName: devstack
+    secretName: openstack-clouds
+  managementPolicy: managed
+  resource:
+    # FIXME: just having the name causes a panic
+    # https://github.com/k-orc/openstack-resource-controller/issues/187
+    description: import

--- a/internal/controllers/subnet/tests/import/00-import-subnet.yaml
+++ b/internal/controllers/subnet/tests/import/00-import-subnet.yaml
@@ -1,0 +1,24 @@
+---
+apiVersion: openstack.k-orc.cloud/v1alpha1
+kind: Subnet
+metadata:
+  name: import
+spec:
+  cloudCredentialsRef:
+    cloudName: devstack
+    secretName: openstack-clouds
+  managementPolicy: unmanaged
+  networkRef: import
+  import:
+    filter:
+      name: import-external
+      description: Subnet from "import" test
+      ipVersion: 6
+      cidr: fc00:3::/64
+      gatewayIP: "fc00:3::"
+      ipv6:
+        addressMode: dhcpv6-stateful
+        raMode: dhcpv6-stateful
+      tags:
+      - tag1
+      - tag2

--- a/internal/controllers/subnet/tests/import/00-secret.yaml
+++ b/internal/controllers/subnet/tests/import/00-secret.yaml
@@ -1,0 +1,5 @@
+apiVersion: kuttl.dev/v1beta1
+kind: TestStep
+commands:
+  - command: kubectl create secret generic openstack-clouds --from-file=clouds.yaml=/etc/openstack/clouds.yaml
+    namespaced: true

--- a/internal/controllers/subnet/tests/import/01-assert.yaml
+++ b/internal/controllers/subnet/tests/import/01-assert.yaml
@@ -1,0 +1,31 @@
+---
+apiVersion: openstack.k-orc.cloud/v1alpha1
+kind: Subnet
+metadata:
+  name: import
+status:
+  conditions:
+    - type: Available
+      message: OpenStack resource is available
+      status: "True"
+      reason: Success
+    - type: Progressing
+      message: OpenStack resource is up to date
+      status: "False"
+      reason: Success
+  resource:
+    allocationPools:
+      - start: "fc00:3::1"
+        end: "fc00:3::ffff:ffff:ffff:ffff"
+    cidr: fc00:3::/64
+    description: Subnet from "import" test
+    dnsPublishFixedIP: false
+    enableDHCP: true
+    gatewayIP: 'fc00:3::'
+    ipVersion: 6
+    ipv6AddressMode: dhcpv6-stateful
+    ipv6RAMode: dhcpv6-stateful
+    name: import-external
+    tags:
+    - tag1
+    - tag2

--- a/internal/controllers/subnet/tests/import/01-create-subnet.yaml
+++ b/internal/controllers/subnet/tests/import/01-create-subnet.yaml
@@ -1,0 +1,24 @@
+---
+apiVersion: openstack.k-orc.cloud/v1alpha1
+kind: Subnet
+metadata:
+  name: import-external
+spec:
+  cloudCredentialsRef:
+    cloudName: devstack
+    secretName: openstack-clouds
+  managementPolicy: managed
+  networkRef: import
+  resource:
+    description: Subnet from "import" test
+    ipVersion: 6
+    cidr: fc00:3::/64
+    tags:
+    - tag1
+    - tag2
+    # NOTE: enable_dhcp must be enabled for setting ipv6_ra_mode or ipv6_address_mode
+    enableDHCP: true
+    # NOTE: when both ipv6_ra_mode and ipv6_address_mode are set they must be identical
+    ipv6:
+      addressMode: dhcpv6-stateful
+      raMode: dhcpv6-stateful

--- a/internal/controllers/subnet/tests/import/02-assert.yaml
+++ b/internal/controllers/subnet/tests/import/02-assert.yaml
@@ -1,0 +1,9 @@
+apiVersion: kuttl.dev/v1beta1
+kind: TestAssert
+commands:
+- script: "! kubectl get subnet import --namespace $NAMESPACE"
+  skipLogOutput: true
+- script: "! kubectl get subnet import-external --namespace $NAMESPACE"
+  skipLogOutput: true
+- script: "! kubectl get network import --namespace $NAMESPACE"
+  skipLogOutput: true

--- a/internal/controllers/subnet/tests/import/02-cleanup.yaml
+++ b/internal/controllers/subnet/tests/import/02-cleanup.yaml
@@ -1,0 +1,12 @@
+apiVersion: kuttl.dev/v1beta1
+kind: TestStep
+delete:
+- apiVersion: openstack.k-orc.cloud/v1alpha1
+  kind: Subnet
+  name: import
+- apiVersion: openstack.k-orc.cloud/v1alpha1
+  kind: Subnet
+  name: import-external
+- apiVersion: openstack.k-orc.cloud/v1alpha1
+  kind: Network
+  name: import

--- a/internal/controllers/subnet/tests/import/README.md
+++ b/internal/controllers/subnet/tests/import/README.md
@@ -1,0 +1,18 @@
+# Import Subnet
+
+## Step 00
+
+Import a subnet, matching all of the available filter's fields, and verify it is waiting for the external resource to be created.
+
+## Step 01
+
+Create a subnet matching the filter and verify that the observed status on the imported subnet corresponds to the spec of the created subnet.
+
+## Step 02
+
+Validate we're able to delete resources.
+Cleaning up resources also avoids a race where kuttl could delete the secret before the other resources.
+
+## TODO
+
+Possibly check that adding a new subnet matching the import filter does not cause issues after it successfully imported the first one.

--- a/kuttl-test.yaml
+++ b/kuttl-test.yaml
@@ -1,0 +1,4 @@
+apiVersion: kuttl.dev/v1beta1
+kind: TestSuite
+testDirs:
+- ./internal/controllers/flavor/tests/

--- a/kuttl-test.yaml
+++ b/kuttl-test.yaml
@@ -2,3 +2,5 @@ apiVersion: kuttl.dev/v1beta1
 kind: TestSuite
 testDirs:
 - ./internal/controllers/flavor/tests/
+- ./internal/controllers/subnet/tests/
+timeout: 120

--- a/website/docs/writing-controllers.md
+++ b/website/docs/writing-controllers.md
@@ -47,6 +47,28 @@ Create your resource in one of the example directory in `examples/`.
 Add your resource to `examples/components/kustomizeconfig/kustomizeconfig.yaml`
 so that the resource name get prefixed with your username.
 
+## Unit tests
+
+Add API validation tests for your controller in `test/apivalidations`.
+
 ## e2e tests
 
-Add e2e tests for your resource.
+ORC uses [kuttl](https://kuttl.dev/) for end-to-end testing. Add tests for the
+controllers you're writing. Check out the [flavor][flavor-tests] and the
+[subnet][subnet-tests] that should cover all the patterns we're expecting to
+see tested.
+
+Each test runs in a separate kubernetes namespace, however because they all run
+in the same openstack tenant, we still need to be careful about name clash when
+referencing resources, and filters for importing resources:
+
+- a test must only reference resources it created. Resources created on
+  OpenStack must have a unique name among the whole test suite.
+- a test must ensure their filters match resources uniquely
+
+This is the condition to run tests concurrently.
+
+Each test contains a `README.md` file describing what the test does.
+
+[flavor-tests]: https://github.com/k-orc/openstack-resource-controller/tree/main/internal/controllers/flavor/tests
+[subnet-tests]: https://github.com/k-orc/openstack-resource-controller/tree/main/internal/controllers/subnet/tests


### PR DESCRIPTION
Add e2e testing with kuttl.

This currently implements tests for flavors and subnets, and allows to demonstrate the testing pattern we can apply to other controllers:
- creation and deletion of resources, using both the minimum options and the full available options
- dependency management at creation and deletion
- importing resources

Each test runs in a separate kubernetes namespace, however because they all run in the same openstack tenant, we still need to be careful about name clash when referencing resources, and filters for importing resources:
- a test must only reference resources it created. Resources created on OpenStack must have a unique name among the whole test suite.
- a test must ensure their filters match resources uniquely

This is the condition to run tests concurrently.

Each test contains a `README.md` file describing what the test does.