### PR TITLE
Fix controller-runtime warning when DeleteResource returns error

### DIFF
--- a/internal/controllers/generic/controller.go
+++ b/internal/controllers/generic/controller.go
@@ -280,5 +280,8 @@ func (c *Controller[
 	}
 
 	deleted, progressStatus, osResource, err = DeleteResource(ctx, log, c, objAdapter, actuator)
-	return ctrl.Result{RequeueAfter: MaxRequeue(progressStatus)}, err
+	if err != nil {
+		return ctrl.Result{}, err
+	}
+	return ctrl.Result{RequeueAfter: MaxRequeue(progressStatus)}, nil
 }


### PR DESCRIPTION
CR complains that ctrl.Result{} is not empty when returning an error.
