### PR TITLE
CI: Give additional permissions to label-issue workflow

### DIFF
--- a/.github/workflows/label-issue.yaml
+++ b/.github/workflows/label-issue.yaml
@@ -11,6 +11,7 @@ jobs:
     runs-on: ubuntu-latest
     permissions:
       issues: write
+      pull-requests: write
     steps:
     - run: gh issue edit "$NUMBER" --remove-label "needinfo"
       env:


### PR DESCRIPTION
It needs permission on pull requests as well.