### PR TITLE
CI: Allows to override cloud names in tests

### DIFF
--- a/hack/e2e.sh
+++ b/hack/e2e.sh
@@ -3,17 +3,18 @@
 set -euo pipefail
 
 # Path to a clouds.yaml to use for e2e tests.
-# Exported because it is referenced in kuttl tests.
-export E2E_OSCLOUDS=${E2E_OSCLOUDS:-/etc/openstack/clouds.yaml}
+E2E_OSCLOUDS=${E2E_OSCLOUDS:-/etc/openstack/clouds.yaml}
 
 # Path to a cacert file to use to connect to OpenStack.
 E2E_CACERT=${E2E_CACERT:-}
-
-E2E_CACERT_OPT=
+E2E_KUTTL_CACERT_OPT=
 if [ -n "$E2E_CACERT" ]; then
-    export E2E_CACERT_OPT="--from-file=cacert=${E2E_CACERT}"
+    E2E_KUTTL_CACERT_OPT="--from-file=cacert=${E2E_CACERT}"
 fi
-export E2E_CACERT_OPT
+
+# Export variables referenced in kuttl tests.
+export E2E_KUTTL_OSCLOUDS
+export E2E_KUTTL_CACERT_OPT
 
 # Run kuttl tests from a specific directory.
 # Defaults to empty string (all discovered kuttl directories)

--- a/hack/e2e.sh
+++ b/hack/e2e.sh
@@ -12,10 +12,6 @@ if [ -n "$E2E_CACERT" ]; then
     E2E_KUTTL_CACERT_OPT="--from-file=cacert=${E2E_CACERT}"
 fi
 
-# Export variables referenced in kuttl tests.
-export E2E_KUTTL_OSCLOUDS
-export E2E_KUTTL_CACERT_OPT
-
 # Run kuttl tests from a specific directory.
 # Defaults to empty string (all discovered kuttl directories)
 E2E_KUTTL_DIR=${E2E_KUTTL_DIR:-}
@@ -26,6 +22,36 @@ E2E_KUTTL_TEST=${E2E_KUTTL_TEST:-}
 
 # Define a custom external network
 export E2E_EXTERNAL_NETWORK_NAME=${E2E_EXTERNAL_NETWORK_NAME:-private}
+
+creds_dir=$(mktemp -d)
+
+function logresources() {
+    # Log all resources if exiting with an error
+    if [ $? != 0 ]; then
+        kubectl get openstack -o yaml -A
+    fi
+}
+
+function cleanup() {
+    # logresources must be called first as it checks the exit code
+    logresources
+    rm -rf -- "$creds_dir"
+}
+
+trap cleanup EXIT
+
+# Export variables referenced in kuttl tests.
+export E2E_KUTTL_OSCLOUDS="${creds_dir}/clouds.yaml"
+export E2E_KUTTL_CACERT_OPT
+
+# Name of the openstack credentials to use from the E2E_OSCLOUDS file
+E2E_OPENSTACK_CLOUD_NAME=${E2E_OPENSTACK_CLOUD_NAME:-devstack}
+# Name of the openstack admin credentials to use from the E2E_OSCLOUDS file
+E2E_OPENSTACK_ADMIN_CLOUD_NAME=${E2E_OPENSTACK_ADMIN_CLOUD_NAME:-"devstack-admin-demo"}
+
+cp "${E2E_OSCLOUDS}" "${E2E_KUTTL_OSCLOUDS}"
+sed -r -i "s/^(\s+)${E2E_OPENSTACK_CLOUD_NAME}:/\1openstack:/g" "${E2E_KUTTL_OSCLOUDS}"
+sed -r -i "s/^(\s+)${E2E_OPENSTACK_ADMIN_CLOUD_NAME}:/\1openstack-admin:/g" "${E2E_KUTTL_OSCLOUDS}"
 
 kubectl kuttl test $E2E_KUTTL_DIR --test "$E2E_KUTTL_TEST"
 
@@ -38,14 +64,6 @@ cd examples
 sed "s/  devstack:/  openstack:/g" /etc/openstack/clouds.yaml > local-config/clouds.yaml
 envsubst < local-config/external-network-filter.yaml.example > local-config/external-network-filter.yaml
 make local-config
-
-function logresources() {
-    # Log all resources if exiting with an error
-    if [ $? != 0 ]; then
-        kubectl get openstack -o yaml -A
-    fi
-}
-trap logresources EXIT
 
 # Apply the cirros server example and wait for the server to be available
 kubectl apply -k apply/cirros --server-side

--- a/internal/controllers/flavor/tests/create-full/00-flavor.yaml
+++ b/internal/controllers/flavor/tests/create-full/00-flavor.yaml
@@ -5,7 +5,7 @@ metadata:
   name: create-full
 spec:
   cloudCredentialsRef:
-    cloudName: devstack-admin-demo
+    cloudName: openstack-admin
     secretName: openstack-clouds
   managementPolicy: managed
   resource:

--- a/internal/controllers/flavor/tests/create-full/00-secret.yaml
+++ b/internal/controllers/flavor/tests/create-full/00-secret.yaml
@@ -1,5 +1,5 @@
 apiVersion: kuttl.dev/v1beta1
 kind: TestStep
 commands:
-  - command: kubectl create secret generic openstack-clouds --from-file=clouds.yaml=${E2E_OSCLOUDS} ${E2E_CACERT_OPT}
+  - command: kubectl create secret generic openstack-clouds --from-file=clouds.yaml=${E2E_KUTTL_OSCLOUDS} ${E2E_KUTTL_CACERT_OPT}
     namespaced: true

--- a/internal/controllers/flavor/tests/create-minimal/00-flavor.yaml
+++ b/internal/controllers/flavor/tests/create-minimal/00-flavor.yaml
@@ -5,7 +5,7 @@ metadata:
   name: create-minimal
 spec:
   cloudCredentialsRef:
-    cloudName: devstack-admin-demo
+    cloudName: openstack-admin
     secretName: openstack-clouds
   managementPolicy: managed
   resource:

--- a/internal/controllers/flavor/tests/create-minimal/00-secret.yaml
+++ b/internal/controllers/flavor/tests/create-minimal/00-secret.yaml
@@ -1,5 +1,5 @@
 apiVersion: kuttl.dev/v1beta1
 kind: TestStep
 commands:
-  - command: kubectl create secret generic openstack-clouds --from-file=clouds.yaml=${E2E_OSCLOUDS} ${E2E_CACERT_OPT}
+  - command: kubectl create secret generic openstack-clouds --from-file=clouds.yaml=${E2E_KUTTL_OSCLOUDS} ${E2E_KUTTL_CACERT_OPT}
     namespaced: true

--- a/internal/controllers/flavor/tests/import-error/00-create-flavors.yaml
+++ b/internal/controllers/flavor/tests/import-error/00-create-flavors.yaml
@@ -5,7 +5,7 @@ metadata:
   name: import-error-external-1
 spec:
   cloudCredentialsRef:
-    cloudName: devstack-admin-demo
+    cloudName: openstack-admin
     secretName: openstack-clouds
   managementPolicy: managed
   resource:
@@ -19,7 +19,7 @@ metadata:
   name: import-error-external-2
 spec:
   cloudCredentialsRef:
-    cloudName: devstack-admin-demo
+    cloudName: openstack-admin
     secretName: openstack-clouds
   managementPolicy: managed
   resource:

--- a/internal/controllers/flavor/tests/import-error/00-secret.yaml
+++ b/internal/controllers/flavor/tests/import-error/00-secret.yaml
@@ -1,5 +1,5 @@
 apiVersion: kuttl.dev/v1beta1
 kind: TestStep
 commands:
-  - command: kubectl create secret generic openstack-clouds --from-file=clouds.yaml=${E2E_OSCLOUDS} ${E2E_CACERT_OPT}
+  - command: kubectl create secret generic openstack-clouds --from-file=clouds.yaml=${E2E_KUTTL_OSCLOUDS} ${E2E_KUTTL_CACERT_OPT}
     namespaced: true

--- a/internal/controllers/flavor/tests/import-error/01-import-flavor.yaml
+++ b/internal/controllers/flavor/tests/import-error/01-import-flavor.yaml
@@ -6,7 +6,7 @@ metadata:
 spec:
   cloudCredentialsRef:
     # Import does not require admin creds
-    cloudName: devstack
+    cloudName: openstack
     secretName: openstack-clouds
   managementPolicy: unmanaged
   import:

--- a/internal/controllers/flavor/tests/import/00-import-flavor.yaml
+++ b/internal/controllers/flavor/tests/import/00-import-flavor.yaml
@@ -6,7 +6,7 @@ metadata:
 spec:
   cloudCredentialsRef:
     # Import does not require admin creds
-    cloudName: devstack
+    cloudName: openstack
     secretName: openstack-clouds
   managementPolicy: unmanaged
   import:

--- a/internal/controllers/flavor/tests/import/00-secret.yaml
+++ b/internal/controllers/flavor/tests/import/00-secret.yaml
@@ -1,5 +1,5 @@
 apiVersion: kuttl.dev/v1beta1
 kind: TestStep
 commands:
-  - command: kubectl create secret generic openstack-clouds --from-file=clouds.yaml=${E2E_OSCLOUDS} ${E2E_CACERT_OPT}
+  - command: kubectl create secret generic openstack-clouds --from-file=clouds.yaml=${E2E_KUTTL_OSCLOUDS} ${E2E_KUTTL_CACERT_OPT}
     namespaced: true

--- a/internal/controllers/flavor/tests/import/01-create-flavor.yaml
+++ b/internal/controllers/flavor/tests/import/01-create-flavor.yaml
@@ -5,7 +5,7 @@ metadata:
   name: import-external
 spec:
   cloudCredentialsRef:
-    cloudName: devstack-admin-demo
+    cloudName: openstack-admin
     secretName: openstack-clouds
   managementPolicy: managed
   resource:

--- a/internal/controllers/subnet/tests/create-full-v4/00-secret.yaml
+++ b/internal/controllers/subnet/tests/create-full-v4/00-secret.yaml
@@ -1,5 +1,5 @@
 apiVersion: kuttl.dev/v1beta1
 kind: TestStep
 commands:
-  - command: kubectl create secret generic openstack-clouds --from-file=clouds.yaml=${E2E_OSCLOUDS} ${E2E_CACERT_OPT}
+  - command: kubectl create secret generic openstack-clouds --from-file=clouds.yaml=${E2E_KUTTL_OSCLOUDS} ${E2E_KUTTL_CACERT_OPT}
     namespaced: true

--- a/internal/controllers/subnet/tests/create-full-v4/00-subnet.yaml
+++ b/internal/controllers/subnet/tests/create-full-v4/00-subnet.yaml
@@ -4,7 +4,7 @@ metadata:
   name: create-full-v4
 spec:
   cloudCredentialsRef:
-    cloudName: devstack
+    cloudName: openstack
     secretName: openstack-clouds
   managementPolicy: managed
   resource:
@@ -16,7 +16,7 @@ metadata:
   name: create-full-v4-gateway
 spec:
   cloudCredentialsRef:
-    cloudName: devstack-admin-demo
+    cloudName: openstack-admin
     secretName: openstack-clouds
   managementPolicy: managed
   resource:
@@ -28,7 +28,7 @@ metadata:
   name: create-full-v4-gateway
 spec:
   cloudCredentialsRef:
-    cloudName: devstack
+    cloudName: openstack
     secretName: openstack-clouds
   managementPolicy: managed
   networkRef: create-full-v4-gateway
@@ -42,7 +42,7 @@ metadata:
   name: create-full-v4
 spec:
   cloudCredentialsRef:
-    cloudName: devstack
+    cloudName: openstack
     secretName: openstack-clouds
   managementPolicy: managed
   resource:
@@ -55,7 +55,7 @@ metadata:
   name: create-full-v4
 spec:
   cloudCredentialsRef:
-    cloudName: devstack
+    cloudName: openstack
     secretName: openstack-clouds
   managementPolicy: managed
   networkRef: create-full-v4

--- a/internal/controllers/subnet/tests/create-full-v6/00-secret.yaml
+++ b/internal/controllers/subnet/tests/create-full-v6/00-secret.yaml
@@ -1,5 +1,5 @@
 apiVersion: kuttl.dev/v1beta1
 kind: TestStep
 commands:
-  - command: kubectl create secret generic openstack-clouds --from-file=clouds.yaml=${E2E_OSCLOUDS} ${E2E_CACERT_OPT}
+  - command: kubectl create secret generic openstack-clouds --from-file=clouds.yaml=${E2E_KUTTL_OSCLOUDS} ${E2E_KUTTL_CACERT_OPT}
     namespaced: true

--- a/internal/controllers/subnet/tests/create-full-v6/00-subnet.yaml
+++ b/internal/controllers/subnet/tests/create-full-v6/00-subnet.yaml
@@ -4,7 +4,7 @@ metadata:
   name: create-full-v6
 spec:
   cloudCredentialsRef:
-    cloudName: devstack
+    cloudName: openstack
     secretName: openstack-clouds
   managementPolicy: managed
   resource:
@@ -16,7 +16,7 @@ metadata:
   name: create-full-v6-gateway
 spec:
   cloudCredentialsRef:
-    cloudName: devstack-admin-demo
+    cloudName: openstack-admin
     secretName: openstack-clouds
   managementPolicy: managed
   resource:
@@ -28,7 +28,7 @@ metadata:
   name: create-full-v6-gateway
 spec:
   cloudCredentialsRef:
-    cloudName: devstack
+    cloudName: openstack
     secretName: openstack-clouds
   managementPolicy: managed
   networkRef: create-full-v6-gateway
@@ -42,7 +42,7 @@ metadata:
   name: create-full-v6
 spec:
   cloudCredentialsRef:
-    cloudName: devstack
+    cloudName: openstack
     secretName: openstack-clouds
   managementPolicy: managed
   resource:
@@ -55,7 +55,7 @@ metadata:
   name: create-full-v6
 spec:
   cloudCredentialsRef:
-    cloudName: devstack
+    cloudName: openstack
     secretName: openstack-clouds
   managementPolicy: managed
   networkRef: create-full-v6

--- a/internal/controllers/subnet/tests/create-minimal-v4/00-secret.yaml
+++ b/internal/controllers/subnet/tests/create-minimal-v4/00-secret.yaml
@@ -1,5 +1,5 @@
 apiVersion: kuttl.dev/v1beta1
 kind: TestStep
 commands:
-  - command: kubectl create secret generic openstack-clouds --from-file=clouds.yaml=${E2E_OSCLOUDS} ${E2E_CACERT_OPT}
+  - command: kubectl create secret generic openstack-clouds --from-file=clouds.yaml=${E2E_KUTTL_OSCLOUDS} ${E2E_KUTTL_CACERT_OPT}
     namespaced: true

--- a/internal/controllers/subnet/tests/create-minimal-v4/00-subnet.yaml
+++ b/internal/controllers/subnet/tests/create-minimal-v4/00-subnet.yaml
@@ -4,7 +4,7 @@ metadata:
   name: create-minimal-v4
 spec:
   cloudCredentialsRef:
-    cloudName: devstack
+    cloudName: openstack
     secretName: openstack-clouds
   managementPolicy: managed
   resource:
@@ -16,7 +16,7 @@ metadata:
   name: create-minimal-v4
 spec:
   cloudCredentialsRef:
-    cloudName: devstack
+    cloudName: openstack
     secretName: openstack-clouds
   managementPolicy: managed
   networkRef: create-minimal-v4

--- a/internal/controllers/subnet/tests/create-minimal-v6/00-secret.yaml
+++ b/internal/controllers/subnet/tests/create-minimal-v6/00-secret.yaml
@@ -1,5 +1,5 @@
 apiVersion: kuttl.dev/v1beta1
 kind: TestStep
 commands:
-  - command: kubectl create secret generic openstack-clouds --from-file=clouds.yaml=${E2E_OSCLOUDS} ${E2E_CACERT_OPT}
+  - command: kubectl create secret generic openstack-clouds --from-file=clouds.yaml=${E2E_KUTTL_OSCLOUDS} ${E2E_KUTTL_CACERT_OPT}
     namespaced: true

--- a/internal/controllers/subnet/tests/create-minimal-v6/00-subnet.yaml
+++ b/internal/controllers/subnet/tests/create-minimal-v6/00-subnet.yaml
@@ -4,7 +4,7 @@ metadata:
   name: create-minimal-v6
 spec:
   cloudCredentialsRef:
-    cloudName: devstack
+    cloudName: openstack
     secretName: openstack-clouds
   managementPolicy: managed
   resource:
@@ -16,7 +16,7 @@ metadata:
   name: create-minimal-v6
 spec:
   cloudCredentialsRef:
-    cloudName: devstack
+    cloudName: openstack
     secretName: openstack-clouds
   managementPolicy: managed
   networkRef: create-minimal-v6

--- a/internal/controllers/subnet/tests/dependency/00-create-subnet.yaml
+++ b/internal/controllers/subnet/tests/dependency/00-create-subnet.yaml
@@ -5,7 +5,7 @@ metadata:
   name: dependency
 spec:
   cloudCredentialsRef:
-    cloudName: devstack
+    cloudName: openstack
     secretName: openstack-clouds
   managementPolicy: managed
   networkRef: dependency

--- a/internal/controllers/subnet/tests/dependency/00-secret.yaml
+++ b/internal/controllers/subnet/tests/dependency/00-secret.yaml
@@ -1,5 +1,5 @@
 apiVersion: kuttl.dev/v1beta1
 kind: TestStep
 commands:
-  - command: kubectl create secret generic openstack-clouds --from-file=clouds.yaml=${E2E_OSCLOUDS} ${E2E_CACERT_OPT}
+  - command: kubectl create secret generic openstack-clouds --from-file=clouds.yaml=${E2E_KUTTL_OSCLOUDS} ${E2E_KUTTL_CACERT_OPT}
     namespaced: true

--- a/internal/controllers/subnet/tests/dependency/01-create-network.yaml
+++ b/internal/controllers/subnet/tests/dependency/01-create-network.yaml
@@ -4,7 +4,7 @@ metadata:
   name: dependency
 spec:
   cloudCredentialsRef:
-    cloudName: devstack
+    cloudName: openstack
     secretName: openstack-clouds
   managementPolicy: managed
   resource:

--- a/internal/controllers/subnet/tests/import-error/00-create-network.yaml
+++ b/internal/controllers/subnet/tests/import-error/00-create-network.yaml
@@ -4,7 +4,7 @@ metadata:
   name: import-error
 spec:
   cloudCredentialsRef:
-    cloudName: devstack
+    cloudName: openstack
     secretName: openstack-clouds
   managementPolicy: managed
   resource:

--- a/internal/controllers/subnet/tests/import-error/00-create-subnets.yaml
+++ b/internal/controllers/subnet/tests/import-error/00-create-subnets.yaml
@@ -5,7 +5,7 @@ metadata:
   name: import-error-external-1
 spec:
   cloudCredentialsRef:
-    cloudName: devstack
+    cloudName: openstack
     secretName: openstack-clouds
   managementPolicy: managed
   networkRef: import-error
@@ -20,7 +20,7 @@ metadata:
   name: import-error-external-2
 spec:
   cloudCredentialsRef:
-    cloudName: devstack
+    cloudName: openstack
     secretName: openstack-clouds
   managementPolicy: managed
   networkRef: import-error

--- a/internal/controllers/subnet/tests/import-error/00-secret.yaml
+++ b/internal/controllers/subnet/tests/import-error/00-secret.yaml
@@ -1,5 +1,5 @@
 apiVersion: kuttl.dev/v1beta1
 kind: TestStep
 commands:
-  - command: kubectl create secret generic openstack-clouds --from-file=clouds.yaml=${E2E_OSCLOUDS} ${E2E_CACERT_OPT}
+  - command: kubectl create secret generic openstack-clouds --from-file=clouds.yaml=${E2E_KUTTL_OSCLOUDS} ${E2E_KUTTL_CACERT_OPT}
     namespaced: true

--- a/internal/controllers/subnet/tests/import-error/01-import-subnet.yaml
+++ b/internal/controllers/subnet/tests/import-error/01-import-subnet.yaml
@@ -5,7 +5,7 @@ metadata:
   name: import-error
 spec:
   cloudCredentialsRef:
-    cloudName: devstack
+    cloudName: openstack
     secretName: openstack-clouds
   managementPolicy: unmanaged
   networkRef: import-error

--- a/internal/controllers/subnet/tests/import/00-create-network.yaml
+++ b/internal/controllers/subnet/tests/import/00-create-network.yaml
@@ -4,7 +4,7 @@ metadata:
   name: import
 spec:
   cloudCredentialsRef:
-    cloudName: devstack
+    cloudName: openstack
     secretName: openstack-clouds
   managementPolicy: managed
   resource:

--- a/internal/controllers/subnet/tests/import/00-import-subnet.yaml
+++ b/internal/controllers/subnet/tests/import/00-import-subnet.yaml
@@ -5,7 +5,7 @@ metadata:
   name: import
 spec:
   cloudCredentialsRef:
-    cloudName: devstack
+    cloudName: openstack
     secretName: openstack-clouds
   managementPolicy: unmanaged
   networkRef: import

--- a/internal/controllers/subnet/tests/import/00-secret.yaml
+++ b/internal/controllers/subnet/tests/import/00-secret.yaml
@@ -1,5 +1,5 @@
 apiVersion: kuttl.dev/v1beta1
 kind: TestStep
 commands:
-  - command: kubectl create secret generic openstack-clouds --from-file=clouds.yaml=${E2E_OSCLOUDS} ${E2E_CACERT_OPT}
+  - command: kubectl create secret generic openstack-clouds --from-file=clouds.yaml=${E2E_KUTTL_OSCLOUDS} ${E2E_KUTTL_CACERT_OPT}
     namespaced: true

--- a/internal/controllers/subnet/tests/import/01-create-subnet.yaml
+++ b/internal/controllers/subnet/tests/import/01-create-subnet.yaml
@@ -5,7 +5,7 @@ metadata:
   name: import-external
 spec:
   cloudCredentialsRef:
-    cloudName: devstack
+    cloudName: openstack
     secretName: openstack-clouds
   managementPolicy: managed
   networkRef: import


### PR DESCRIPTION
We can now export the `E2E_OPENSTACK_CLOUD_NAME` and
`E2E_OPENSTACK_ADMIN_CLOUD_NAME` variables to override the default
credentials to use for tenant and admin operations during tests.

These default to `devstack` and `devstack-admin-demo` respectively.

Fixes https://github.com/k-orc/openstack-resource-controller/issues/207