### PR TITLE
CI: Remove confusion about gateway in subnet tests

### DIFF
--- a/internal/controllers/subnet/tests/create-full-v4/00-assert.yaml
+++ b/internal/controllers/subnet/tests/create-full-v4/00-assert.yaml
@@ -19,9 +19,7 @@ status:
       # - start: 192.168.1.20
       #   end: 192.168.1.25
     enableDHCP: false
-    # FIXME: we should not have a gateway
-    # https://github.com/k-orc/openstack-resource-controller/issues/190
-    gatewayIP: 192.168.1.1
+    gatewayIP: 192.168.1.2
     enableDHCP: false
     dnsNameservers:
       - 1.1.1.1

--- a/internal/controllers/subnet/tests/create-full-v4/00-subnet.yaml
+++ b/internal/controllers/subnet/tests/create-full-v4/00-subnet.yaml
@@ -75,6 +75,8 @@ spec:
       # - start: 192.168.1.20
       #   end: 192.168.1.25
     gateway:
+      type: IP
+      ip: 192.168.1.2
     enableDHCP: false
     dnsNameservers:
       - 1.1.1.1

--- a/internal/controllers/subnet/tests/create-full-v6/00-assert.yaml
+++ b/internal/controllers/subnet/tests/create-full-v6/00-assert.yaml
@@ -19,9 +19,7 @@ status:
       # - start: "fc00:2:0:0:2::"
       #   end: "fc00:2::2:ffff:ffff:ffff"
     enableDHCP: false
-    # FIXME: we should not have a gateway
-    # https://github.com/k-orc/openstack-resource-controller/issues/190
-    gatewayIP: "fc00:2::"
+    gatewayIP: "fc00:2::2"
     dnsNameservers:
       - 2606:4700:4700::1111
       - 2001:4860:4860::8888

--- a/internal/controllers/subnet/tests/create-full-v6/00-subnet.yaml
+++ b/internal/controllers/subnet/tests/create-full-v6/00-subnet.yaml
@@ -75,6 +75,8 @@ spec:
       # - start: "fc00:2:0:0:2::"
       #   end: "fc00:2:0:0:2:ffff:ffff:ffff"
     gateway:
+      type: IP
+      ip: "fc00:2::2"
     dnsNameservers:
       - 2606:4700:4700::1111
       - 2001:4860:4860::8888


### PR DESCRIPTION
`gateway: null` is different from gateway with type = None. It works as expected.

Closes #190