### PR TITLE
Add routerinterface to openstack category

### DIFF
--- a/api/v1alpha1/router_interface_types.go
+++ b/api/v1alpha1/router_interface_types.go
@@ -22,6 +22,7 @@ import (
 
 // +genclient
 // +kubebuilder:object:root=true
+// +kubebuilder:resource:categories=openstack
 // +kubebuilder:subresource:status
 // +kubebuilder:printcolumn:name="Available",type="string",JSONPath=".status.conditions[?(@.type=='Available')].status",description="Availability status of resource"
 // +kubebuilder:printcolumn:name="Message",type="string",JSONPath=".status.conditions[?(@.type=='Available')].message",description="Message describing current availability status"

--- a/config/crd/bases/openstack.k-orc.cloud_routerinterfaces.yaml
+++ b/config/crd/bases/openstack.k-orc.cloud_routerinterfaces.yaml
@@ -8,6 +8,8 @@ metadata:
 spec:
   group: openstack.k-orc.cloud
   names:
+    categories:
+    - openstack
     kind: RouterInterface
     listKind: RouterInterfaceList
     plural: routerinterfaces


### PR DESCRIPTION
It was missing because it doesn't use the generated scaffolding.
