### PR TITLE
🌱 Enhancements to Manager Deployment Configuration

### DIFF
--- a/config/manager/manager.yaml
+++ b/config/manager/manager.yaml
@@ -28,35 +28,6 @@ spec:
       labels:
         control-plane: controller-manager
     spec:
-      # TODO(user): Uncomment the following code to configure the nodeAffinity expression
-      # according to the platforms which are supported by your solution.
-      # It is considered best practice to support multiple architectures. You can
-      # build your manager image using the makefile target docker-buildx.
-      # affinity:
-      #   nodeAffinity:
-      #     requiredDuringSchedulingIgnoredDuringExecution:
-      #       nodeSelectorTerms:
-      #         - matchExpressions:
-      #           - key: kubernetes.io/arch
-      #             operator: In
-      #             values:
-      #               - amd64
-      #               - arm64
-      #               - ppc64le
-      #               - s390x
-      #           - key: kubernetes.io/os
-      #             operator: In
-      #             values:
-      #               - linux
-      securityContext:
-        runAsNonRoot: true
-        # TODO(user): For common cases that do not require escalating privileges
-        # it is recommended to ensure that all your Pods/Containers are restrictive.
-        # More info: https://kubernetes.io/docs/concepts/security/pod-security-standards/#restricted
-        # Please uncomment the following code if your project does NOT have to work on old Kubernetes
-        # versions < 1.19 or on vendors versions which do NOT support this field by default (i.e. Openshift < 4.11 ).
-        # seccompProfile:
-        #   type: RuntimeDefault
       containers:
       - command:
         - /manager
@@ -70,6 +41,10 @@ spec:
           capabilities:
             drop:
             - "ALL"
+          privileged: false
+          runAsUser: 65532
+          runAsGroup: 65532
+        terminationMessagePolicy: FallbackToLogsOnError
         livenessProbe:
           httpGet:
             path: /healthz
@@ -91,5 +66,9 @@ spec:
           requests:
             cpu: 10m
             memory: 64Mi
+      securityContext:
+        runAsNonRoot: true
+        seccompProfile:
+          type: RuntimeDefault
       serviceAccountName: controller-manager
       terminationGracePeriodSeconds: 10


### PR DESCRIPTION
This patch updates the `manager.yaml` configuration file with the following changes:

- Enforces stricter security policies by explicitly setting:
  - `runAsUser: 65532` and `runAsGroup: 65532` to define a non-root user for the manager container.
  - `privileged: false` to ensure the container does not run with elevated privileges.
  - `terminationMessagePolicy: FallbackToLogsOnError` for improved debugging.
  - `seccompProfile: RuntimeDefault` to align with Kubernetes security best practices.

> [!NOTE]
> This change was inspired from upstream CAPO.

- Removed legacy comments and outdated recommendations related to Kubernetes versions < 1.19 and OpenShift < 4.11.
