### PR TITLE
CI: Re-enable tag checks in network tests

### DIFF
--- a/internal/controllers/network/tests/create-full/00-assert.yaml
+++ b/internal/controllers/network/tests/create-full/00-assert.yaml
@@ -15,7 +15,6 @@ status:
     portSecurityEnabled: false
     shared: true
     status: ACTIVE
-    # Skipped until https://github.com/k-orc/openstack-resource-controller/issues/242 is fixed
-    # tags:
-    #  - foo1
-    #  - foo2
+    tags:
+     - tag1
+     - tag2

--- a/internal/controllers/network/tests/create-full/00-network.yaml
+++ b/internal/controllers/network/tests/create-full/00-network.yaml
@@ -17,5 +17,5 @@ spec:
     portSecurityEnabled: false
     shared: true
     tags:
-      - foo1
-      - foo2
+      - tag1
+      - tag2

--- a/internal/controllers/network/tests/import/01-assert.yaml
+++ b/internal/controllers/network/tests/import/01-assert.yaml
@@ -23,7 +23,6 @@ status:
     portSecurityEnabled: true
     shared: false
     status: ACTIVE
-    # Skipped until https://github.com/k-orc/openstack-resource-controller/issues/242 is fixed
-    # tags:
-    #  - tag1
-    #  - tag2
+    tags:
+     - tag1
+     - tag2


### PR DESCRIPTION
Now that #242 is fixed, we can re-enable these checks.