### PR TITLE
kubectl reports Progressing instead of Available message

### DIFF
--- a/api/v1alpha1/router_interface_types.go
+++ b/api/v1alpha1/router_interface_types.go
@@ -25,8 +25,7 @@ import (
 // +kubebuilder:resource:categories=openstack
 // +kubebuilder:subresource:status
 // +kubebuilder:printcolumn:name="Available",type="string",JSONPath=".status.conditions[?(@.type=='Available')].status",description="Availability status of resource"
-// +kubebuilder:printcolumn:name="Message",type="string",JSONPath=".status.conditions[?(@.type=='Available')].message",description="Message describing current availability status"
-// +kubebuilder:printcolumn:name="Age",type="date",JSONPath=".metadata.creationTimestamp",description="Time duration since creation"
+// +kubebuilder:printcolumn:name="Message",type="string",JSONPath=".status.conditions[?(@.type=='Progressing')].message",description="Message describing current progress status"
 
 // RouterInterface is the Schema for an ORC resource.
 type RouterInterface struct {

--- a/api/v1alpha1/zz_generated.flavor-resource.go
+++ b/api/v1alpha1/zz_generated.flavor-resource.go
@@ -123,8 +123,7 @@ func (i *Flavor) GetConditions() []metav1.Condition {
 // +kubebuilder:subresource:status
 // +kubebuilder:printcolumn:name="ID",type="string",JSONPath=".status.id",description="Resource ID"
 // +kubebuilder:printcolumn:name="Available",type="string",JSONPath=".status.conditions[?(@.type=='Available')].status",description="Availability status of resource"
-// +kubebuilder:printcolumn:name="Message",type="string",JSONPath=".status.conditions[?(@.type=='Available')].message",description="Message describing current availability status"
-// +kubebuilder:printcolumn:name="Age",type="date",JSONPath=".metadata.creationTimestamp",description="Time duration since creation"
+// +kubebuilder:printcolumn:name="Message",type="string",JSONPath=".status.conditions[?(@.type=='Progressing')].message",description="Message describing current progress status"
 
 // Flavor is the Schema for an ORC resource.
 type Flavor struct {

--- a/api/v1alpha1/zz_generated.image-resource.go
+++ b/api/v1alpha1/zz_generated.image-resource.go
@@ -126,8 +126,7 @@ func (i *Image) GetConditions() []metav1.Condition {
 // +kubebuilder:subresource:status
 // +kubebuilder:printcolumn:name="ID",type="string",JSONPath=".status.id",description="Resource ID"
 // +kubebuilder:printcolumn:name="Available",type="string",JSONPath=".status.conditions[?(@.type=='Available')].status",description="Availability status of resource"
-// +kubebuilder:printcolumn:name="Message",type="string",JSONPath=".status.conditions[?(@.type=='Available')].message",description="Message describing current availability status"
-// +kubebuilder:printcolumn:name="Age",type="date",JSONPath=".metadata.creationTimestamp",description="Time duration since creation"
+// +kubebuilder:printcolumn:name="Message",type="string",JSONPath=".status.conditions[?(@.type=='Progressing')].message",description="Message describing current progress status"
 
 // Image is the Schema for an ORC resource.
 type Image struct {

--- a/api/v1alpha1/zz_generated.network-resource.go
+++ b/api/v1alpha1/zz_generated.network-resource.go
@@ -123,8 +123,7 @@ func (i *Network) GetConditions() []metav1.Condition {
 // +kubebuilder:subresource:status
 // +kubebuilder:printcolumn:name="ID",type="string",JSONPath=".status.id",description="Resource ID"
 // +kubebuilder:printcolumn:name="Available",type="string",JSONPath=".status.conditions[?(@.type=='Available')].status",description="Availability status of resource"
-// +kubebuilder:printcolumn:name="Message",type="string",JSONPath=".status.conditions[?(@.type=='Available')].message",description="Message describing current availability status"
-// +kubebuilder:printcolumn:name="Age",type="date",JSONPath=".metadata.creationTimestamp",description="Time duration since creation"
+// +kubebuilder:printcolumn:name="Message",type="string",JSONPath=".status.conditions[?(@.type=='Progressing')].message",description="Message describing current progress status"
 
 // Network is the Schema for an ORC resource.
 type Network struct {

--- a/api/v1alpha1/zz_generated.port-resource.go
+++ b/api/v1alpha1/zz_generated.port-resource.go
@@ -125,8 +125,7 @@ func (i *Port) GetConditions() []metav1.Condition {
 // +kubebuilder:subresource:status
 // +kubebuilder:printcolumn:name="ID",type="string",JSONPath=".status.id",description="Resource ID"
 // +kubebuilder:printcolumn:name="Available",type="string",JSONPath=".status.conditions[?(@.type=='Available')].status",description="Availability status of resource"
-// +kubebuilder:printcolumn:name="Message",type="string",JSONPath=".status.conditions[?(@.type=='Available')].message",description="Message describing current availability status"
-// +kubebuilder:printcolumn:name="Age",type="date",JSONPath=".metadata.creationTimestamp",description="Time duration since creation"
+// +kubebuilder:printcolumn:name="Message",type="string",JSONPath=".status.conditions[?(@.type=='Progressing')].message",description="Message describing current progress status"
 
 // Port is the Schema for an ORC resource.
 type Port struct {

--- a/api/v1alpha1/zz_generated.router-resource.go
+++ b/api/v1alpha1/zz_generated.router-resource.go
@@ -123,8 +123,7 @@ func (i *Router) GetConditions() []metav1.Condition {
 // +kubebuilder:subresource:status
 // +kubebuilder:printcolumn:name="ID",type="string",JSONPath=".status.id",description="Resource ID"
 // +kubebuilder:printcolumn:name="Available",type="string",JSONPath=".status.conditions[?(@.type=='Available')].status",description="Availability status of resource"
-// +kubebuilder:printcolumn:name="Message",type="string",JSONPath=".status.conditions[?(@.type=='Available')].message",description="Message describing current availability status"
-// +kubebuilder:printcolumn:name="Age",type="date",JSONPath=".metadata.creationTimestamp",description="Time duration since creation"
+// +kubebuilder:printcolumn:name="Message",type="string",JSONPath=".status.conditions[?(@.type=='Progressing')].message",description="Message describing current progress status"
 
 // Router is the Schema for an ORC resource.
 type Router struct {

--- a/api/v1alpha1/zz_generated.securitygroup-resource.go
+++ b/api/v1alpha1/zz_generated.securitygroup-resource.go
@@ -123,8 +123,7 @@ func (i *SecurityGroup) GetConditions() []metav1.Condition {
 // +kubebuilder:subresource:status
 // +kubebuilder:printcolumn:name="ID",type="string",JSONPath=".status.id",description="Resource ID"
 // +kubebuilder:printcolumn:name="Available",type="string",JSONPath=".status.conditions[?(@.type=='Available')].status",description="Availability status of resource"
-// +kubebuilder:printcolumn:name="Message",type="string",JSONPath=".status.conditions[?(@.type=='Available')].message",description="Message describing current availability status"
-// +kubebuilder:printcolumn:name="Age",type="date",JSONPath=".metadata.creationTimestamp",description="Time duration since creation"
+// +kubebuilder:printcolumn:name="Message",type="string",JSONPath=".status.conditions[?(@.type=='Progressing')].message",description="Message describing current progress status"
 
 // SecurityGroup is the Schema for an ORC resource.
 type SecurityGroup struct {

--- a/api/v1alpha1/zz_generated.server-resource.go
+++ b/api/v1alpha1/zz_generated.server-resource.go
@@ -123,8 +123,7 @@ func (i *Server) GetConditions() []metav1.Condition {
 // +kubebuilder:subresource:status
 // +kubebuilder:printcolumn:name="ID",type="string",JSONPath=".status.id",description="Resource ID"
 // +kubebuilder:printcolumn:name="Available",type="string",JSONPath=".status.conditions[?(@.type=='Available')].status",description="Availability status of resource"
-// +kubebuilder:printcolumn:name="Message",type="string",JSONPath=".status.conditions[?(@.type=='Available')].message",description="Message describing current availability status"
-// +kubebuilder:printcolumn:name="Age",type="date",JSONPath=".metadata.creationTimestamp",description="Time duration since creation"
+// +kubebuilder:printcolumn:name="Message",type="string",JSONPath=".status.conditions[?(@.type=='Progressing')].message",description="Message describing current progress status"
 
 // Server is the Schema for an ORC resource.
 type Server struct {

--- a/api/v1alpha1/zz_generated.subnet-resource.go
+++ b/api/v1alpha1/zz_generated.subnet-resource.go
@@ -125,8 +125,7 @@ func (i *Subnet) GetConditions() []metav1.Condition {
 // +kubebuilder:subresource:status
 // +kubebuilder:printcolumn:name="ID",type="string",JSONPath=".status.id",description="Resource ID"
 // +kubebuilder:printcolumn:name="Available",type="string",JSONPath=".status.conditions[?(@.type=='Available')].status",description="Availability status of resource"
-// +kubebuilder:printcolumn:name="Message",type="string",JSONPath=".status.conditions[?(@.type=='Available')].message",description="Message describing current availability status"
-// +kubebuilder:printcolumn:name="Age",type="date",JSONPath=".metadata.creationTimestamp",description="Time duration since creation"
+// +kubebuilder:printcolumn:name="Message",type="string",JSONPath=".status.conditions[?(@.type=='Progressing')].message",description="Message describing current progress status"
 
 // Subnet is the Schema for an ORC resource.
 type Subnet struct {

--- a/cmd/resource-generator/data/api.template
+++ b/cmd/resource-generator/data/api.template
@@ -132,8 +132,7 @@ func (i *{{ .Name }}) GetConditions() []metav1.Condition {
 // +kubebuilder:subresource:status
 // +kubebuilder:printcolumn:name="ID",type="string",JSONPath=".status.id",description="Resource ID"
 // +kubebuilder:printcolumn:name="Available",type="string",JSONPath=".status.conditions[?(@.type=='Available')].status",description="Availability status of resource"
-// +kubebuilder:printcolumn:name="Message",type="string",JSONPath=".status.conditions[?(@.type=='Available')].message",description="Message describing current availability status"
-// +kubebuilder:printcolumn:name="Age",type="date",JSONPath=".metadata.creationTimestamp",description="Time duration since creation"
+// +kubebuilder:printcolumn:name="Message",type="string",JSONPath=".status.conditions[?(@.type=='Progressing')].message",description="Message describing current progress status"
 
 // {{ .Name }} is the Schema for an ORC resource.
 type {{ .Name }} struct {

--- a/config/crd/bases/openstack.k-orc.cloud_flavors.yaml
+++ b/config/crd/bases/openstack.k-orc.cloud_flavors.yaml
@@ -25,14 +25,10 @@ spec:
       jsonPath: .status.conditions[?(@.type=='Available')].status
       name: Available
       type: string
-    - description: Message describing current availability status
-      jsonPath: .status.conditions[?(@.type=='Available')].message
+    - description: Message describing current progress status
+      jsonPath: .status.conditions[?(@.type=='Progressing')].message
       name: Message
       type: string
-    - description: Time duration since creation
-      jsonPath: .metadata.creationTimestamp
-      name: Age
-      type: date
     name: v1alpha1
     schema:
       openAPIV3Schema:

--- a/config/crd/bases/openstack.k-orc.cloud_images.yaml
+++ b/config/crd/bases/openstack.k-orc.cloud_images.yaml
@@ -25,14 +25,10 @@ spec:
       jsonPath: .status.conditions[?(@.type=='Available')].status
       name: Available
       type: string
-    - description: Message describing current availability status
-      jsonPath: .status.conditions[?(@.type=='Available')].message
+    - description: Message describing current progress status
+      jsonPath: .status.conditions[?(@.type=='Progressing')].message
       name: Message
       type: string
-    - description: Time duration since creation
-      jsonPath: .metadata.creationTimestamp
-      name: Age
-      type: date
     name: v1alpha1
     schema:
       openAPIV3Schema:

--- a/config/crd/bases/openstack.k-orc.cloud_networks.yaml
+++ b/config/crd/bases/openstack.k-orc.cloud_networks.yaml
@@ -25,14 +25,10 @@ spec:
       jsonPath: .status.conditions[?(@.type=='Available')].status
       name: Available
       type: string
-    - description: Message describing current availability status
-      jsonPath: .status.conditions[?(@.type=='Available')].message
+    - description: Message describing current progress status
+      jsonPath: .status.conditions[?(@.type=='Progressing')].message
       name: Message
       type: string
-    - description: Time duration since creation
-      jsonPath: .metadata.creationTimestamp
-      name: Age
-      type: date
     name: v1alpha1
     schema:
       openAPIV3Schema:

--- a/config/crd/bases/openstack.k-orc.cloud_ports.yaml
+++ b/config/crd/bases/openstack.k-orc.cloud_ports.yaml
@@ -25,14 +25,10 @@ spec:
       jsonPath: .status.conditions[?(@.type=='Available')].status
       name: Available
       type: string
-    - description: Message describing current availability status
-      jsonPath: .status.conditions[?(@.type=='Available')].message
+    - description: Message describing current progress status
+      jsonPath: .status.conditions[?(@.type=='Progressing')].message
       name: Message
       type: string
-    - description: Time duration since creation
-      jsonPath: .metadata.creationTimestamp
-      name: Age
-      type: date
     name: v1alpha1
     schema:
       openAPIV3Schema:

--- a/config/crd/bases/openstack.k-orc.cloud_routerinterfaces.yaml
+++ b/config/crd/bases/openstack.k-orc.cloud_routerinterfaces.yaml
@@ -21,14 +21,10 @@ spec:
       jsonPath: .status.conditions[?(@.type=='Available')].status
       name: Available
       type: string
-    - description: Message describing current availability status
-      jsonPath: .status.conditions[?(@.type=='Available')].message
+    - description: Message describing current progress status
+      jsonPath: .status.conditions[?(@.type=='Progressing')].message
       name: Message
       type: string
-    - description: Time duration since creation
-      jsonPath: .metadata.creationTimestamp
-      name: Age
-      type: date
     name: v1alpha1
     schema:
       openAPIV3Schema:

--- a/config/crd/bases/openstack.k-orc.cloud_routers.yaml
+++ b/config/crd/bases/openstack.k-orc.cloud_routers.yaml
@@ -25,14 +25,10 @@ spec:
       jsonPath: .status.conditions[?(@.type=='Available')].status
       name: Available
       type: string
-    - description: Message describing current availability status
-      jsonPath: .status.conditions[?(@.type=='Available')].message
+    - description: Message describing current progress status
+      jsonPath: .status.conditions[?(@.type=='Progressing')].message
       name: Message
       type: string
-    - description: Time duration since creation
-      jsonPath: .metadata.creationTimestamp
-      name: Age
-      type: date
     name: v1alpha1
     schema:
       openAPIV3Schema:

--- a/config/crd/bases/openstack.k-orc.cloud_securitygroups.yaml
+++ b/config/crd/bases/openstack.k-orc.cloud_securitygroups.yaml
@@ -25,14 +25,10 @@ spec:
       jsonPath: .status.conditions[?(@.type=='Available')].status
       name: Available
       type: string
-    - description: Message describing current availability status
-      jsonPath: .status.conditions[?(@.type=='Available')].message
+    - description: Message describing current progress status
+      jsonPath: .status.conditions[?(@.type=='Progressing')].message
       name: Message
       type: string
-    - description: Time duration since creation
-      jsonPath: .metadata.creationTimestamp
-      name: Age
-      type: date
     name: v1alpha1
     schema:
       openAPIV3Schema:

--- a/config/crd/bases/openstack.k-orc.cloud_servers.yaml
+++ b/config/crd/bases/openstack.k-orc.cloud_servers.yaml
@@ -25,14 +25,10 @@ spec:
       jsonPath: .status.conditions[?(@.type=='Available')].status
       name: Available
       type: string
-    - description: Message describing current availability status
-      jsonPath: .status.conditions[?(@.type=='Available')].message
+    - description: Message describing current progress status
+      jsonPath: .status.conditions[?(@.type=='Progressing')].message
       name: Message
       type: string
-    - description: Time duration since creation
-      jsonPath: .metadata.creationTimestamp
-      name: Age
-      type: date
     name: v1alpha1
     schema:
       openAPIV3Schema:

--- a/config/crd/bases/openstack.k-orc.cloud_subnets.yaml
+++ b/config/crd/bases/openstack.k-orc.cloud_subnets.yaml
@@ -25,14 +25,10 @@ spec:
       jsonPath: .status.conditions[?(@.type=='Available')].status
       name: Available
       type: string
-    - description: Message describing current availability status
-      jsonPath: .status.conditions[?(@.type=='Available')].message
+    - description: Message describing current progress status
+      jsonPath: .status.conditions[?(@.type=='Progressing')].message
       name: Message
       type: string
-    - description: Time duration since creation
-      jsonPath: .metadata.creationTimestamp
-      name: Age
-      type: date
     name: v1alpha1
     schema:
       openAPIV3Schema:


### PR DESCRIPTION
Changes the printcolumns to use the message on the Progressing condition
instead of the message on the Available condition. Available is still present
as a boolean column.

The Progressing message is copied to the Available message, but only when the
resource is not available. This makes any progress message harder to see if the
resource is available, but is being updated.

Also drops the Age column because it's not very useful and clutters the
display.
