### PR TITLE
Neutron ReconcileTags returns NeedsRefresh

### DIFF
--- a/internal/controllers/generic/progress_status.go
+++ b/internal/controllers/generic/progress_status.go
@@ -147,6 +147,22 @@ func (e waitingOnOpenStack) Requeue() time.Duration {
 	return e.pollingPeriod
 }
 
+type needsRefresh struct{}
+
+var _ ProgressStatus = needsRefresh{}
+
+func (needsRefresh) Message() string {
+	return "Resource status will be refreshed"
+}
+
+func (needsRefresh) Requeue() time.Duration {
+	return 0
+}
+
+func NeedsRefresh() ProgressStatus {
+	return needsRefresh{}
+}
+
 func MaxRequeue(evts []ProgressStatus) time.Duration {
 	var ret time.Duration
 	for _, evt := range evts {

--- a/internal/util/neutrontags/join.go
+++ b/internal/util/neutrontags/join.go
@@ -52,11 +52,16 @@ func ReconcileTags[orcObjectPT, osResourceT any](
 		for i := range specTags {
 			specTagSet.Insert(string(specTags[i]))
 		}
+		var progressStatus []generic.ProgressStatus
 		var err error
 		if !specTagSet.Equal(observedTagSet) {
 			opts := attributestags.ReplaceAllOpts{Tags: specTagSet.SortedList()}
 			_, err = networkClient.ReplaceAllAttributesTags(ctx, resourceType, resourceID, &opts)
+			if err == nil {
+				// If we updated the tags we need another reconcile to refresh the resource status
+				progressStatus = []generic.ProgressStatus{generic.NeedsRefresh()}
+			}
 		}
-		return nil, err
+		return progressStatus, err
 	}
 }


### PR DESCRIPTION
Fixes: #242

Combined with #247 this gives us the following output when watching a network with tags during provisioning:
```
mbooth-orc-managed-network
mbooth-orc-managed-network   9d88fa62-5195-403d-bfbe-da90a3353322
mbooth-orc-managed-network   9d88fa62-5195-403d-bfbe-da90a3353322   True        Resource status will be refreshed
mbooth-orc-managed-network   9d88fa62-5195-403d-bfbe-da90a3353322   True        Resource status will be refreshed
mbooth-orc-managed-network   9d88fa62-5195-403d-bfbe-da90a3353322   True        OpenStack resource is up to date

```