### PR TITLE
CI: Make it possible to use a cacert for openstack creds

### DIFF
--- a/hack/e2e.sh
+++ b/hack/e2e.sh
@@ -6,6 +6,15 @@ set -euo pipefail
 # Exported because it is referenced in kuttl tests.
 export E2E_OSCLOUDS=${E2E_OSCLOUDS:-/etc/openstack/clouds.yaml}
 
+# Path to a cacert file to use to connect to OpenStack.
+E2E_CACERT=${E2E_CACERT:-}
+
+E2E_CACERT_OPT=
+if [ -n "$E2E_CACERT" ]; then
+    export E2E_CACERT_OPT="--from-file=cacert=${E2E_CACERT}"
+fi
+export E2E_CACERT_OPT
+
 # Run kuttl tests from a specific directory.
 # Defaults to empty string (all discovered kuttl directories)
 E2E_KUTTL_DIR=${E2E_KUTTL_DIR:-}

--- a/internal/controllers/flavor/tests/create-full/00-secret.yaml
+++ b/internal/controllers/flavor/tests/create-full/00-secret.yaml
@@ -1,5 +1,5 @@
 apiVersion: kuttl.dev/v1beta1
 kind: TestStep
 commands:
-  - command: kubectl create secret generic openstack-clouds --from-file=clouds.yaml=${E2E_OSCLOUDS}
+  - command: kubectl create secret generic openstack-clouds --from-file=clouds.yaml=${E2E_OSCLOUDS} ${E2E_CACERT_OPT}
     namespaced: true

--- a/internal/controllers/flavor/tests/create-minimal/00-secret.yaml
+++ b/internal/controllers/flavor/tests/create-minimal/00-secret.yaml
@@ -1,5 +1,5 @@
 apiVersion: kuttl.dev/v1beta1
 kind: TestStep
 commands:
-  - command: kubectl create secret generic openstack-clouds --from-file=clouds.yaml=${E2E_OSCLOUDS}
+  - command: kubectl create secret generic openstack-clouds --from-file=clouds.yaml=${E2E_OSCLOUDS} ${E2E_CACERT_OPT}
     namespaced: true

--- a/internal/controllers/flavor/tests/import-error/00-secret.yaml
+++ b/internal/controllers/flavor/tests/import-error/00-secret.yaml
@@ -1,5 +1,5 @@
 apiVersion: kuttl.dev/v1beta1
 kind: TestStep
 commands:
-  - command: kubectl create secret generic openstack-clouds --from-file=clouds.yaml=${E2E_OSCLOUDS}
+  - command: kubectl create secret generic openstack-clouds --from-file=clouds.yaml=${E2E_OSCLOUDS} ${E2E_CACERT_OPT}
     namespaced: true

--- a/internal/controllers/flavor/tests/import/00-secret.yaml
+++ b/internal/controllers/flavor/tests/import/00-secret.yaml
@@ -1,5 +1,5 @@
 apiVersion: kuttl.dev/v1beta1
 kind: TestStep
 commands:
-  - command: kubectl create secret generic openstack-clouds --from-file=clouds.yaml=${E2E_OSCLOUDS}
+  - command: kubectl create secret generic openstack-clouds --from-file=clouds.yaml=${E2E_OSCLOUDS} ${E2E_CACERT_OPT}
     namespaced: true

--- a/internal/controllers/subnet/tests/create-full-v4/00-secret.yaml
+++ b/internal/controllers/subnet/tests/create-full-v4/00-secret.yaml
@@ -1,5 +1,5 @@
 apiVersion: kuttl.dev/v1beta1
 kind: TestStep
 commands:
-  - command: kubectl create secret generic openstack-clouds --from-file=clouds.yaml=${E2E_OSCLOUDS}
+  - command: kubectl create secret generic openstack-clouds --from-file=clouds.yaml=${E2E_OSCLOUDS} ${E2E_CACERT_OPT}
     namespaced: true

--- a/internal/controllers/subnet/tests/create-full-v6/00-secret.yaml
+++ b/internal/controllers/subnet/tests/create-full-v6/00-secret.yaml
@@ -1,5 +1,5 @@
 apiVersion: kuttl.dev/v1beta1
 kind: TestStep
 commands:
-  - command: kubectl create secret generic openstack-clouds --from-file=clouds.yaml=${E2E_OSCLOUDS}
+  - command: kubectl create secret generic openstack-clouds --from-file=clouds.yaml=${E2E_OSCLOUDS} ${E2E_CACERT_OPT}
     namespaced: true

--- a/internal/controllers/subnet/tests/create-minimal-v4/00-secret.yaml
+++ b/internal/controllers/subnet/tests/create-minimal-v4/00-secret.yaml
@@ -1,5 +1,5 @@
 apiVersion: kuttl.dev/v1beta1
 kind: TestStep
 commands:
-  - command: kubectl create secret generic openstack-clouds --from-file=clouds.yaml=${E2E_OSCLOUDS}
+  - command: kubectl create secret generic openstack-clouds --from-file=clouds.yaml=${E2E_OSCLOUDS} ${E2E_CACERT_OPT}
     namespaced: true

--- a/internal/controllers/subnet/tests/create-minimal-v6/00-secret.yaml
+++ b/internal/controllers/subnet/tests/create-minimal-v6/00-secret.yaml
@@ -1,5 +1,5 @@
 apiVersion: kuttl.dev/v1beta1
 kind: TestStep
 commands:
-  - command: kubectl create secret generic openstack-clouds --from-file=clouds.yaml=${E2E_OSCLOUDS}
+  - command: kubectl create secret generic openstack-clouds --from-file=clouds.yaml=${E2E_OSCLOUDS} ${E2E_CACERT_OPT}
     namespaced: true

--- a/internal/controllers/subnet/tests/dependency/00-secret.yaml
+++ b/internal/controllers/subnet/tests/dependency/00-secret.yaml
@@ -1,5 +1,5 @@
 apiVersion: kuttl.dev/v1beta1
 kind: TestStep
 commands:
-  - command: kubectl create secret generic openstack-clouds --from-file=clouds.yaml=${E2E_OSCLOUDS}
+  - command: kubectl create secret generic openstack-clouds --from-file=clouds.yaml=${E2E_OSCLOUDS} ${E2E_CACERT_OPT}
     namespaced: true

--- a/internal/controllers/subnet/tests/import-error/00-secret.yaml
+++ b/internal/controllers/subnet/tests/import-error/00-secret.yaml
@@ -1,5 +1,5 @@
 apiVersion: kuttl.dev/v1beta1
 kind: TestStep
 commands:
-  - command: kubectl create secret generic openstack-clouds --from-file=clouds.yaml=${E2E_OSCLOUDS}
+  - command: kubectl create secret generic openstack-clouds --from-file=clouds.yaml=${E2E_OSCLOUDS} ${E2E_CACERT_OPT}
     namespaced: true

--- a/internal/controllers/subnet/tests/import/00-secret.yaml
+++ b/internal/controllers/subnet/tests/import/00-secret.yaml
@@ -1,5 +1,5 @@
 apiVersion: kuttl.dev/v1beta1
 kind: TestStep
 commands:
-  - command: kubectl create secret generic openstack-clouds --from-file=clouds.yaml=${E2E_OSCLOUDS}
+  - command: kubectl create secret generic openstack-clouds --from-file=clouds.yaml=${E2E_OSCLOUDS} ${E2E_CACERT_OPT}
     namespaced: true


### PR DESCRIPTION
Set the `E2E_CACERT` environment variable to the path of the CA cert to use before running `make test-e2e`.

Fix #206