### PR TITLE
Port: Make port available based on its status

### DIFF
--- a/internal/controllers/port/status.go
+++ b/internal/controllers/port/status.go
@@ -24,6 +24,11 @@ import (
 	orcapplyconfigv1alpha1 "github.com/k-orc/openstack-resource-controller/pkg/clients/applyconfiguration/api/v1alpha1"
 )
 
+const (
+	PortStatusActive = "ACTIVE"
+	PortStatusDown   = "DOWN"
+)
+
 type objectApplyPT = *orcapplyconfigv1alpha1.PortApplyConfiguration
 type statusApplyPT = *orcapplyconfigv1alpha1.PortStatusApplyConfiguration
 
@@ -35,9 +40,12 @@ func (portStatusWriter) GetApplyConfigConstructor() generic.ORCApplyConfigConstr
 	return orcapplyconfigv1alpha1.Port
 }
 
-func (portStatusWriter) ResourceIsAvailable(_ orcObjectPT, osResource *osResourceT) bool {
-	// A port is available as soon as it exists
-	return osResource != nil
+func (portStatusWriter) ResourceIsAvailable(orcObject orcObjectPT, osResource *osResourceT) bool {
+	// Both active and down ports
+	return orcObject.Status.ID != nil && osResource != nil &&
+		(osResource.Status == PortStatusActive ||
+			osResource.Status == PortStatusDown)
+
 }
 
 func (portStatusWriter) ApplyResourceStatus(log logr.Logger, osResource *osResourceT, statusApply statusApplyPT) {

--- a/internal/controllers/routerinterface/reconcile.go
+++ b/internal/controllers/routerinterface/reconcile.go
@@ -32,6 +32,7 @@ import (
 	"sigs.k8s.io/controller-runtime/pkg/controller/controllerutil"
 
 	orcv1alpha1 "github.com/k-orc/openstack-resource-controller/api/v1alpha1"
+	"github.com/k-orc/openstack-resource-controller/internal/controllers/port"
 	osclients "github.com/k-orc/openstack-resource-controller/internal/osclients"
 	"github.com/k-orc/openstack-resource-controller/internal/util/applyconfigs"
 	orcerrors "github.com/k-orc/openstack-resource-controller/internal/util/errors"
@@ -245,7 +246,7 @@ func (r *orcRouterInterfaceReconciler) reconcileNormalSubnet(ctx context.Context
 	statusOpts.port = routerInterfacePort
 
 	if routerInterfacePort != nil {
-		if routerInterfacePort.Status == portStatusActive {
+		if routerInterfacePort.Status == port.PortStatusActive {
 			// We're done
 			return false, nil, nil
 		}

--- a/internal/controllers/routerinterface/status.go
+++ b/internal/controllers/routerinterface/status.go
@@ -27,11 +27,10 @@ import (
 
 	orcv1alpha1 "github.com/k-orc/openstack-resource-controller/api/v1alpha1"
 	"github.com/k-orc/openstack-resource-controller/internal/controllers/generic"
+	"github.com/k-orc/openstack-resource-controller/internal/controllers/port"
 	"github.com/k-orc/openstack-resource-controller/internal/util/applyconfigs"
 	orcapplyconfigv1alpha1 "github.com/k-orc/openstack-resource-controller/pkg/clients/applyconfiguration/api/v1alpha1"
 )
-
-const portStatusActive = "ACTIVE"
 
 type updateStatusOpts struct {
 	subnet *orcv1alpha1.Subnet
@@ -56,7 +55,7 @@ func getStatusSummary(routerInterface *orcv1alpha1.RouterInterface, opts *update
 
 	available := false
 	if opts.port != nil {
-		if opts.port.Status == portStatusActive {
+		if opts.port.Status == port.PortStatusActive {
 			available = true
 		} else {
 			progressStatus = append(progressStatus, generic.WaitingOnOpenStackReady(portStatusPollingPeriod))


### PR DESCRIPTION
Ports reports their statuses via a status field, we should take that
into consideration when computing if the port is available or not.

With this change, ports are reported as Available when the object has
a known ID for the resource, and the resource has ACTIVE or DOWN status.

Fixes https://github.com/k-orc/openstack-resource-controller/issues/198