### PR TITLE
DRY updatetags reconciler

### DIFF
--- a/internal/controllers/port/actuator.go
+++ b/internal/controllers/port/actuator.go
@@ -21,11 +21,9 @@ import (
 	"fmt"
 	"iter"
 
-	"github.com/gophercloud/gophercloud/v2/openstack/networking/v2/extensions/attributestags"
 	"github.com/gophercloud/gophercloud/v2/openstack/networking/v2/ports"
 	apierrors "k8s.io/apimachinery/pkg/api/errors"
 	"k8s.io/utils/ptr"
-	"k8s.io/utils/set"
 	ctrl "sigs.k8s.io/controller-runtime"
 	"sigs.k8s.io/controller-runtime/pkg/client"
 
@@ -189,22 +187,8 @@ var _ reconcileResourceActuator = portActuator{}
 
 func (actuator portActuator) GetResourceReconcilers(ctx context.Context, orcObject orcObjectPT, osResource *osResourceT, controller generic.ResourceController) ([]resourceReconciler, error) {
 	return []resourceReconciler{
-		actuator.updateTags,
+		neutrontags.ReconcileTags[orcObjectPT, osResourceT](actuator.osClient, "ports", osResource.ID, orcObject.Spec.Resource.Tags, osResource.Tags),
 	}, nil
-}
-
-func (actuator portActuator) updateTags(ctx context.Context, orcObject orcObjectPT, osResource *osResourceT) ([]generic.ProgressStatus, error) {
-	resourceTagSet := set.New[string](osResource.Tags...)
-	objectTagSet := set.New[string]()
-	for i := range orcObject.Spec.Resource.Tags {
-		objectTagSet.Insert(string(orcObject.Spec.Resource.Tags[i]))
-	}
-	var err error
-	if !objectTagSet.Equal(resourceTagSet) {
-		opts := attributestags.ReplaceAllOpts{Tags: objectTagSet.SortedList()}
-		_, err = actuator.osClient.ReplaceAllAttributesTags(ctx, "ports", osResource.ID, &opts)
-	}
-	return nil, err
 }
 
 type portHelperFactory struct{}


### PR DESCRIPTION
All neutron controllers had an almost identical reconciler for setting
and updating tags. We replace them all with a common implementation.
