### PR TITLE
dependabot: ignore k8s & CR updates on release-1.0

### DIFF
--- a/.github/dependabot.yml
+++ b/.github/dependabot.yml
@@ -61,4 +61,11 @@ updates:
   commit-message:
     prefix: ":seedling:"
     include: scope
+  ignore:
+  # Ignore controller-runtime major and minor bumps as its upgraded manually.
+  - dependency-name: "sigs.k8s.io/controller-runtime"
+    update-types: ["version-update:semver-major", "version-update:semver-minor"]
+  # Ignore k8s major and minor bumps and its transitives modules
+  - dependency-name: "k8s.io/*"
+    update-types: ["version-update:semver-major", "version-update:semver-minor"]
 ## release-1.0 branch config ends here


### PR DESCRIPTION
release-1.0 will be released with CR 0.19 and k8s 0.31.
