### PR TITLE
Split test-e2e make target into test-e2e and test-examples

### DIFF
--- a/.github/workflows/e2e.yaml
+++ b/.github/workflows/e2e.yaml
@@ -49,7 +49,9 @@ jobs:
         make deploy IMG=${{ env.image_tag }}
 
     - name: Run e2e tests
-      run: make test-e2e
+      run: |
+        make test-e2e
+        make test-examples
 
     - name: Generate logs on failure
       run: ./hack/collectlogs

--- a/Makefile
+++ b/Makefile
@@ -105,6 +105,10 @@ test-e2e: kuttl
 	# go test ./test/e2e/ -v -ginkgo.v
 	./hack/e2e.sh
 
+.PHONY: test-examples
+test-examples:
+	./hack/run_examples.sh
+
 .PHONY: lint
 lint: golangci-kal ## Run golangci-kal linter
 	$(GOLANGCI_KAL) run

--- a/hack/e2e.sh
+++ b/hack/e2e.sh
@@ -2,15 +2,11 @@
 
 set -euo pipefail
 
-# Path to a clouds.yaml to use for e2e tests.
-E2E_OSCLOUDS=${E2E_OSCLOUDS:-/etc/openstack/clouds.yaml}
+# Move to top level directory
+REAL_PATH=$(realpath $0)
+cd "$(dirname "$REAL_PATH")/.."
 
-# Path to a cacert file to use to connect to OpenStack.
-E2E_CACERT=${E2E_CACERT:-}
-E2E_KUTTL_CACERT_OPT=
-if [ -n "$E2E_CACERT" ]; then
-    E2E_KUTTL_CACERT_OPT="--from-file=cacert=${E2E_CACERT}"
-fi
+source ./hack/init_test_env.sh
 
 # Run kuttl tests from a specific directory.
 # Defaults to empty string (all discovered kuttl directories)
@@ -20,53 +16,13 @@ E2E_KUTTL_DIR=${E2E_KUTTL_DIR:-}
 # Defaults to empty string (run all tests)
 E2E_KUTTL_TEST=${E2E_KUTTL_TEST:-}
 
-# Define a custom external network
-export E2E_EXTERNAL_NETWORK_NAME=${E2E_EXTERNAL_NETWORK_NAME:-private}
-
-creds_dir=$(mktemp -d)
-
-function logresources() {
-    # Log all resources if exiting with an error
-    if [ $? != 0 ]; then
-        kubectl get openstack -o yaml -A
-    fi
-}
-
-function cleanup() {
-    # logresources must be called first as it checks the exit code
-    logresources
-    rm -rf -- "$creds_dir"
-}
-
-trap cleanup EXIT
+E2E_KUTTL_CACERT_OPT=
+if [ -n "$E2E_CACERT" ]; then
+    E2E_KUTTL_CACERT_OPT="--from-file=cacert=${E2E_CACERT}"
+fi
 
 # Export variables referenced in kuttl tests.
-export E2E_KUTTL_OSCLOUDS="${creds_dir}/clouds.yaml"
+export E2E_KUTTL_OSCLOUDS=${PREPARED_OSCLOUDS}
 export E2E_KUTTL_CACERT_OPT
 
-# Name of the openstack credentials to use from the E2E_OSCLOUDS file
-E2E_OPENSTACK_CLOUD_NAME=${E2E_OPENSTACK_CLOUD_NAME:-devstack}
-# Name of the openstack admin credentials to use from the E2E_OSCLOUDS file
-E2E_OPENSTACK_ADMIN_CLOUD_NAME=${E2E_OPENSTACK_ADMIN_CLOUD_NAME:-"devstack-admin-demo"}
-
-cp "${E2E_OSCLOUDS}" "${E2E_KUTTL_OSCLOUDS}"
-sed -r -i "s/^(\s+)${E2E_OPENSTACK_CLOUD_NAME}:/\1openstack:/g" "${E2E_KUTTL_OSCLOUDS}"
-sed -r -i "s/^(\s+)${E2E_OPENSTACK_ADMIN_CLOUD_NAME}:/\1openstack-admin:/g" "${E2E_KUTTL_OSCLOUDS}"
-
 kubectl kuttl test $E2E_KUTTL_DIR --test "$E2E_KUTTL_TEST"
-
-# Now drop admin privileges
-export OS_CLOUD=devstack
-
-cd examples
-
-# Populate local config
-sed "s/  devstack:/  openstack:/g" /etc/openstack/clouds.yaml > local-config/clouds.yaml
-envsubst < local-config/external-network-filter.yaml.example > local-config/external-network-filter.yaml
-make local-config
-
-# Apply the cirros server example and wait for the server to be available
-kubectl apply -k apply/cirros --server-side
-kubectl wait --timeout=10m --for=condition=available server ${USER}-cirros-server
-
-openstack server show "$(kubectl get server ${USER}-cirros-server -o jsonpath='{.status.id}')"

--- a/hack/e2e.sh
+++ b/hack/e2e.sh
@@ -3,8 +3,7 @@
 set -euo pipefail
 
 # Move to top level directory
-REAL_PATH=$(realpath $0)
-cd "$(dirname "$REAL_PATH")/.."
+cd "$(git rev-parse --show-toplevel)"
 
 source ./hack/init_test_env.sh
 

--- a/hack/init_test_env.sh
+++ b/hack/init_test_env.sh
@@ -37,5 +37,10 @@ trap cleanup EXIT
 PREPARED_OSCLOUDS="${creds_dir}/clouds.yaml"
 
 cp "${E2E_OSCLOUDS}" "${PREPARED_OSCLOUDS}"
-sed -r -i "s/^(\s+)${E2E_OPENSTACK_CLOUD_NAME}:/\1openstack:/g" "${PREPARED_OSCLOUDS}"
-sed -r -i "s/^(\s+)${E2E_OPENSTACK_ADMIN_CLOUD_NAME}:/\1openstack-admin:/g" "${PREPARED_OSCLOUDS}"
+if sed --version 2>/dev/null | grep -q GNU; then
+    sed -E -i "s/^([[:space:]]+)${E2E_OPENSTACK_CLOUD_NAME}:/\1openstack:/g" "${PREPARED_OSCLOUDS}"
+    sed -E -i "s/^([[:space:]]+)${E2E_OPENSTACK_ADMIN_CLOUD_NAME}:/\1openstack-admin:/g" "${PREPARED_OSCLOUDS}"
+else
+    sed -E -i' ' "s/^([[:space:]]+)${E2E_OPENSTACK_CLOUD_NAME}:/\1openstack:/g" "${PREPARED_OSCLOUDS}"
+    sed -E -i' ' "s/^([[:space:]]+)${E2E_OPENSTACK_ADMIN_CLOUD_NAME}:/\1openstack-admin:/g" "${PREPARED_OSCLOUDS}"
+fi

--- a/hack/init_test_env.sh
+++ b/hack/init_test_env.sh
@@ -1,0 +1,41 @@
+#!/bin/bash
+
+set -euo pipefail
+
+# Path to a clouds.yaml to use for e2e tests.
+E2E_OSCLOUDS=${E2E_OSCLOUDS:-/etc/openstack/clouds.yaml}
+
+# Path to a cacert file to use to connect to OpenStack.
+E2E_CACERT=${E2E_CACERT:-}
+
+# Name of the openstack credentials to use from the E2E_OSCLOUDS file
+E2E_OPENSTACK_CLOUD_NAME=${E2E_OPENSTACK_CLOUD_NAME:-devstack}
+
+# Name of the openstack admin credentials to use from the E2E_OSCLOUDS file
+E2E_OPENSTACK_ADMIN_CLOUD_NAME=${E2E_OPENSTACK_ADMIN_CLOUD_NAME:-"devstack-admin-demo"}
+
+# Define a custom external network
+E2E_EXTERNAL_NETWORK_NAME=${E2E_EXTERNAL_NETWORK_NAME:-private}
+
+creds_dir=$(mktemp -d)
+
+function logresources() {
+    # Log all resources if exiting with an error
+    if [ $? != 0 ]; then
+        kubectl get openstack -o yaml -A
+    fi
+}
+
+function cleanup() {
+    # logresources must be called first as it checks the exit code
+    logresources
+    rm -rf -- "$creds_dir"
+}
+
+trap cleanup EXIT
+
+PREPARED_OSCLOUDS="${creds_dir}/clouds.yaml"
+
+cp "${E2E_OSCLOUDS}" "${PREPARED_OSCLOUDS}"
+sed -r -i "s/^(\s+)${E2E_OPENSTACK_CLOUD_NAME}:/\1openstack:/g" "${PREPARED_OSCLOUDS}"
+sed -r -i "s/^(\s+)${E2E_OPENSTACK_ADMIN_CLOUD_NAME}:/\1openstack-admin:/g" "${PREPARED_OSCLOUDS}"

--- a/hack/run_examples.sh
+++ b/hack/run_examples.sh
@@ -1,0 +1,26 @@
+#!/bin/bash
+
+set -euo pipefail
+
+# Move to top level directory
+REAL_PATH=$(realpath $0)
+cd "$(dirname "$REAL_PATH")/.."
+
+source ./hack/init_test_env.sh
+
+export OS_CLOUD=${E2E_OPENSTACK_CLOUD_NAME}
+
+export E2E_EXTERNAL_NETWORK_NAME
+
+cd ./examples
+
+# Populate local config
+cp "${PREPARED_OSCLOUDS}" local-config/clouds.yaml
+envsubst < local-config/external-network-filter.yaml.example > local-config/external-network-filter.yaml
+make local-config
+
+# Apply the cirros server example and wait for the server to be available
+kubectl apply -k apply/cirros --server-side
+kubectl wait --timeout=10m --for=condition=available server ${USER}-cirros-server
+
+openstack server show "$(kubectl get server ${USER}-cirros-server -o jsonpath='{.status.id}')"

--- a/hack/run_examples.sh
+++ b/hack/run_examples.sh
@@ -3,8 +3,7 @@
 set -euo pipefail
 
 # Move to top level directory
-REAL_PATH=$(realpath $0)
-cd "$(dirname "$REAL_PATH")/.."
+cd "$(git rev-parse --show-toplevel)"
 
 source ./hack/init_test_env.sh
 


### PR DESCRIPTION
This makes it more user friendly for local development by allowing running the kuttl tests alone.