### PR TITLE
Use a regular expression in server ListOSResourcesForAdoption

### DIFF
--- a/hack/e2e.sh
+++ b/hack/e2e.sh
@@ -20,6 +20,9 @@ E2E_KUTTL_DIR=${E2E_KUTTL_DIR:-}
 # Defaults to empty string (run all tests)
 E2E_KUTTL_TEST=${E2E_KUTTL_TEST:-}
 
+# default flavor name to use for tests
+export E2E_KUTTL_FLAVOR=${E2E_KUTTL_FLAVOR:-m1.tiny}
+
 # Define a custom external network
 export E2E_EXTERNAL_NETWORK_NAME=${E2E_EXTERNAL_NETWORK_NAME:-private}
 

--- a/internal/controllers/server/actuator.go
+++ b/internal/controllers/server/actuator.go
@@ -73,14 +73,14 @@ func (actuator serverActuator) ListOSResourcesForAdoption(ctx context.Context, o
 	}
 
 	listOpts := servers.ListOpts{
-		Name: string(getResourceName(obj)),
+		Name: fmt.Sprintf("^%s$", string(getResourceName(obj))),
 	}
 	return actuator.osClient.ListServers(ctx, listOpts), true
 }
 
 func (actuator serverActuator) ListOSResourcesForImport(ctx context.Context, filter filterT) serverIterator {
 	listOpts := servers.ListOpts{
-		Name: string(ptr.Deref(filter.Name, "")),
+		Name: fmt.Sprintf("^%s$", string(ptr.Deref(filter.Name, ""))),
 	}
 	return actuator.osClient.ListServers(ctx, listOpts)
 }

--- a/internal/controllers/server/tests/create-adoption-server/00-assert.yaml
+++ b/internal/controllers/server/tests/create-adoption-server/00-assert.yaml
@@ -1,0 +1,8 @@
+---
+apiVersion: openstack.k-orc.cloud/v1alpha1
+kind: Server
+metadata:
+  name: create-adoption
+status:
+  resource:
+    name: create-adoption

--- a/internal/controllers/server/tests/create-adoption-server/00-flavor.yaml
+++ b/internal/controllers/server/tests/create-adoption-server/00-flavor.yaml
@@ -1,0 +1,7 @@
+---
+apiVersion: kuttl.dev/v1beta1
+kind: TestStep
+commands:
+  - command: kubectl create secret generic openstack-clouds --from-file=clouds.yaml=${E2E_KUTTL_OSCLOUDS} ${E2E_KUTTL_CACERT_OPT}
+    namespaced: true
+  - script: cat ../templates/create-flavor.tmpl |envsubst | kubectl -n ${NAMESPACE} apply -f -

--- a/internal/controllers/server/tests/create-adoption-server/00-server.yaml
+++ b/internal/controllers/server/tests/create-adoption-server/00-server.yaml
@@ -1,0 +1,71 @@
+---
+apiVersion: openstack.k-orc.cloud/v1alpha1
+kind: Image
+metadata:
+  name: create-adoption
+spec:
+  cloudCredentialsRef:
+    cloudName: openstack-admin
+    secretName: openstack-clouds
+  managementPolicy: managed
+  resource:
+    content:
+      diskFormat: qcow2
+      download:
+        url: https://download.cirros-cloud.net/0.6.3/cirros-0.6.3-x86_64-disk.img
+    visibility: public
+---
+apiVersion: openstack.k-orc.cloud/v1alpha1
+kind: Network
+metadata:
+  name: create-adoption
+spec:
+  cloudCredentialsRef:
+    cloudName: openstack
+    secretName: openstack-clouds
+  managementPolicy: managed
+  resource:
+    name: create-adoption
+---
+apiVersion: openstack.k-orc.cloud/v1alpha1
+kind: Subnet
+metadata:
+  name: create-adoption
+spec:
+  cloudCredentialsRef:
+    cloudName: openstack
+    secretName: openstack-clouds
+  managementPolicy: managed
+  networkRef: create-adoption
+  resource:
+    ipVersion: 4
+    cidr: 192.168.200.0/24
+---
+apiVersion: openstack.k-orc.cloud/v1alpha1
+kind: Port
+metadata:
+  name: create-adoption
+spec:
+  cloudCredentialsRef:
+    cloudName: openstack
+    secretName: openstack-clouds
+  managementPolicy: managed
+  networkRef: create-adoption
+  resource:
+    addresses:
+    - subnetRef: create-adoption
+---
+apiVersion: openstack.k-orc.cloud/v1alpha1
+kind: Server
+metadata:
+  name: create-adoption
+spec:
+  cloudCredentialsRef:
+    cloudName: openstack
+    secretName: openstack-clouds
+  managementPolicy: managed
+  resource:
+    imageRef: create-adoption
+    flavorRef: server-flavor
+    ports:
+    - portRef: create-adoption

--- a/internal/controllers/server/tests/create-adoption-server/01-adoption-server.yaml
+++ b/internal/controllers/server/tests/create-adoption-server/01-adoption-server.yaml
@@ -1,0 +1,28 @@
+apiVersion: openstack.k-orc.cloud/v1alpha1
+kind: Port
+metadata:
+  name: adoption
+spec:
+  cloudCredentialsRef:
+    cloudName: openstack
+    secretName: openstack-clouds
+  managementPolicy: managed
+  networkRef: create-adoption
+  resource:
+    addresses:
+    - subnetRef: create-adoption
+---
+apiVersion: openstack.k-orc.cloud/v1alpha1
+kind: Server
+metadata:
+  name: adoption
+spec:
+  cloudCredentialsRef:
+    cloudName: openstack
+    secretName: openstack-clouds
+  managementPolicy: managed
+  resource:
+    imageRef: create-adoption
+    flavorRef: server-flavor
+    ports:
+    - portRef: adoption

--- a/internal/controllers/server/tests/create-adoption-server/01-assert.yaml
+++ b/internal/controllers/server/tests/create-adoption-server/01-assert.yaml
@@ -1,0 +1,8 @@
+---
+apiVersion: openstack.k-orc.cloud/v1alpha1
+kind: Server
+metadata:
+  name: adoption
+status:
+  resource:
+    name: adoption

--- a/internal/controllers/server/tests/create-adoption-server/02-assert.yaml
+++ b/internal/controllers/server/tests/create-adoption-server/02-assert.yaml
@@ -1,0 +1,20 @@
+apiVersion: kuttl.dev/v1beta1
+kind: TestAssert
+commands:
+- script: "! kubectl get server create-adoption --namespace $NAMESPACE"
+  skipLogOutput: true
+- script: "! kubectl get port create-adoption --namespace $NAMESPACE"
+  skipLogOutput: true
+- script: "! kubectl get server adoption --namespace $NAMESPACE"
+  skipLogOutput: true
+- script: "! kubectl get port adoption --namespace $NAMESPACE"
+  skipLogOutput: true  
+- script: "! kubectl get subnet create-adoption --namespace $NAMESPACE"
+  skipLogOutput: true
+- script: "! kubectl get network create-adoption --namespace $NAMESPACE"
+  skipLogOutput: true      
+- script: "! kubectl get flavor server-flavor --namespace $NAMESPACE"
+  skipLogOutput: true
+- script: "! kubectl get image create-adoption --namespace $NAMESPACE"
+  skipLogOutput: true
+  

--- a/internal/controllers/server/tests/create-adoption-server/02-cleanup.yaml
+++ b/internal/controllers/server/tests/create-adoption-server/02-cleanup.yaml
@@ -1,0 +1,27 @@
+apiVersion: kuttl.dev/v1beta1
+kind: TestStep
+delete:
+- apiVersion: openstack.k-orc.cloud/v1alpha1
+  kind: Server
+  name: create-adoption
+- apiVersion: openstack.k-orc.cloud/v1alpha1
+  kind: Port
+  name: create-adoption
+- apiVersion: openstack.k-orc.cloud/v1alpha1
+  kind: Server
+  name: adoption
+- apiVersion: openstack.k-orc.cloud/v1alpha1
+  kind: Port
+  name: adoption  
+- apiVersion: openstack.k-orc.cloud/v1alpha1
+  kind: Subnet
+  name: create-adoption
+- apiVersion: openstack.k-orc.cloud/v1alpha1
+  kind: Network
+  name: create-adoption
+- apiVersion: openstack.k-orc.cloud/v1alpha1
+  kind: Flavor
+  name: server-flavor
+- apiVersion: openstack.k-orc.cloud/v1alpha1
+  kind: Image
+  name: create-adoption  

--- a/internal/controllers/server/tests/create-adoption-server/README.md
+++ b/internal/controllers/server/tests/create-adoption-server/README.md
@@ -1,0 +1,13 @@
+# Create two servers to test adoption
+
+## Step 00
+
+Import a flavor, create an image,network,subnet and a port and then create a server with name 'create-adoption'.
+
+## Step 01
+Create another server with the name 'adoption'. The second server should have a resource name of 'adoption'
+
+## Step 02
+
+Validate we're able to delete resources.
+Cleaning up resources also avoids a race where kuttl could delete the secret before the other resources.

--- a/internal/controllers/server/tests/import-server/00-assert.yaml
+++ b/internal/controllers/server/tests/import-server/00-assert.yaml
@@ -1,0 +1,30 @@
+---
+apiVersion: openstack.k-orc.cloud/v1alpha1
+kind: Server
+metadata:
+  name: import
+status:
+  conditions:
+    - type: Available
+      message: Waiting for OpenStack resource to be created externally
+      status: "False"
+      reason: Progressing
+    - type: Progressing
+      message: Waiting for OpenStack resource to be created externally
+      status: "True"
+      reason: Progressing
+---
+apiVersion: openstack.k-orc.cloud/v1alpha1
+kind: Server
+metadata:
+  name: import-error
+status:
+  conditions:
+    - type: Available
+      message: Waiting for OpenStack resource to be created externally
+      status: "False"
+      reason: Progressing
+    - type: Progressing
+      message: Waiting for OpenStack resource to be created externally
+      status: "True"
+      reason: Progressing      

--- a/internal/controllers/server/tests/import-server/00-import-server-error.yaml
+++ b/internal/controllers/server/tests/import-server/00-import-server-error.yaml
@@ -1,0 +1,13 @@
+---
+apiVersion: openstack.k-orc.cloud/v1alpha1
+kind: Server
+metadata:
+  name: import-error
+spec:
+  cloudCredentialsRef:
+    cloudName: openstack
+    secretName: openstack-clouds
+  managementPolicy: unmanaged
+  import:
+    filter:
+      name: external

--- a/internal/controllers/server/tests/import-server/00-import-server.yaml
+++ b/internal/controllers/server/tests/import-server/00-import-server.yaml
@@ -1,0 +1,13 @@
+---
+apiVersion: openstack.k-orc.cloud/v1alpha1
+kind: Server
+metadata:
+  name: import
+spec:
+  cloudCredentialsRef:
+    cloudName: openstack
+    secretName: openstack-clouds
+  managementPolicy: unmanaged
+  import:
+    filter:
+      name: import-external

--- a/internal/controllers/server/tests/import-server/00-prerequisites.yaml
+++ b/internal/controllers/server/tests/import-server/00-prerequisites.yaml
@@ -1,0 +1,7 @@
+---
+apiVersion: kuttl.dev/v1beta1
+kind: TestStep
+commands:
+  - command: kubectl create secret generic openstack-clouds --from-file=clouds.yaml=${E2E_KUTTL_OSCLOUDS} ${E2E_KUTTL_CACERT_OPT}
+    namespaced: true
+  - script: cat ../templates/create-flavor.tmpl |envsubst | kubectl -n ${NAMESPACE} apply -f -

--- a/internal/controllers/server/tests/import-server/01-assert.yaml
+++ b/internal/controllers/server/tests/import-server/01-assert.yaml
@@ -1,0 +1,32 @@
+---
+apiVersion: openstack.k-orc.cloud/v1alpha1
+kind: Server
+metadata:
+  name: import
+status:
+  conditions:
+    - type: Available
+      message: OpenStack resource is available
+      status: "True"
+      reason: Success
+    - type: Progressing
+      message: OpenStack resource is up to date
+      status: "False"
+      reason: Success
+  resource:
+    name: import-external
+---
+apiVersion: openstack.k-orc.cloud/v1alpha1
+kind: Server
+metadata:
+  name: import-error
+status:
+  conditions:
+    - type: Available
+      message: Waiting for OpenStack resource to be created externally
+      status: "False"
+      reason: Progressing
+    - type: Progressing
+      message: Waiting for OpenStack resource to be created externally
+      status: "True"
+      reason: Progressing

--- a/internal/controllers/server/tests/import-server/01-create-server.yaml
+++ b/internal/controllers/server/tests/import-server/01-create-server.yaml
@@ -1,0 +1,71 @@
+---
+apiVersion: openstack.k-orc.cloud/v1alpha1
+kind: Image
+metadata:
+  name: import-external-image-server
+spec:
+  cloudCredentialsRef:
+    cloudName: openstack-admin
+    secretName: openstack-clouds
+  managementPolicy: managed
+  resource:
+    content:
+      diskFormat: qcow2
+      download:
+        url: https://download.cirros-cloud.net/0.6.3/cirros-0.6.3-x86_64-disk.img
+    visibility: public
+---
+apiVersion: openstack.k-orc.cloud/v1alpha1
+kind: Network
+metadata:
+  name: import-external-network-server
+spec:
+  cloudCredentialsRef:
+    cloudName: openstack
+    secretName: openstack-clouds
+  managementPolicy: managed
+  resource:
+    name: import-external-network-server
+---
+apiVersion: openstack.k-orc.cloud/v1alpha1
+kind: Subnet
+metadata:
+  name: import-external-subnet-server
+spec:
+  cloudCredentialsRef:
+    cloudName: openstack
+    secretName: openstack-clouds
+  managementPolicy: managed
+  networkRef: import-external-network-server
+  resource:
+    ipVersion: 4
+    cidr: 192.168.200.0/24
+---
+apiVersion: openstack.k-orc.cloud/v1alpha1
+kind: Port
+metadata:
+  name: import-external-port-server
+spec:
+  cloudCredentialsRef:
+    cloudName: openstack
+    secretName: openstack-clouds
+  managementPolicy: managed
+  networkRef: import-external-network-server
+  resource:
+    addresses:
+    - subnetRef: import-external-subnet-server
+---
+apiVersion: openstack.k-orc.cloud/v1alpha1
+kind: Server
+metadata:
+  name: import-external
+spec:
+  cloudCredentialsRef:
+    cloudName: openstack
+    secretName: openstack-clouds
+  managementPolicy: managed
+  resource:
+    imageRef: import-external-image-server
+    flavorRef: server-flavor
+    ports:
+    - portRef: import-external-port-server

--- a/internal/controllers/server/tests/import-server/02-assert.yaml
+++ b/internal/controllers/server/tests/import-server/02-assert.yaml
@@ -1,0 +1,12 @@
+---
+apiVersion: kuttl.dev/v1beta1
+kind: TestAssert
+commands:
+- script: "! kubectl get server import --namespace $NAMESPACE"
+  skipLogOutput: true
+- script: "! kubectl get server import-external--namespace $NAMESPACE"
+  skipLogOutput: true
+- script: "! kubectl get server import-error --namespace $NAMESPACE"
+  skipLogOutput: true  
+- script: "! kubectl get flavor server-flavor --namespace $NAMESPACE"
+  skipLogOutput: true

--- a/internal/controllers/server/tests/import-server/02-cleanup.yaml
+++ b/internal/controllers/server/tests/import-server/02-cleanup.yaml
@@ -1,0 +1,27 @@
+apiVersion: kuttl.dev/v1beta1
+kind: TestStep
+delete:
+- apiVersion: openstack.k-orc.cloud/v1alpha1
+  kind: Server
+  name: import
+- apiVersion: openstack.k-orc.cloud/v1alpha1
+  kind: Server
+  name: import-external
+- apiVersion: openstack.k-orc.cloud/v1alpha1
+  kind: Server
+  name: import-error  
+- apiVersion: openstack.k-orc.cloud/v1alpha1
+  kind: Flavor
+  name: server-flavor 
+- apiVersion: openstack.k-orc.cloud/v1alpha1
+  kind: Port
+  name: import-external-port-server
+- apiVersion: openstack.k-orc.cloud/v1alpha1
+  kind: Subnet
+  name: import-external-subnet-server
+- apiVersion: openstack.k-orc.cloud/v1alpha1
+  kind: Network
+  name: import-external-network-server
+- apiVersion: openstack.k-orc.cloud/v1alpha1
+  kind: Image
+  name: import-external-image-server     

--- a/internal/controllers/server/tests/import-server/README.md
+++ b/internal/controllers/server/tests/import-server/README.md
@@ -1,0 +1,16 @@
+# Test import making sure only a server with the exact name matches
+
+## Step 00
+
+Create a secert and import a flavor. Create a server with import resource 'external'.
+Create another server with import resource 'import-external'
+
+## Step 01
+
+Create an image,network,subnet and a port and then create a server with name 'import-external'.
+Make sure only the server with filter of 'import-external is available'
+
+## Step 02
+
+Validate we're able to delete resources.
+Cleaning up resources also avoids a race where kuttl could delete the secret before the other resources.

--- a/internal/controllers/server/tests/templates/create-flavor.tmpl
+++ b/internal/controllers/server/tests/templates/create-flavor.tmpl
@@ -1,0 +1,12 @@
+apiVersion: openstack.k-orc.cloud/v1alpha1
+kind: Flavor
+metadata:
+  name: server-flavor
+spec:
+  cloudCredentialsRef:
+    cloudName: openstack-admin
+    secretName: openstack-clouds
+  managementPolicy: unmanaged
+  import:
+    filter:
+      name: ${E2E_KUTTL_FLAVOR}

--- a/kuttl-test.yaml
+++ b/kuttl-test.yaml
@@ -3,5 +3,6 @@ kind: TestSuite
 testDirs:
 - ./internal/controllers/flavor/tests/
 - ./internal/controllers/network/tests/
+- ./internal/controllers/server/tests/
 - ./internal/controllers/subnet/tests/
-timeout: 120
+timeout: 1200


### PR DESCRIPTION
In adoption use a regular expression to get a specific server instead of using the name as it is which can lead to getting servers that contain the server name in their names Example: We look for 'foo' where there is a server 'foobar'

Also added a test for server adoption
 - Create one server named 'create-adoption'.
- Create another server with the substring of the first - 'adoption'
- Test that the resource name of the second server is 'adoption'.

Fixes: #250 