### PR TITLE
CI: Drop workaround creating almost identical resources

### DIFF
--- a/internal/controllers/flavor/tests/import-error/00-create-flavors.yaml
+++ b/internal/controllers/flavor/tests/import-error/00-create-flavors.yaml
@@ -9,7 +9,6 @@ spec:
     secretName: openstack-clouds
   managementPolicy: managed
   resource:
-    name: import-error-external-1
     ram: 22
     vcpus: 23
     disk: 24
@@ -24,9 +23,6 @@ spec:
     secretName: openstack-clouds
   managementPolicy: managed
   resource:
-    # FIXME: name shouldn't be necessary
-    # https://github.com/k-orc/openstack-resource-controller/issues/185
-    name: import-error-external-2
     ram: 22
     vcpus: 23
     disk: 24


### PR DESCRIPTION
Drop the workaround for #185. We no longer need to specify a name in the spec to differentiate the resources.