### PR TITLE
Add Addresses printcolumn to Ports

### DIFF
--- a/api/v1alpha1/zz_generated.port-resource.go
+++ b/api/v1alpha1/zz_generated.port-resource.go
@@ -125,6 +125,7 @@ func (i *Port) GetConditions() []metav1.Condition {
 // +kubebuilder:subresource:status
 // +kubebuilder:printcolumn:name="ID",type="string",JSONPath=".status.id",description="Resource ID"
 // +kubebuilder:printcolumn:name="Available",type="string",JSONPath=".status.conditions[?(@.type=='Available')].status",description="Availability status of resource"
+// +kubebuilder:printcolumn:name="Addresses",type="string",JSONPath=".status.resource.fixedIPs[*].ip",description="Allocated IP addresses"
 // +kubebuilder:printcolumn:name="Message",type="string",JSONPath=".status.conditions[?(@.type=='Progressing')].message",description="Message describing current progress status"
 
 // Port is the Schema for an ORC resource.

--- a/cmd/resource-generator/data/api.template
+++ b/cmd/resource-generator/data/api.template
@@ -46,9 +46,9 @@ type {{ .Name }}Import struct {
 // +kubebuilder:validation:XValidation:rule="self.managementPolicy == 'unmanaged' ? !has(self.resource) : true",message="resource may not be specified when policy is unmanaged"
 // +kubebuilder:validation:XValidation:rule="self.managementPolicy == 'unmanaged' ? has(self.__import__) : true",message="import must be specified when policy is unmanaged"
 // +kubebuilder:validation:XValidation:rule="has(self.managedOptions) ? self.managementPolicy == 'managed' : true",message="managedOptions may only be provided when policy is managed"
-{{ range .SpecExtraValidations -}}
+{{- range .SpecExtraValidations }}
 // +kubebuilder:validation:XValidation:rule="{{ .Rule }}",message="{{ .Message }}"
-{{ end -}}
+{{- end }}
 type {{ .Name }}Spec struct {
 {{- if .SpecExtraType }}
 	{{ .SpecExtraType }} `json:",inline"`
@@ -132,6 +132,9 @@ func (i *{{ .Name }}) GetConditions() []metav1.Condition {
 // +kubebuilder:subresource:status
 // +kubebuilder:printcolumn:name="ID",type="string",JSONPath=".status.id",description="Resource ID"
 // +kubebuilder:printcolumn:name="Available",type="string",JSONPath=".status.conditions[?(@.type=='Available')].status",description="Availability status of resource"
+{{- range .AdditionalPrintColumns }}
+// +kubebuilder:printcolumn:name="{{ .Name }}",type="{{ .Type }}",JSONPath="{{ .JSONPath }}",description="{{ .Description }}"
+{{- end }}
 // +kubebuilder:printcolumn:name="Message",type="string",JSONPath=".status.conditions[?(@.type=='Progressing')].message",description="Message describing current progress status"
 
 // {{ .Name }} is the Schema for an ORC resource.

--- a/cmd/resource-generator/main.go
+++ b/cmd/resource-generator/main.go
@@ -25,14 +25,22 @@ type specExtraValidation struct {
 	Message string
 }
 
+type additionalPrintColumn struct {
+	Name        string
+	Type        string
+	JSONPath    string
+	Description string
+}
+
 type templateFields struct {
-	APIVersion           string
-	Year                 string
-	Name                 string
-	NameLower            string
-	SpecExtraType        string
-	StatusExtraType      string
-	SpecExtraValidations []specExtraValidation
+	APIVersion             string
+	Year                   string
+	Name                   string
+	NameLower              string
+	SpecExtraType          string
+	StatusExtraType        string
+	SpecExtraValidations   []specExtraValidation
+	AdditionalPrintColumns []additionalPrintColumn
 }
 
 var allResources []templateFields = []templateFields{
@@ -64,6 +72,14 @@ var allResources []templateFields = []templateFields{
 	{
 		Name:          "Port",
 		SpecExtraType: "PortRefs",
+		AdditionalPrintColumns: []additionalPrintColumn{
+			{
+				Name:        "Addresses",
+				Type:        "string",
+				JSONPath:    ".status.resource.fixedIPs[*].ip",
+				Description: "Allocated IP addresses",
+			},
+		},
 	},
 	{
 		Name: "SecurityGroup",

--- a/config/crd/bases/openstack.k-orc.cloud_ports.yaml
+++ b/config/crd/bases/openstack.k-orc.cloud_ports.yaml
@@ -25,6 +25,10 @@ spec:
       jsonPath: .status.conditions[?(@.type=='Available')].status
       name: Available
       type: string
+    - description: Allocated IP addresses
+      jsonPath: .status.resource.fixedIPs[*].ip
+      name: Addresses
+      type: string
     - description: Message describing current progress status
       jsonPath: .status.conditions[?(@.type=='Progressing')].message
       name: Message


### PR DESCRIPTION
Adds an Addresses column to the kubectl print columns. Example output:
```
NAME                                            ID                                     AVAILABLE   ADDRESSES      MESSAGE
port.openstack.k-orc.cloud/mbooth-cirros-port   944efb42-8f58-473b-8582-e75f61cc92f3   True        10.0.185.190   OpenStack resource is up to date
```

If the port has multiple addresses they will all be displayed, space separated.
