### PR TITLE
Network: fix panic when creating resource without description

### DIFF
--- a/internal/controllers/network/actuator.go
+++ b/internal/controllers/network/actuator.go
@@ -96,7 +96,7 @@ func (actuator networkActuator) CreateResource(ctx context.Context, obj orcObjec
 	{
 		createOptsBase := networks.CreateOpts{
 			Name:         string(getResourceName(obj)),
-			Description:  string(*resource.Description),
+			Description:  string(ptr.Deref(resource.Description, "")),
 			AdminStateUp: resource.AdminStateUp,
 			Shared:       resource.Shared,
 		}

--- a/internal/controllers/subnet/tests/create-full-v4/00-subnet.yaml
+++ b/internal/controllers/subnet/tests/create-full-v4/00-subnet.yaml
@@ -8,9 +8,7 @@ spec:
     secretName: openstack-clouds
   managementPolicy: managed
   resource:
-    # FIXME: just having the name causes a panic
-    # https://github.com/k-orc/openstack-resource-controller/issues/187
-    description: create-full-v4
+    name: create-full-v4
 ---
 apiVersion: openstack.k-orc.cloud/v1alpha1
 kind: Network
@@ -22,9 +20,6 @@ spec:
     secretName: openstack-clouds
   managementPolicy: managed
   resource:
-    # FIXME: just having the name causes a panic
-    # https://github.com/k-orc/openstack-resource-controller/issues/187
-    description: create-full-v4-gateway
     external: true
 ---
 apiVersion: openstack.k-orc.cloud/v1alpha1

--- a/internal/controllers/subnet/tests/create-full-v6/00-subnet.yaml
+++ b/internal/controllers/subnet/tests/create-full-v6/00-subnet.yaml
@@ -8,9 +8,7 @@ spec:
     secretName: openstack-clouds
   managementPolicy: managed
   resource:
-    # FIXME: just having the name causes a panic
-    # https://github.com/k-orc/openstack-resource-controller/issues/187
-    description: create-full-v6
+    name: create-full-v6
 ---
 apiVersion: openstack.k-orc.cloud/v1alpha1
 kind: Network
@@ -22,9 +20,6 @@ spec:
     secretName: openstack-clouds
   managementPolicy: managed
   resource:
-    # FIXME: just having the name causes a panic
-    # https://github.com/k-orc/openstack-resource-controller/issues/187
-    description: create-full-v6-gateway
     external: true
 ---
 apiVersion: openstack.k-orc.cloud/v1alpha1

--- a/internal/controllers/subnet/tests/create-minimal-v4/00-subnet.yaml
+++ b/internal/controllers/subnet/tests/create-minimal-v4/00-subnet.yaml
@@ -8,9 +8,7 @@ spec:
     secretName: openstack-clouds
   managementPolicy: managed
   resource:
-    # FIXME: just having the name causes a panic
-    # https://github.com/k-orc/openstack-resource-controller/issues/187
-    description: create-minimal-v4
+    name: create-minimal-v4
 ---
 apiVersion: openstack.k-orc.cloud/v1alpha1
 kind: Subnet

--- a/internal/controllers/subnet/tests/create-minimal-v6/00-subnet.yaml
+++ b/internal/controllers/subnet/tests/create-minimal-v6/00-subnet.yaml
@@ -8,9 +8,7 @@ spec:
     secretName: openstack-clouds
   managementPolicy: managed
   resource:
-    # FIXME: just having the name causes a panic
-    # https://github.com/k-orc/openstack-resource-controller/issues/187
-    description: create-minimal-v6
+    name: create-minimal-v6
 ---
 apiVersion: openstack.k-orc.cloud/v1alpha1
 kind: Subnet

--- a/internal/controllers/subnet/tests/import-error/00-create-network.yaml
+++ b/internal/controllers/subnet/tests/import-error/00-create-network.yaml
@@ -8,6 +8,4 @@ spec:
     secretName: openstack-clouds
   managementPolicy: managed
   resource:
-    # FIXME: just having the name causes a panic
-    # https://github.com/k-orc/openstack-resource-controller/issues/187
-    description: import-error
+    name: import-error

--- a/internal/controllers/subnet/tests/import/00-create-network.yaml
+++ b/internal/controllers/subnet/tests/import/00-create-network.yaml
@@ -8,6 +8,4 @@ spec:
     secretName: openstack-clouds
   managementPolicy: managed
   resource:
-    # FIXME: just having the name causes a panic
-    # https://github.com/k-orc/openstack-resource-controller/issues/187
-    description: import
+    name: import


### PR DESCRIPTION
We didn't check for the description to be set before converting to string which could result in a panic in the reconcile loop.

Fixes #187