### PR TITLE
examples: Import and use the default security group

### DIFF
--- a/examples/bases/cirros/port.yaml
+++ b/examples/bases/cirros/port.yaml
@@ -14,5 +14,6 @@ spec:
     - orc-test
     securityGroupRefs:
     - allow-ssh
+    - default
     addresses:
     - subnetRef: external-subnet-ipv4

--- a/examples/bases/devstack/port.yaml
+++ b/examples/bases/devstack/port.yaml
@@ -15,5 +15,6 @@ spec:
     securityGroupRefs:
     - allow-ssh
     - devstack
+    - default
     addresses:
     - subnetRef: external-subnet-ipv4

--- a/examples/bases/local-config-ref/kustomization.yaml
+++ b/examples/bases/local-config-ref/kustomization.yaml
@@ -30,3 +30,10 @@ patches:
     - op: add
       path: /metadata/annotations/config.kubernetes.io~1local-config
       value: "true"
+- target:
+    kind: SecurityGroup
+    name: default
+  patch: |-
+    - op: add
+      path: /metadata/annotations/config.kubernetes.io~1local-config
+      value: "true"

--- a/examples/local-config/kustomization.yaml
+++ b/examples/local-config/kustomization.yaml
@@ -3,6 +3,7 @@ kind: Kustomization
 
 resources:
 - external-network.yaml
+- securitygroup.yaml
 
 patches:
 - path: external-network-filter.yaml

--- a/examples/local-config/securitygroup.yaml
+++ b/examples/local-config/securitygroup.yaml
@@ -1,0 +1,13 @@
+---
+apiVersion: openstack.k-orc.cloud/v1alpha1
+kind: SecurityGroup
+metadata:
+  name: default
+spec:
+  cloudCredentialsRef:
+    cloudName: openstack
+    secretName: cloud-config
+  managementPolicy: unmanaged
+  import:
+    filter:
+      name: default


### PR DESCRIPTION
Fixes issue of no networking in cirros and devstack examples.
