### PR TITLE
Improvements to Progressing condition

### DIFF
--- a/internal/controllers/flavor/actuator.go
+++ b/internal/controllers/flavor/actuator.go
@@ -128,7 +128,7 @@ func (actuator flavorActuator) listOSResources(ctx context.Context, filters []os
 	return osclients.Filter(flavors, filters...)
 }
 
-func (actuator flavorActuator) CreateResource(ctx context.Context, obj orcObjectPT) ([]generic.WaitingOnEvent, *flavors.Flavor, error) {
+func (actuator flavorActuator) CreateResource(ctx context.Context, obj orcObjectPT) ([]generic.ProgressStatus, *flavors.Flavor, error) {
 	resource := obj.Spec.Resource
 
 	if resource == nil {
@@ -159,7 +159,7 @@ func (actuator flavorActuator) CreateResource(ctx context.Context, obj orcObject
 	return nil, osResource, nil
 }
 
-func (actuator flavorActuator) DeleteResource(ctx context.Context, _ orcObjectPT, flavor *flavors.Flavor) ([]generic.WaitingOnEvent, error) {
+func (actuator flavorActuator) DeleteResource(ctx context.Context, _ orcObjectPT, flavor *flavors.Flavor) ([]generic.ProgressStatus, error) {
 	return nil, actuator.osClient.DeleteFlavor(ctx, flavor.ID)
 }
 
@@ -188,12 +188,12 @@ func (flavorHelperFactory) NewAPIObjectAdapter(obj orcObjectPT) adapterI {
 	return flavorAdapter{obj}
 }
 
-func (flavorHelperFactory) NewCreateActuator(ctx context.Context, orcObject orcObjectPT, controller generic.ResourceController) ([]generic.WaitingOnEvent, createResourceActuator, error) {
+func (flavorHelperFactory) NewCreateActuator(ctx context.Context, orcObject orcObjectPT, controller generic.ResourceController) ([]generic.ProgressStatus, createResourceActuator, error) {
 	actuator, err := newActuator(ctx, orcObject, controller)
 	return nil, actuator, err
 }
 
-func (flavorHelperFactory) NewDeleteActuator(ctx context.Context, orcObject orcObjectPT, controller generic.ResourceController) ([]generic.WaitingOnEvent, deleteResourceActuator, error) {
+func (flavorHelperFactory) NewDeleteActuator(ctx context.Context, orcObject orcObjectPT, controller generic.ResourceController) ([]generic.ProgressStatus, deleteResourceActuator, error) {
 	actuator, err := newActuator(ctx, orcObject, controller)
 	return nil, actuator, err
 }

--- a/internal/controllers/flavor/status.go
+++ b/internal/controllers/flavor/status.go
@@ -36,9 +36,8 @@ func (flavorStatusWriter) GetApplyConfigConstructor() generic.ORCApplyConfigCons
 	return orcapplyconfigv1alpha1.Flavor
 }
 
-func (flavorStatusWriter) GetCommonStatus(_ *orcv1alpha1.Flavor, osResource *flavors.Flavor) (bool, bool) {
-	available := osResource != nil
-	return available, available
+func (flavorStatusWriter) ResourceIsAvailable(_ *orcv1alpha1.Flavor, osResource *flavors.Flavor) bool {
+	return osResource != nil
 }
 
 func (flavorStatusWriter) ApplyResourceStatus(_ logr.Logger, osResource *flavors.Flavor, statusApply *statusApplyT) {

--- a/internal/controllers/image/actuator.go
+++ b/internal/controllers/image/actuator.go
@@ -87,7 +87,7 @@ func (actuator imageActuator) ListOSResourcesForImport(ctx context.Context, filt
 	return actuator.osClient.ListImages(ctx, listOpts)
 }
 
-func (actuator imageActuator) CreateResource(ctx context.Context, obj *orcv1alpha1.Image) ([]generic.WaitingOnEvent, *images.Image, error) {
+func (actuator imageActuator) CreateResource(ctx context.Context, obj *orcv1alpha1.Image) ([]generic.ProgressStatus, *images.Image, error) {
 	resource := obj.Spec.Resource
 	if resource == nil {
 		// Should have been caught by API validation
@@ -147,7 +147,7 @@ func (actuator imageActuator) CreateResource(ctx context.Context, obj *orcv1alph
 	return nil, image, err
 }
 
-func (actuator imageActuator) DeleteResource(ctx context.Context, _ orcObjectPT, osResource *images.Image) ([]generic.WaitingOnEvent, error) {
+func (actuator imageActuator) DeleteResource(ctx context.Context, _ orcObjectPT, osResource *images.Image) ([]generic.ProgressStatus, error) {
 	return nil, actuator.osClient.DeleteImage(ctx, osResource.ID)
 }
 

--- a/internal/controllers/network/actuator.go
+++ b/internal/controllers/network/actuator.go
@@ -85,7 +85,7 @@ func (actuator networkActuator) ListOSResourcesForImport(ctx context.Context, fi
 	return actuator.osClient.ListNetwork(ctx, listOpts)
 }
 
-func (actuator networkActuator) CreateResource(ctx context.Context, obj orcObjectPT) ([]generic.WaitingOnEvent, *osclients.NetworkExt, error) {
+func (actuator networkActuator) CreateResource(ctx context.Context, obj orcObjectPT) ([]generic.ProgressStatus, *osclients.NetworkExt, error) {
 	resource := obj.Spec.Resource
 	if resource == nil {
 		// Should have been caught by API validation
@@ -150,7 +150,7 @@ func (actuator networkActuator) CreateResource(ctx context.Context, obj orcObjec
 	return nil, osResource, nil
 }
 
-func (actuator networkActuator) DeleteResource(ctx context.Context, _ orcObjectPT, network *osclients.NetworkExt) ([]generic.WaitingOnEvent, error) {
+func (actuator networkActuator) DeleteResource(ctx context.Context, _ orcObjectPT, network *osclients.NetworkExt) ([]generic.ProgressStatus, error) {
 	return nil, actuator.osClient.DeleteNetwork(ctx, network.ID)
 }
 
@@ -160,7 +160,7 @@ func (actuator networkActuator) GetResourceReconcilers(ctx context.Context, orcO
 	}, nil
 }
 
-func (actuator networkActuator) updateTags(ctx context.Context, orcObject orcObjectPT, osResource *osclients.NetworkExt) ([]generic.WaitingOnEvent, error) {
+func (actuator networkActuator) updateTags(ctx context.Context, orcObject orcObjectPT, osResource *osclients.NetworkExt) ([]generic.ProgressStatus, error) {
 	resourceTagSet := set.New[string](osResource.Tags...)
 	objectTagSet := set.New[string]()
 	for i := range orcObject.Spec.Resource.Tags {
@@ -199,12 +199,12 @@ func (networkHelperFactory) NewAPIObjectAdapter(obj orcObjectPT) adapterI {
 	return networkAdapter{obj}
 }
 
-func (networkHelperFactory) NewCreateActuator(ctx context.Context, orcObject orcObjectPT, controller generic.ResourceController) ([]generic.WaitingOnEvent, createResourceActuator, error) {
+func (networkHelperFactory) NewCreateActuator(ctx context.Context, orcObject orcObjectPT, controller generic.ResourceController) ([]generic.ProgressStatus, createResourceActuator, error) {
 	actuator, err := newActuator(ctx, orcObject, controller)
 	return nil, actuator, err
 }
 
-func (networkHelperFactory) NewDeleteActuator(ctx context.Context, orcObject orcObjectPT, controller generic.ResourceController) ([]generic.WaitingOnEvent, deleteResourceActuator, error) {
+func (networkHelperFactory) NewDeleteActuator(ctx context.Context, orcObject orcObjectPT, controller generic.ResourceController) ([]generic.ProgressStatus, deleteResourceActuator, error) {
 	actuator, err := newActuator(ctx, orcObject, controller)
 	return nil, actuator, err
 }

--- a/internal/controllers/network/status.go
+++ b/internal/controllers/network/status.go
@@ -40,9 +40,8 @@ func (networkStatusWriter) GetApplyConfigConstructor() generic.ORCApplyConfigCon
 	return orcapplyconfigv1alpha1.Network
 }
 
-func (networkStatusWriter) GetCommonStatus(orcObject *orcv1alpha1.Network, osResource *osclients.NetworkExt) (bool, bool) {
-	available := osResource != nil && osResource.Status == NetworkStatusActive
-	return available, available
+func (networkStatusWriter) ResourceIsAvailable(orcObject *orcv1alpha1.Network, osResource *osclients.NetworkExt) bool {
+	return osResource != nil && osResource.Status == NetworkStatusActive
 }
 
 func (networkStatusWriter) ApplyResourceStatus(log logr.Logger, osResource *osclients.NetworkExt, statusApply *orcapplyconfigv1alpha1.NetworkStatusApplyConfiguration) {

--- a/internal/controllers/port/status.go
+++ b/internal/controllers/port/status.go
@@ -35,10 +35,9 @@ func (portStatusWriter) GetApplyConfigConstructor() generic.ORCApplyConfigConstr
 	return orcapplyconfigv1alpha1.Port
 }
 
-func (portStatusWriter) GetCommonStatus(_ orcObjectPT, osResource *osResourceT) (bool, bool) {
+func (portStatusWriter) ResourceIsAvailable(_ orcObjectPT, osResource *osResourceT) bool {
 	// A port is available as soon as it exists
-	available := osResource != nil
-	return available, available
+	return osResource != nil
 }
 
 func (portStatusWriter) ApplyResourceStatus(log logr.Logger, osResource *osResourceT, statusApply statusApplyPT) {

--- a/internal/controllers/router/actuator.go
+++ b/internal/controllers/router/actuator.go
@@ -88,14 +88,14 @@ func (actuator routerCreateActuator) ListOSResourcesForImport(ctx context.Contex
 	return actuator.osClient.ListRouter(ctx, listOpts)
 }
 
-func (actuator routerCreateActuator) CreateResource(ctx context.Context, obj *orcv1alpha1.Router) ([]generic.WaitingOnEvent, *routers.Router, error) {
+func (actuator routerCreateActuator) CreateResource(ctx context.Context, obj *orcv1alpha1.Router) ([]generic.ProgressStatus, *routers.Router, error) {
 	resource := obj.Spec.Resource
 	if resource == nil {
 		// Should have been caught by API validation
 		return nil, nil, orcerrors.Terminal(orcv1alpha1.ConditionReasonInvalidConfiguration, "Creation requested, but spec.resource is not set")
 	}
 
-	var waitEvents []generic.WaitingOnEvent
+	var waitEvents []generic.ProgressStatus
 
 	var gatewayInfo *routers.GatewayInfo
 	for name, result := range externalGWDep.GetDependencies(ctx, actuator.k8sClient, obj) {
@@ -149,7 +149,7 @@ func (actuator routerCreateActuator) CreateResource(ctx context.Context, obj *or
 	return nil, osResource, err
 }
 
-func (actuator routerActuator) DeleteResource(ctx context.Context, _ orcObjectPT, router *routers.Router) ([]generic.WaitingOnEvent, error) {
+func (actuator routerActuator) DeleteResource(ctx context.Context, _ orcObjectPT, router *routers.Router) ([]generic.ProgressStatus, error) {
 	return nil, actuator.osClient.DeleteRouter(ctx, router.ID)
 }
 
@@ -161,7 +161,7 @@ func (actuator routerActuator) GetResourceReconcilers(ctx context.Context, orcOb
 	}, nil
 }
 
-func (actuator routerActuator) updateTags(ctx context.Context, orcObject orcObjectPT, osResource *osResourceT) ([]generic.WaitingOnEvent, error) {
+func (actuator routerActuator) updateTags(ctx context.Context, orcObject orcObjectPT, osResource *osResourceT) ([]generic.ProgressStatus, error) {
 	resourceTagSet := set.New[string](osResource.Tags...)
 	objectTagSet := set.New[string]()
 	for i := range orcObject.Spec.Resource.Tags {
@@ -183,12 +183,12 @@ func (routerHelperFactory) NewAPIObjectAdapter(obj orcObjectPT) adapterI {
 	return routerAdapter{obj}
 }
 
-func (routerHelperFactory) NewCreateActuator(ctx context.Context, orcObject orcObjectPT, controller generic.ResourceController) ([]generic.WaitingOnEvent, createResourceActuator, error) {
+func (routerHelperFactory) NewCreateActuator(ctx context.Context, orcObject orcObjectPT, controller generic.ResourceController) ([]generic.ProgressStatus, createResourceActuator, error) {
 	actuator, err := newCreateActuator(ctx, orcObject, controller)
 	return nil, actuator, err
 }
 
-func (routerHelperFactory) NewDeleteActuator(ctx context.Context, orcObject orcObjectPT, controller generic.ResourceController) ([]generic.WaitingOnEvent, deleteResourceActuator, error) {
+func (routerHelperFactory) NewDeleteActuator(ctx context.Context, orcObject orcObjectPT, controller generic.ResourceController) ([]generic.ProgressStatus, deleteResourceActuator, error) {
 	actuator, err := newActuator(ctx, orcObject, controller)
 	return nil, actuator, err
 }

--- a/internal/controllers/router/status.go
+++ b/internal/controllers/router/status.go
@@ -38,9 +38,8 @@ func (routerStatusWriter) GetApplyConfigConstructor() generic.ORCApplyConfigCons
 	return orcapplyconfigv1alpha1.Router
 }
 
-func (routerStatusWriter) GetCommonStatus(orcObject orcObjectPT, osResource *osResourceT) (bool, bool) {
-	available := orcObject.Status.ID != nil && osResource != nil && osResource.Status == RouterStatusActive
-	return available, available
+func (routerStatusWriter) ResourceIsAvailable(orcObject orcObjectPT, osResource *osResourceT) bool {
+	return orcObject.Status.ID != nil && osResource != nil && osResource.Status == RouterStatusActive
 }
 
 func (routerStatusWriter) ApplyResourceStatus(log logr.Logger, osResource *osResourceT, statusApply statusApplyPT) {

--- a/internal/controllers/securitygroup/actuator_test.go
+++ b/internal/controllers/securitygroup/actuator_test.go
@@ -75,7 +75,7 @@ func Test_securityGroupActuator_updateRules(t *testing.T) {
 		orcObject  orcObjectPT
 		osResource *osResourceT
 		expect     func(*mock.MockNetworkClientMockRecorder)
-		wantEvents []generic.WaitingOnEvent
+		wantEvents []generic.ProgressStatus
 		wantErrs   []error
 	}{
 		{
@@ -115,7 +115,7 @@ func Test_securityGroupActuator_updateRules(t *testing.T) {
 				}
 				recorder.CreateSecGroupRules(gomock.Any(), []rules.CreateOpts{createOpts}).Return(nil, nil)
 			},
-			wantEvents: []generic.WaitingOnEvent{
+			wantEvents: []generic.ProgressStatus{
 				generic.WaitingOnOpenStackUpdate(time.Second),
 			},
 		},
@@ -164,7 +164,7 @@ func Test_securityGroupActuator_updateRules(t *testing.T) {
 			expect: func(recorder *mock.MockNetworkClientMockRecorder) {
 				recorder.DeleteSecGroupRule(gomock.Any(), ruleID).Return(nil)
 			},
-			wantEvents: []generic.WaitingOnEvent{
+			wantEvents: []generic.ProgressStatus{
 				generic.WaitingOnOpenStackUpdate(time.Second),
 			},
 		},
@@ -207,7 +207,7 @@ func Test_securityGroupActuator_updateRules(t *testing.T) {
 				recorder.CreateSecGroupRules(gomock.Any(), []rules.CreateOpts{createOpts}).Return(nil, nil)
 				recorder.DeleteSecGroupRule(gomock.Any(), ruleID).Return(nil)
 			},
-			wantEvents: []generic.WaitingOnEvent{
+			wantEvents: []generic.ProgressStatus{
 				generic.WaitingOnOpenStackUpdate(time.Second),
 			},
 		},
@@ -259,7 +259,7 @@ func Test_securityGroupActuator_updateRules(t *testing.T) {
 				}
 				recorder.CreateSecGroupRules(gomock.Any(), []rules.CreateOpts{createOpts}).Return(nil, nil)
 			},
-			wantEvents: []generic.WaitingOnEvent{
+			wantEvents: []generic.ProgressStatus{
 				generic.WaitingOnOpenStackUpdate(time.Second),
 			},
 		},
@@ -302,7 +302,7 @@ func Test_securityGroupActuator_updateRules(t *testing.T) {
 				recorder.CreateSecGroupRules(gomock.Any(), []rules.CreateOpts{createOpts}).Return(nil, createError)
 				recorder.DeleteSecGroupRule(gomock.Any(), ruleID).Return(nil)
 			},
-			wantEvents: []generic.WaitingOnEvent{
+			wantEvents: []generic.ProgressStatus{
 				generic.WaitingOnOpenStackUpdate(time.Second),
 			},
 			wantErrs: []error{createError},
@@ -357,7 +357,7 @@ func Test_securityGroupActuator_updateRules(t *testing.T) {
 				recorder.DeleteSecGroupRule(gomock.Any(), ruleID).Return(deleteError)
 				recorder.DeleteSecGroupRule(gomock.Any(), ruleID2).Return(nil)
 			},
-			wantEvents: []generic.WaitingOnEvent{
+			wantEvents: []generic.ProgressStatus{
 				generic.WaitingOnOpenStackUpdate(time.Second),
 			},
 			wantErrs: []error{deleteError},
@@ -401,7 +401,7 @@ func Test_securityGroupActuator_updateRules(t *testing.T) {
 				recorder.CreateSecGroupRules(gomock.Any(), []rules.CreateOpts{createOpts}).Return(nil, createError)
 				recorder.DeleteSecGroupRule(gomock.Any(), ruleID).Return(deleteError)
 			},
-			wantEvents: []generic.WaitingOnEvent{
+			wantEvents: []generic.ProgressStatus{
 				generic.WaitingOnOpenStackUpdate(time.Second),
 			},
 			wantErrs: []error{createError, deleteError},

--- a/internal/controllers/securitygroup/status.go
+++ b/internal/controllers/securitygroup/status.go
@@ -35,9 +35,8 @@ func (securityGroupStatusWriter) GetApplyConfigConstructor() generic.ORCApplyCon
 	return orcapplyconfigv1alpha1.SecurityGroup
 }
 
-func (securityGroupStatusWriter) GetCommonStatus(_ orcObjectPT, osResource *osResourceT) (bool, bool) {
-	available := osResource != nil
-	return available, available
+func (securityGroupStatusWriter) ResourceIsAvailable(_ orcObjectPT, osResource *osResourceT) bool {
+	return osResource != nil
 }
 
 func (securityGroupStatusWriter) ApplyResourceStatus(log logr.Logger, osResource *osResourceT, statusApply statusApplyPT) {

--- a/internal/controllers/server/actuator.go
+++ b/internal/controllers/server/actuator.go
@@ -85,14 +85,14 @@ func (actuator serverActuator) ListOSResourcesForImport(ctx context.Context, fil
 	return actuator.osClient.ListServers(ctx, listOpts)
 }
 
-func (actuator serverActuator) CreateResource(ctx context.Context, obj *orcv1alpha1.Server) ([]generic.WaitingOnEvent, *servers.Server, error) {
+func (actuator serverActuator) CreateResource(ctx context.Context, obj *orcv1alpha1.Server) ([]generic.ProgressStatus, *servers.Server, error) {
 	resource := obj.Spec.Resource
 	if resource == nil {
 		// Should have been caught by API validation
 		return nil, nil, orcerrors.Terminal(orcv1alpha1.ConditionReasonInvalidConfiguration, "Creation requested, but spec.resource is not set")
 	}
 
-	var waitEvents []generic.WaitingOnEvent
+	var waitEvents []generic.ProgressStatus
 
 	image := &orcv1alpha1.Image{}
 	{
@@ -195,7 +195,7 @@ func (actuator serverActuator) CreateResource(ctx context.Context, obj *orcv1alp
 	return nil, osResource, err
 }
 
-func (actuator serverActuator) DeleteResource(ctx context.Context, _ orcObjectPT, osResource *servers.Server) ([]generic.WaitingOnEvent, error) {
+func (actuator serverActuator) DeleteResource(ctx context.Context, _ orcObjectPT, osResource *servers.Server) ([]generic.ProgressStatus, error) {
 	return nil, actuator.osClient.DeleteServer(ctx, osResource.ID)
 }
 
@@ -207,10 +207,10 @@ func (actuator serverActuator) GetResourceReconcilers(ctx context.Context, orcOb
 	}, nil
 }
 
-func (serverActuator) checkStatus(ctx context.Context, orcObject orcObjectPT, osResource *osResourceT) ([]generic.WaitingOnEvent, error) {
+func (serverActuator) checkStatus(ctx context.Context, orcObject orcObjectPT, osResource *osResourceT) ([]generic.ProgressStatus, error) {
 	log := ctrl.LoggerFrom(ctx)
 
-	var waitEvents []generic.WaitingOnEvent
+	var waitEvents []generic.ProgressStatus
 	var err error
 
 	switch osResource.Status {
@@ -234,12 +234,12 @@ func (serverHelperFactory) NewAPIObjectAdapter(obj orcObjectPT) adapterI {
 	return serverAdapter{obj}
 }
 
-func (serverHelperFactory) NewCreateActuator(ctx context.Context, orcObject orcObjectPT, controller generic.ResourceController) ([]generic.WaitingOnEvent, createResourceActuator, error) {
+func (serverHelperFactory) NewCreateActuator(ctx context.Context, orcObject orcObjectPT, controller generic.ResourceController) ([]generic.ProgressStatus, createResourceActuator, error) {
 	actuator, err := newActuator(ctx, controller, orcObject)
 	return nil, actuator, err
 }
 
-func (serverHelperFactory) NewDeleteActuator(ctx context.Context, orcObject orcObjectPT, controller generic.ResourceController) ([]generic.WaitingOnEvent, deleteResourceActuator, error) {
+func (serverHelperFactory) NewDeleteActuator(ctx context.Context, orcObject orcObjectPT, controller generic.ResourceController) ([]generic.ProgressStatus, deleteResourceActuator, error) {
 	actuator, err := newActuator(ctx, controller, orcObject)
 	return nil, actuator, err
 }

--- a/internal/controllers/server/status.go
+++ b/internal/controllers/server/status.go
@@ -39,9 +39,8 @@ func (serverStatusWriter) GetApplyConfigConstructor() generic.ORCApplyConfigCons
 	return orcapplyconfigv1alpha1.Server
 }
 
-func (serverStatusWriter) GetCommonStatus(orcObject orcObjectPT, osResource *osResourceT) (bool, bool) {
-	available := orcObject.Status.ID != nil && osResource != nil && osResource.Status == ServerStatusActive
-	return available, available
+func (serverStatusWriter) ResourceIsAvailable(orcObject orcObjectPT, osResource *osResourceT) bool {
+	return orcObject.Status.ID != nil && osResource != nil && osResource.Status == ServerStatusActive
 }
 
 func (serverStatusWriter) ApplyResourceStatus(log logr.Logger, osResource *osResourceT, statusApply statusApplyPT) {

--- a/internal/controllers/subnet/status.go
+++ b/internal/controllers/subnet/status.go
@@ -34,10 +34,9 @@ func (subnetStatusWriter) GetApplyConfigConstructor() generic.ORCApplyConfigCons
 	return orcapplyconfigv1alpha1.Subnet
 }
 
-func (subnetStatusWriter) GetCommonStatus(orcObject orcObjectPT, osResource *osResourceT) (bool, bool) {
+func (subnetStatusWriter) ResourceIsAvailable(orcObject orcObjectPT, osResource *osResourceT) bool {
 	// Subnet is available as soon as it exists
-	available := osResource != nil
-	return available, available
+	return osResource != nil
 }
 
 func (subnetStatusWriter) ApplyResourceStatus(log logr.Logger, osResource *osResourceT, statusApply statusApplyPT) {


### PR DESCRIPTION
This change makes accurately reporting the Progressing condition easier
to understand and more consistent across controllers.

Several methods previously returned a slice of WaitingOnEvent.
WaitingOnEvent is renamed to ProgressStatus to reflect its use.
Returning a ProgressStatus indicates that some operation is incomplete
and we are expecting to be called again.

We pass this slice of ProgressStatus to the status writer. We no longer
pass a progressMessage, so ProgressStatus is now the only way to report
Progressing.

We update the logic setting Progressing so that it only considers any
returned error, and ProgressStatus.

Consequently, the GetCommonStatus method of ResourceStatusWriter is now
renamed to ResourceIsAvailable (and its signature updated), as it no
longer pretends to report Progressing.
