### PR TITLE
Break generic controller into multiple packages

### DIFF
--- a/cmd/manager/main.go
+++ b/cmd/manager/main.go
@@ -27,8 +27,8 @@ import (
 	ctrl "sigs.k8s.io/controller-runtime"
 	"sigs.k8s.io/controller-runtime/pkg/log/zap"
 
-	"github.com/k-orc/openstack-resource-controller/internal/controllers/export"
 	"github.com/k-orc/openstack-resource-controller/internal/controllers/flavor"
+	"github.com/k-orc/openstack-resource-controller/internal/controllers/generic/interfaces"
 	"github.com/k-orc/openstack-resource-controller/internal/controllers/image"
 	"github.com/k-orc/openstack-resource-controller/internal/controllers/network"
 	"github.com/k-orc/openstack-resource-controller/internal/controllers/port"
@@ -96,7 +96,7 @@ func main() {
 	}
 	scopeFactory := scope.NewFactory(orcOpts.ScopeCacheMaxSize, caCerts)
 
-	controllers := []export.Controller{
+	controllers := []interfaces.Controller{
 		image.New(scopeFactory),
 		network.New(scopeFactory),
 		subnet.New(scopeFactory),

--- a/cmd/resource-generator/data/adapter.template
+++ b/cmd/resource-generator/data/adapter.template
@@ -18,7 +18,7 @@ package {{ .NameLower }}
 
 import (
 	orcv1alpha1 "github.com/k-orc/openstack-resource-controller/api/v1alpha1"
-	"github.com/k-orc/openstack-resource-controller/internal/controllers/generic"
+	"github.com/k-orc/openstack-resource-controller/internal/controllers/generic/interfaces"
 )
 
 // Fundamental types
@@ -32,7 +32,7 @@ type (
 // Derived types
 type (
 	orcObjectPT    = *orcObjectT
-	adapterI       = generic.APIObjectAdapter[orcObjectPT, resourceSpecT, filterT]
+	adapterI       = interfaces.APIObjectAdapter[orcObjectPT, resourceSpecT, filterT]
 	adapterT       = {{ .NameLower }}Adapter
 )
 

--- a/cmd/resource-generator/data/controller.template
+++ b/cmd/resource-generator/data/controller.template
@@ -19,7 +19,7 @@ package {{ .NameLower }}
 import (
 	corev1 "k8s.io/api/core/v1"
 
-	"github.com/k-orc/openstack-resource-controller/internal/controllers/generic"
+        orcstrings "github.com/k-orc/openstack-resource-controller/internal/util/strings"
 	"github.com/k-orc/openstack-resource-controller/internal/util/dependency"
 )
 
@@ -27,11 +27,11 @@ var (
 	// NOTE: controllerName must be defined in any controller using this template
 
 	// finalizer is the string this controller adds to an object's Finalizers
-	finalizer  = generic.GetFinalizerName(controllerName)
+	finalizer  = orcstrings.GetFinalizerName(controllerName)
 
 	// externalObjectFieldOwner is the field owner we use when using
 	// server-side-apply on objects we don't control
-	externalObjectFieldOwner = generic.GetSSAFieldOwner(controllerName)
+	externalObjectFieldOwner = orcstrings.GetSSAFieldOwner(controllerName)
 
 	credentialsDependency = dependency.NewDeletionGuardDependency[*orcObjectListT, *corev1.Secret](
 		"spec.cloudCredentialsRef.secretName",

--- a/internal/controllers/flavor/actuator.go
+++ b/internal/controllers/flavor/actuator.go
@@ -26,7 +26,8 @@ import (
 	ctrl "sigs.k8s.io/controller-runtime"
 
 	orcv1alpha1 "github.com/k-orc/openstack-resource-controller/api/v1alpha1"
-	"github.com/k-orc/openstack-resource-controller/internal/controllers/generic"
+	generic "github.com/k-orc/openstack-resource-controller/internal/controllers/generic/interfaces"
+	"github.com/k-orc/openstack-resource-controller/internal/controllers/generic/progress"
 	osclients "github.com/k-orc/openstack-resource-controller/internal/osclients"
 	orcerrors "github.com/k-orc/openstack-resource-controller/internal/util/errors"
 )
@@ -129,7 +130,7 @@ func (actuator flavorActuator) listOSResources(ctx context.Context, filters []os
 	return osclients.Filter(flavors, filters...)
 }
 
-func (actuator flavorActuator) CreateResource(ctx context.Context, obj orcObjectPT) ([]generic.ProgressStatus, *flavors.Flavor, error) {
+func (actuator flavorActuator) CreateResource(ctx context.Context, obj orcObjectPT) ([]progress.ProgressStatus, *flavors.Flavor, error) {
 	resource := obj.Spec.Resource
 
 	if resource == nil {
@@ -160,7 +161,7 @@ func (actuator flavorActuator) CreateResource(ctx context.Context, obj orcObject
 	return nil, osResource, nil
 }
 
-func (actuator flavorActuator) DeleteResource(ctx context.Context, _ orcObjectPT, flavor *flavors.Flavor) ([]generic.ProgressStatus, error) {
+func (actuator flavorActuator) DeleteResource(ctx context.Context, _ orcObjectPT, flavor *flavors.Flavor) ([]progress.ProgressStatus, error) {
 	return nil, actuator.osClient.DeleteFlavor(ctx, flavor.ID)
 }
 
@@ -168,7 +169,7 @@ type flavorHelperFactory struct{}
 
 var _ helperFactory = flavorHelperFactory{}
 
-func newActuator(ctx context.Context, orcObject *orcv1alpha1.Flavor, controller generic.ResourceController) (flavorActuator, []generic.ProgressStatus, error) {
+func newActuator(ctx context.Context, orcObject *orcv1alpha1.Flavor, controller generic.ResourceController) (flavorActuator, []progress.ProgressStatus, error) {
 	log := ctrl.LoggerFrom(ctx)
 
 	// Ensure credential secrets exist and have our finalizer
@@ -195,12 +196,12 @@ func (flavorHelperFactory) NewAPIObjectAdapter(obj orcObjectPT) adapterI {
 	return flavorAdapter{obj}
 }
 
-func (flavorHelperFactory) NewCreateActuator(ctx context.Context, orcObject orcObjectPT, controller generic.ResourceController) ([]generic.ProgressStatus, createResourceActuator, error) {
+func (flavorHelperFactory) NewCreateActuator(ctx context.Context, orcObject orcObjectPT, controller generic.ResourceController) ([]progress.ProgressStatus, createResourceActuator, error) {
 	actuator, progressStatus, err := newActuator(ctx, orcObject, controller)
 	return progressStatus, actuator, err
 }
 
-func (flavorHelperFactory) NewDeleteActuator(ctx context.Context, orcObject orcObjectPT, controller generic.ResourceController) ([]generic.ProgressStatus, deleteResourceActuator, error) {
+func (flavorHelperFactory) NewDeleteActuator(ctx context.Context, orcObject orcObjectPT, controller generic.ResourceController) ([]progress.ProgressStatus, deleteResourceActuator, error) {
 	actuator, progressStatus, err := newActuator(ctx, orcObject, controller)
 	return progressStatus, actuator, err
 }

--- a/internal/controllers/flavor/controller.go
+++ b/internal/controllers/flavor/controller.go
@@ -25,8 +25,8 @@ import (
 
 	orcv1alpha1 "github.com/k-orc/openstack-resource-controller/api/v1alpha1"
 
-	ctrlexport "github.com/k-orc/openstack-resource-controller/internal/controllers/export"
-	"github.com/k-orc/openstack-resource-controller/internal/controllers/generic"
+	"github.com/k-orc/openstack-resource-controller/internal/controllers/generic/interfaces"
+	"github.com/k-orc/openstack-resource-controller/internal/controllers/generic/reconciler"
 	"github.com/k-orc/openstack-resource-controller/internal/scope"
 	"github.com/k-orc/openstack-resource-controller/internal/util/credentials"
 )
@@ -40,7 +40,7 @@ type flavorReconcilerConstructor struct {
 	scopeFactory scope.Factory
 }
 
-func New(scopeFactory scope.Factory) ctrlexport.Controller {
+func New(scopeFactory scope.Factory) interfaces.Controller {
 	return flavorReconcilerConstructor{scopeFactory: scopeFactory}
 }
 
@@ -63,6 +63,6 @@ func (c flavorReconcilerConstructor) SetupWithManager(ctx context.Context, mgr c
 		return err
 	}
 
-	reconciler := generic.NewController(controllerName, mgr.GetClient(), c.scopeFactory, flavorHelperFactory{}, flavorStatusWriter{})
-	return builder.Complete(&reconciler)
+	r := reconciler.NewController(controllerName, mgr.GetClient(), c.scopeFactory, flavorHelperFactory{}, flavorStatusWriter{})
+	return builder.Complete(&r)
 }

--- a/internal/controllers/flavor/status.go
+++ b/internal/controllers/flavor/status.go
@@ -21,7 +21,7 @@ import (
 	"github.com/gophercloud/gophercloud/v2/openstack/compute/v2/flavors"
 
 	orcv1alpha1 "github.com/k-orc/openstack-resource-controller/api/v1alpha1"
-	"github.com/k-orc/openstack-resource-controller/internal/controllers/generic"
+	generic "github.com/k-orc/openstack-resource-controller/internal/controllers/generic/interfaces"
 	orcapplyconfigv1alpha1 "github.com/k-orc/openstack-resource-controller/pkg/clients/applyconfiguration/api/v1alpha1"
 )
 

--- a/internal/controllers/flavor/zz_generated.adapter.go
+++ b/internal/controllers/flavor/zz_generated.adapter.go
@@ -19,7 +19,7 @@ package flavor
 
 import (
 	orcv1alpha1 "github.com/k-orc/openstack-resource-controller/api/v1alpha1"
-	"github.com/k-orc/openstack-resource-controller/internal/controllers/generic"
+	"github.com/k-orc/openstack-resource-controller/internal/controllers/generic/interfaces"
 )
 
 // Fundamental types
@@ -33,7 +33,7 @@ type (
 // Derived types
 type (
 	orcObjectPT    = *orcObjectT
-	adapterI       = generic.APIObjectAdapter[orcObjectPT, resourceSpecT, filterT]
+	adapterI       = interfaces.APIObjectAdapter[orcObjectPT, resourceSpecT, filterT]
 	adapterT       = flavorAdapter
 )
 

--- a/internal/controllers/flavor/zz_generated.controller.go
+++ b/internal/controllers/flavor/zz_generated.controller.go
@@ -20,7 +20,7 @@ package flavor
 import (
 	corev1 "k8s.io/api/core/v1"
 
-	"github.com/k-orc/openstack-resource-controller/internal/controllers/generic"
+        orcstrings "github.com/k-orc/openstack-resource-controller/internal/util/strings"
 	"github.com/k-orc/openstack-resource-controller/internal/util/dependency"
 )
 
@@ -28,11 +28,11 @@ var (
 	// NOTE: controllerName must be defined in any controller using this template
 
 	// finalizer is the string this controller adds to an object's Finalizers
-	finalizer  = generic.GetFinalizerName(controllerName)
+	finalizer  = orcstrings.GetFinalizerName(controllerName)
 
 	// externalObjectFieldOwner is the field owner we use when using
 	// server-side-apply on objects we don't control
-	externalObjectFieldOwner = generic.GetSSAFieldOwner(controllerName)
+	externalObjectFieldOwner = orcstrings.GetSSAFieldOwner(controllerName)
 
 	credentialsDependency = dependency.NewDeletionGuardDependency[*orcObjectListT, *corev1.Secret](
 		"spec.cloudCredentialsRef.secretName",

--- a/internal/controllers/generic/interfaces/adapter.go
+++ b/internal/controllers/generic/interfaces/adapter.go
@@ -14,7 +14,7 @@ See the License for the specific language governing permissions and
 limitations under the License.
 */
 
-package generic
+package interfaces
 
 import (
 	metav1 "k8s.io/apimachinery/pkg/apis/meta/v1"

--- a/internal/controllers/generic/interfaces/controller.go
+++ b/internal/controllers/generic/interfaces/controller.go
@@ -1,5 +1,5 @@
 /*
-Copyright 2024 The ORC Authors.
+Copyright 2025 The ORC Authors.
 
 Licensed under the Apache License, Version 2.0 (the "License");
 you may not use this file except in compliance with the License.
@@ -14,18 +14,26 @@ See the License for the specific language governing permissions and
 limitations under the License.
 */
 
-package export
-
-// This file provides a minimal exported interface to non-exported controllers
+package interfaces
 
 import (
 	"context"
 
 	ctrl "sigs.k8s.io/controller-runtime"
+	"sigs.k8s.io/controller-runtime/pkg/client"
 	"sigs.k8s.io/controller-runtime/pkg/controller"
+
+	"github.com/k-orc/openstack-resource-controller/internal/scope"
 )
 
 type Controller interface {
 	SetupWithManager(context.Context, ctrl.Manager, controller.Options) error
 	GetName() string
+}
+
+type ResourceController interface {
+	GetName() string
+
+	GetK8sClient() client.Client
+	GetScopeFactory() scope.Factory
 }

--- a/internal/controllers/generic/interfaces/status.go
+++ b/internal/controllers/generic/interfaces/status.go
@@ -1,0 +1,43 @@
+/*
+Copyright 2025 The ORC Authors.
+
+Licensed under the Apache License, Version 2.0 (the "License");
+you may not use this file except in compliance with the License.
+You may obtain a copy of the License at
+
+	http://www.apache.org/licenses/LICENSE-2.0
+
+Unless required by applicable law or agreed to in writing, software
+distributed under the License is distributed on an "AS IS" BASIS,
+WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+See the License for the specific language governing permissions and
+limitations under the License.
+*/
+
+package interfaces
+
+import (
+	"github.com/go-logr/logr"
+	"k8s.io/apimachinery/pkg/types"
+	applyconfigv1 "k8s.io/client-go/applyconfigurations/meta/v1"
+
+	orcv1alpha1 "github.com/k-orc/openstack-resource-controller/api/v1alpha1"
+)
+
+type ORCApplyConfig[objectApplyPT any, statusApplyPT ORCStatusApplyConfig[statusApplyPT]] interface {
+	WithUID(types.UID) objectApplyPT
+	WithStatus(statusApplyPT) objectApplyPT
+}
+
+type ORCStatusApplyConfig[statusApplyPT any] interface {
+	WithConditions(...*applyconfigv1.ConditionApplyConfiguration) statusApplyPT
+	WithID(id string) statusApplyPT
+}
+
+type ORCApplyConfigConstructor[objectApplyPT ORCApplyConfig[objectApplyPT, statusApplyPT], statusApplyPT ORCStatusApplyConfig[statusApplyPT]] func(name, namespace string) objectApplyPT
+
+type ResourceStatusWriter[objectPT orcv1alpha1.ObjectWithConditions, osResourcePT any, objectApplyPT ORCApplyConfig[objectApplyPT, statusApplyPT], statusApplyPT ORCStatusApplyConfig[statusApplyPT]] interface {
+	GetApplyConfigConstructor() ORCApplyConfigConstructor[objectApplyPT, statusApplyPT]
+	ResourceIsAvailable(orcObject objectPT, osResource osResourcePT) bool
+	ApplyResourceStatus(log logr.Logger, osResource osResourcePT, statusApply statusApplyPT)
+}

--- a/internal/controllers/generic/progress/progress_status.go
+++ b/internal/controllers/generic/progress/progress_status.go
@@ -14,7 +14,7 @@ See the License for the specific language governing permissions and
 limitations under the License.
 */
 
-package generic
+package progress
 
 import (
 	"fmt"

--- a/internal/controllers/generic/status/conditions.go
+++ b/internal/controllers/generic/status/conditions.go
@@ -13,7 +13,7 @@ WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
 See the License for the specific language governing permissions and
 limitations under the License.
 */
-package generic
+package status
 
 import (
 	"errors"
@@ -24,6 +24,7 @@ import (
 	applyconfigv1 "k8s.io/client-go/applyconfigurations/meta/v1"
 
 	orcv1alpha1 "github.com/k-orc/openstack-resource-controller/api/v1alpha1"
+	"github.com/k-orc/openstack-resource-controller/internal/controllers/generic/progress"
 	"github.com/k-orc/openstack-resource-controller/internal/util/applyconfigs"
 	orcerrors "github.com/k-orc/openstack-resource-controller/internal/util/errors"
 )
@@ -32,7 +33,7 @@ type WithConditionsApplyConfiguration[T any] interface {
 	WithConditions(...*applyconfigv1.ConditionApplyConfiguration) T
 }
 
-func SetCommonConditions[T any](orcObject orcv1alpha1.ObjectWithConditions, applyConfig WithConditionsApplyConfiguration[T], isAvailable bool, progressStatus []ProgressStatus, err error, now metav1.Time) {
+func SetCommonConditions[T any](orcObject orcv1alpha1.ObjectWithConditions, applyConfig WithConditionsApplyConfiguration[T], isAvailable bool, progressStatus []progress.ProgressStatus, err error, now metav1.Time) {
 	availableCondition := applyconfigv1.Condition().
 		WithType(orcv1alpha1.ConditionAvailable).
 		WithObservedGeneration(orcObject.GetGeneration())

--- a/internal/controllers/image/controller.go
+++ b/internal/controllers/image/controller.go
@@ -28,8 +28,7 @@ import (
 
 	orcv1alpha1 "github.com/k-orc/openstack-resource-controller/api/v1alpha1"
 
-	ctrlexport "github.com/k-orc/openstack-resource-controller/internal/controllers/export"
-	"github.com/k-orc/openstack-resource-controller/internal/controllers/generic"
+	"github.com/k-orc/openstack-resource-controller/internal/controllers/generic/interfaces"
 	"github.com/k-orc/openstack-resource-controller/internal/scope"
 	"github.com/k-orc/openstack-resource-controller/internal/util/credentials"
 )
@@ -62,7 +61,7 @@ type imageReconcilerConstructor struct {
 	scopeFactory scope.Factory
 }
 
-func New(scopeFactory scope.Factory) ctrlexport.Controller {
+func New(scopeFactory scope.Factory) interfaces.Controller {
 	return imageReconcilerConstructor{scopeFactory: scopeFactory}
 }
 
@@ -78,7 +77,7 @@ type orcImageReconciler struct {
 	imageReconcilerConstructor
 }
 
-var _ generic.ResourceController = &orcImageReconciler{}
+var _ interfaces.ResourceController = &orcImageReconciler{}
 
 func (r *orcImageReconciler) GetK8sClient() client.Client {
 	return r.client

--- a/internal/controllers/image/status.go
+++ b/internal/controllers/image/status.go
@@ -32,7 +32,7 @@ import (
 	"sigs.k8s.io/controller-runtime/pkg/client"
 
 	orcv1alpha1 "github.com/k-orc/openstack-resource-controller/api/v1alpha1"
-	"github.com/k-orc/openstack-resource-controller/internal/controllers/generic"
+	"github.com/k-orc/openstack-resource-controller/internal/controllers/generic/progress"
 	"github.com/k-orc/openstack-resource-controller/internal/util/applyconfigs"
 	orcerrors "github.com/k-orc/openstack-resource-controller/internal/util/errors"
 	orcapplyconfigv1alpha1 "github.com/k-orc/openstack-resource-controller/pkg/clients/applyconfiguration/api/v1alpha1"
@@ -58,7 +58,7 @@ type updateStatusOpts struct {
 	progressMessage           *string
 	err                       error
 	incrementDownloadAttempts bool
-	progressStatus            []generic.ProgressStatus
+	progressStatus            []progress.ProgressStatus
 }
 
 type updateStatusOpt func(*updateStatusOpts)
@@ -75,7 +75,7 @@ func withError(err error) updateStatusOpt {
 	}
 }
 
-func withProgressStatus(progressStatus ...generic.ProgressStatus) updateStatusOpt {
+func withProgressStatus(progressStatus ...progress.ProgressStatus) updateStatusOpt {
 	return func(opts *updateStatusOpts) {
 		opts.progressStatus = append(opts.progressStatus, progressStatus...)
 	}

--- a/internal/controllers/image/zz_generated.adapter.go
+++ b/internal/controllers/image/zz_generated.adapter.go
@@ -19,7 +19,7 @@ package image
 
 import (
 	orcv1alpha1 "github.com/k-orc/openstack-resource-controller/api/v1alpha1"
-	"github.com/k-orc/openstack-resource-controller/internal/controllers/generic"
+	"github.com/k-orc/openstack-resource-controller/internal/controllers/generic/interfaces"
 )
 
 // Fundamental types
@@ -33,7 +33,7 @@ type (
 // Derived types
 type (
 	orcObjectPT    = *orcObjectT
-	adapterI       = generic.APIObjectAdapter[orcObjectPT, resourceSpecT, filterT]
+	adapterI       = interfaces.APIObjectAdapter[orcObjectPT, resourceSpecT, filterT]
 	adapterT       = imageAdapter
 )
 

--- a/internal/controllers/image/zz_generated.controller.go
+++ b/internal/controllers/image/zz_generated.controller.go
@@ -20,7 +20,7 @@ package image
 import (
 	corev1 "k8s.io/api/core/v1"
 
-	"github.com/k-orc/openstack-resource-controller/internal/controllers/generic"
+        orcstrings "github.com/k-orc/openstack-resource-controller/internal/util/strings"
 	"github.com/k-orc/openstack-resource-controller/internal/util/dependency"
 )
 
@@ -28,11 +28,11 @@ var (
 	// NOTE: controllerName must be defined in any controller using this template
 
 	// finalizer is the string this controller adds to an object's Finalizers
-	finalizer  = generic.GetFinalizerName(controllerName)
+	finalizer  = orcstrings.GetFinalizerName(controllerName)
 
 	// externalObjectFieldOwner is the field owner we use when using
 	// server-side-apply on objects we don't control
-	externalObjectFieldOwner = generic.GetSSAFieldOwner(controllerName)
+	externalObjectFieldOwner = orcstrings.GetSSAFieldOwner(controllerName)
 
 	credentialsDependency = dependency.NewDeletionGuardDependency[*orcObjectListT, *corev1.Secret](
 		"spec.cloudCredentialsRef.secretName",

--- a/internal/controllers/network/controller.go
+++ b/internal/controllers/network/controller.go
@@ -25,8 +25,8 @@ import (
 
 	orcv1alpha1 "github.com/k-orc/openstack-resource-controller/api/v1alpha1"
 
-	ctrlexport "github.com/k-orc/openstack-resource-controller/internal/controllers/export"
-	"github.com/k-orc/openstack-resource-controller/internal/controllers/generic"
+	"github.com/k-orc/openstack-resource-controller/internal/controllers/generic/interfaces"
+	"github.com/k-orc/openstack-resource-controller/internal/controllers/generic/reconciler"
 	"github.com/k-orc/openstack-resource-controller/internal/scope"
 	"github.com/k-orc/openstack-resource-controller/internal/util/credentials"
 )
@@ -40,7 +40,7 @@ type networkReconcilerConstructor struct {
 	scopeFactory scope.Factory
 }
 
-func New(scopeFactory scope.Factory) ctrlexport.Controller {
+func New(scopeFactory scope.Factory) interfaces.Controller {
 	return networkReconcilerConstructor{
 		scopeFactory: scopeFactory,
 	}
@@ -65,6 +65,6 @@ func (c networkReconcilerConstructor) SetupWithManager(ctx context.Context, mgr 
 		return err
 	}
 
-	reconciler := generic.NewController(controllerName, mgr.GetClient(), c.scopeFactory, networkHelperFactory{}, networkStatusWriter{})
-	return builder.Complete(&reconciler)
+	r := reconciler.NewController(controllerName, mgr.GetClient(), c.scopeFactory, networkHelperFactory{}, networkStatusWriter{})
+	return builder.Complete(&r)
 }

--- a/internal/controllers/network/status.go
+++ b/internal/controllers/network/status.go
@@ -23,7 +23,7 @@ import (
 	metav1 "k8s.io/apimachinery/pkg/apis/meta/v1"
 
 	orcv1alpha1 "github.com/k-orc/openstack-resource-controller/api/v1alpha1"
-	"github.com/k-orc/openstack-resource-controller/internal/controllers/generic"
+	"github.com/k-orc/openstack-resource-controller/internal/controllers/generic/interfaces"
 	"github.com/k-orc/openstack-resource-controller/internal/osclients"
 	orcapplyconfigv1alpha1 "github.com/k-orc/openstack-resource-controller/pkg/clients/applyconfiguration/api/v1alpha1"
 )
@@ -34,9 +34,9 @@ const (
 
 type networkStatusWriter struct{}
 
-var _ generic.ResourceStatusWriter[*orcv1alpha1.Network, *osclients.NetworkExt, *orcapplyconfigv1alpha1.NetworkApplyConfiguration, *orcapplyconfigv1alpha1.NetworkStatusApplyConfiguration] = networkStatusWriter{}
+var _ interfaces.ResourceStatusWriter[*orcv1alpha1.Network, *osclients.NetworkExt, *orcapplyconfigv1alpha1.NetworkApplyConfiguration, *orcapplyconfigv1alpha1.NetworkStatusApplyConfiguration] = networkStatusWriter{}
 
-func (networkStatusWriter) GetApplyConfigConstructor() generic.ORCApplyConfigConstructor[*orcapplyconfigv1alpha1.NetworkApplyConfiguration, *orcapplyconfigv1alpha1.NetworkStatusApplyConfiguration] {
+func (networkStatusWriter) GetApplyConfigConstructor() interfaces.ORCApplyConfigConstructor[*orcapplyconfigv1alpha1.NetworkApplyConfiguration, *orcapplyconfigv1alpha1.NetworkStatusApplyConfiguration] {
 	return orcapplyconfigv1alpha1.Network
 }
 

--- a/internal/controllers/network/zz_generated.adapter.go
+++ b/internal/controllers/network/zz_generated.adapter.go
@@ -19,7 +19,7 @@ package network
 
 import (
 	orcv1alpha1 "github.com/k-orc/openstack-resource-controller/api/v1alpha1"
-	"github.com/k-orc/openstack-resource-controller/internal/controllers/generic"
+	"github.com/k-orc/openstack-resource-controller/internal/controllers/generic/interfaces"
 )
 
 // Fundamental types
@@ -33,7 +33,7 @@ type (
 // Derived types
 type (
 	orcObjectPT    = *orcObjectT
-	adapterI       = generic.APIObjectAdapter[orcObjectPT, resourceSpecT, filterT]
+	adapterI       = interfaces.APIObjectAdapter[orcObjectPT, resourceSpecT, filterT]
 	adapterT       = networkAdapter
 )
 

--- a/internal/controllers/network/zz_generated.controller.go
+++ b/internal/controllers/network/zz_generated.controller.go
@@ -20,7 +20,7 @@ package network
 import (
 	corev1 "k8s.io/api/core/v1"
 
-	"github.com/k-orc/openstack-resource-controller/internal/controllers/generic"
+        orcstrings "github.com/k-orc/openstack-resource-controller/internal/util/strings"
 	"github.com/k-orc/openstack-resource-controller/internal/util/dependency"
 )
 
@@ -28,11 +28,11 @@ var (
 	// NOTE: controllerName must be defined in any controller using this template
 
 	// finalizer is the string this controller adds to an object's Finalizers
-	finalizer  = generic.GetFinalizerName(controllerName)
+	finalizer  = orcstrings.GetFinalizerName(controllerName)
 
 	// externalObjectFieldOwner is the field owner we use when using
 	// server-side-apply on objects we don't control
-	externalObjectFieldOwner = generic.GetSSAFieldOwner(controllerName)
+	externalObjectFieldOwner = orcstrings.GetSSAFieldOwner(controllerName)
 
 	credentialsDependency = dependency.NewDeletionGuardDependency[*orcObjectListT, *corev1.Secret](
 		"spec.cloudCredentialsRef.secretName",

--- a/internal/controllers/port/controller.go
+++ b/internal/controllers/port/controller.go
@@ -27,8 +27,8 @@ import (
 	orcv1alpha1 "github.com/k-orc/openstack-resource-controller/api/v1alpha1"
 	"github.com/k-orc/openstack-resource-controller/pkg/predicates"
 
-	ctrlexport "github.com/k-orc/openstack-resource-controller/internal/controllers/export"
-	"github.com/k-orc/openstack-resource-controller/internal/controllers/generic"
+	"github.com/k-orc/openstack-resource-controller/internal/controllers/generic/interfaces"
+	"github.com/k-orc/openstack-resource-controller/internal/controllers/generic/reconciler"
 	"github.com/k-orc/openstack-resource-controller/internal/scope"
 	"github.com/k-orc/openstack-resource-controller/internal/util/credentials"
 	"github.com/k-orc/openstack-resource-controller/internal/util/dependency"
@@ -77,7 +77,7 @@ type portReconcilerConstructor struct {
 	scopeFactory scope.Factory
 }
 
-func New(scopeFactory scope.Factory) ctrlexport.Controller {
+func New(scopeFactory scope.Factory) interfaces.Controller {
 	return portReconcilerConstructor{scopeFactory: scopeFactory}
 }
 
@@ -128,6 +128,6 @@ func (c portReconcilerConstructor) SetupWithManager(ctx context.Context, mgr ctr
 		return err
 	}
 
-	reconciler := generic.NewController(controllerName, k8sClient, c.scopeFactory, portHelperFactory{}, portStatusWriter{})
-	return builder.Complete(&reconciler)
+	r := reconciler.NewController(controllerName, k8sClient, c.scopeFactory, portHelperFactory{}, portStatusWriter{})
+	return builder.Complete(&r)
 }

--- a/internal/controllers/port/status.go
+++ b/internal/controllers/port/status.go
@@ -20,7 +20,7 @@ import (
 	"github.com/go-logr/logr"
 	metav1 "k8s.io/apimachinery/pkg/apis/meta/v1"
 
-	"github.com/k-orc/openstack-resource-controller/internal/controllers/generic"
+	"github.com/k-orc/openstack-resource-controller/internal/controllers/generic/interfaces"
 	orcapplyconfigv1alpha1 "github.com/k-orc/openstack-resource-controller/pkg/clients/applyconfiguration/api/v1alpha1"
 )
 
@@ -34,9 +34,9 @@ type statusApplyPT = *orcapplyconfigv1alpha1.PortStatusApplyConfiguration
 
 type portStatusWriter struct{}
 
-var _ generic.ResourceStatusWriter[orcObjectPT, *osResourceT, objectApplyPT, statusApplyPT] = portStatusWriter{}
+var _ interfaces.ResourceStatusWriter[orcObjectPT, *osResourceT, objectApplyPT, statusApplyPT] = portStatusWriter{}
 
-func (portStatusWriter) GetApplyConfigConstructor() generic.ORCApplyConfigConstructor[objectApplyPT, statusApplyPT] {
+func (portStatusWriter) GetApplyConfigConstructor() interfaces.ORCApplyConfigConstructor[objectApplyPT, statusApplyPT] {
 	return orcapplyconfigv1alpha1.Port
 }
 

--- a/internal/controllers/port/zz_generated.adapter.go
+++ b/internal/controllers/port/zz_generated.adapter.go
@@ -19,7 +19,7 @@ package port
 
 import (
 	orcv1alpha1 "github.com/k-orc/openstack-resource-controller/api/v1alpha1"
-	"github.com/k-orc/openstack-resource-controller/internal/controllers/generic"
+	"github.com/k-orc/openstack-resource-controller/internal/controllers/generic/interfaces"
 )
 
 // Fundamental types
@@ -33,7 +33,7 @@ type (
 // Derived types
 type (
 	orcObjectPT    = *orcObjectT
-	adapterI       = generic.APIObjectAdapter[orcObjectPT, resourceSpecT, filterT]
+	adapterI       = interfaces.APIObjectAdapter[orcObjectPT, resourceSpecT, filterT]
 	adapterT       = portAdapter
 )
 

--- a/internal/controllers/port/zz_generated.controller.go
+++ b/internal/controllers/port/zz_generated.controller.go
@@ -20,7 +20,7 @@ package port
 import (
 	corev1 "k8s.io/api/core/v1"
 
-	"github.com/k-orc/openstack-resource-controller/internal/controllers/generic"
+        orcstrings "github.com/k-orc/openstack-resource-controller/internal/util/strings"
 	"github.com/k-orc/openstack-resource-controller/internal/util/dependency"
 )
 
@@ -28,11 +28,11 @@ var (
 	// NOTE: controllerName must be defined in any controller using this template
 
 	// finalizer is the string this controller adds to an object's Finalizers
-	finalizer  = generic.GetFinalizerName(controllerName)
+	finalizer  = orcstrings.GetFinalizerName(controllerName)
 
 	// externalObjectFieldOwner is the field owner we use when using
 	// server-side-apply on objects we don't control
-	externalObjectFieldOwner = generic.GetSSAFieldOwner(controllerName)
+	externalObjectFieldOwner = orcstrings.GetSSAFieldOwner(controllerName)
 
 	credentialsDependency = dependency.NewDeletionGuardDependency[*orcObjectListT, *corev1.Secret](
 		"spec.cloudCredentialsRef.secretName",

--- a/internal/controllers/router/controller.go
+++ b/internal/controllers/router/controller.go
@@ -27,8 +27,8 @@ import (
 	orcv1alpha1 "github.com/k-orc/openstack-resource-controller/api/v1alpha1"
 	"github.com/k-orc/openstack-resource-controller/pkg/predicates"
 
-	ctrlexport "github.com/k-orc/openstack-resource-controller/internal/controllers/export"
-	"github.com/k-orc/openstack-resource-controller/internal/controllers/generic"
+	"github.com/k-orc/openstack-resource-controller/internal/controllers/generic/interfaces"
+	"github.com/k-orc/openstack-resource-controller/internal/controllers/generic/reconciler"
 	"github.com/k-orc/openstack-resource-controller/internal/scope"
 	"github.com/k-orc/openstack-resource-controller/internal/util/credentials"
 	"github.com/k-orc/openstack-resource-controller/internal/util/dependency"
@@ -41,7 +41,7 @@ type routerReconcilerConstructor struct {
 	scopeFactory scope.Factory
 }
 
-func New(scopeFactory scope.Factory) ctrlexport.Controller {
+func New(scopeFactory scope.Factory) interfaces.Controller {
 	return routerReconcilerConstructor{scopeFactory: scopeFactory}
 }
 
@@ -96,6 +96,6 @@ func (c routerReconcilerConstructor) SetupWithManager(ctx context.Context, mgr c
 		return err
 	}
 
-	reconciler := generic.NewController(controllerName, k8sClient, c.scopeFactory, routerHelperFactory{}, routerStatusWriter{})
-	return builder.Complete(&reconciler)
+	r := reconciler.NewController(controllerName, k8sClient, c.scopeFactory, routerHelperFactory{}, routerStatusWriter{})
+	return builder.Complete(&r)
 }

--- a/internal/controllers/router/status.go
+++ b/internal/controllers/router/status.go
@@ -19,7 +19,7 @@ package router
 import (
 	"github.com/go-logr/logr"
 
-	"github.com/k-orc/openstack-resource-controller/internal/controllers/generic"
+	"github.com/k-orc/openstack-resource-controller/internal/controllers/generic/interfaces"
 	orcapplyconfigv1alpha1 "github.com/k-orc/openstack-resource-controller/pkg/clients/applyconfiguration/api/v1alpha1"
 )
 
@@ -32,9 +32,9 @@ type statusApplyPT = *orcapplyconfigv1alpha1.RouterStatusApplyConfiguration
 
 type routerStatusWriter struct{}
 
-var _ generic.ResourceStatusWriter[orcObjectPT, *osResourceT, objectApplyPT, statusApplyPT] = routerStatusWriter{}
+var _ interfaces.ResourceStatusWriter[orcObjectPT, *osResourceT, objectApplyPT, statusApplyPT] = routerStatusWriter{}
 
-func (routerStatusWriter) GetApplyConfigConstructor() generic.ORCApplyConfigConstructor[objectApplyPT, statusApplyPT] {
+func (routerStatusWriter) GetApplyConfigConstructor() interfaces.ORCApplyConfigConstructor[objectApplyPT, statusApplyPT] {
 	return orcapplyconfigv1alpha1.Router
 }
 

--- a/internal/controllers/router/zz_generated.adapter.go
+++ b/internal/controllers/router/zz_generated.adapter.go
@@ -19,7 +19,7 @@ package router
 
 import (
 	orcv1alpha1 "github.com/k-orc/openstack-resource-controller/api/v1alpha1"
-	"github.com/k-orc/openstack-resource-controller/internal/controllers/generic"
+	"github.com/k-orc/openstack-resource-controller/internal/controllers/generic/interfaces"
 )
 
 // Fundamental types
@@ -33,7 +33,7 @@ type (
 // Derived types
 type (
 	orcObjectPT    = *orcObjectT
-	adapterI       = generic.APIObjectAdapter[orcObjectPT, resourceSpecT, filterT]
+	adapterI       = interfaces.APIObjectAdapter[orcObjectPT, resourceSpecT, filterT]
 	adapterT       = routerAdapter
 )
 

--- a/internal/controllers/router/zz_generated.controller.go
+++ b/internal/controllers/router/zz_generated.controller.go
@@ -20,7 +20,7 @@ package router
 import (
 	corev1 "k8s.io/api/core/v1"
 
-	"github.com/k-orc/openstack-resource-controller/internal/controllers/generic"
+        orcstrings "github.com/k-orc/openstack-resource-controller/internal/util/strings"
 	"github.com/k-orc/openstack-resource-controller/internal/util/dependency"
 )
 
@@ -28,11 +28,11 @@ var (
 	// NOTE: controllerName must be defined in any controller using this template
 
 	// finalizer is the string this controller adds to an object's Finalizers
-	finalizer  = generic.GetFinalizerName(controllerName)
+	finalizer  = orcstrings.GetFinalizerName(controllerName)
 
 	// externalObjectFieldOwner is the field owner we use when using
 	// server-side-apply on objects we don't control
-	externalObjectFieldOwner = generic.GetSSAFieldOwner(controllerName)
+	externalObjectFieldOwner = orcstrings.GetSSAFieldOwner(controllerName)
 
 	credentialsDependency = dependency.NewDeletionGuardDependency[*orcObjectListT, *corev1.Secret](
 		"spec.cloudCredentialsRef.secretName",

--- a/internal/controllers/routerinterface/controller.go
+++ b/internal/controllers/routerinterface/controller.go
@@ -33,10 +33,10 @@ import (
 	orcv1alpha1 "github.com/k-orc/openstack-resource-controller/api/v1alpha1"
 	"github.com/k-orc/openstack-resource-controller/pkg/predicates"
 
-	ctrlexport "github.com/k-orc/openstack-resource-controller/internal/controllers/export"
-	"github.com/k-orc/openstack-resource-controller/internal/controllers/generic"
+	"github.com/k-orc/openstack-resource-controller/internal/controllers/generic/interfaces"
 	"github.com/k-orc/openstack-resource-controller/internal/scope"
 	"github.com/k-orc/openstack-resource-controller/internal/util/dependency"
+	orcstrings "github.com/k-orc/openstack-resource-controller/internal/util/strings"
 )
 
 const (
@@ -48,7 +48,7 @@ type routerInterfaceReconcilerConstructor struct {
 	scopeFactory scope.Factory
 }
 
-func New(scopeFactory scope.Factory) ctrlexport.Controller {
+func New(scopeFactory scope.Factory) interfaces.Controller {
 	return routerInterfaceReconcilerConstructor{scopeFactory: scopeFactory}
 }
 
@@ -65,8 +65,8 @@ type orcRouterInterfaceReconciler struct {
 const controllerName = "routerinterface"
 
 var (
-	finalizer  = generic.GetFinalizerName(controllerName)
-	fieldOwner = generic.GetSSAFieldOwner(controllerName)
+	finalizer  = orcstrings.GetFinalizerName(controllerName)
+	fieldOwner = orcstrings.GetSSAFieldOwner(controllerName)
 
 	routerDependency = dependency.NewDeletionGuardDependency[*orcv1alpha1.RouterInterfaceList, *orcv1alpha1.Router](
 		"spec.routerRef",

--- a/internal/controllers/routerinterface/reconcile.go
+++ b/internal/controllers/routerinterface/reconcile.go
@@ -31,12 +31,12 @@ import (
 	"sigs.k8s.io/controller-runtime/pkg/controller/controllerutil"
 
 	orcv1alpha1 "github.com/k-orc/openstack-resource-controller/api/v1alpha1"
-	"github.com/k-orc/openstack-resource-controller/internal/controllers/generic"
 	"github.com/k-orc/openstack-resource-controller/internal/controllers/port"
 	osclients "github.com/k-orc/openstack-resource-controller/internal/osclients"
 	"github.com/k-orc/openstack-resource-controller/internal/util/dependency"
 	orcerrors "github.com/k-orc/openstack-resource-controller/internal/util/errors"
 	"github.com/k-orc/openstack-resource-controller/internal/util/finalizers"
+	orcstrings "github.com/k-orc/openstack-resource-controller/internal/util/strings"
 )
 
 const noRequeue time.Duration = 0
@@ -177,7 +177,7 @@ func (r *orcRouterInterfaceReconciler) reconcileNormal(ctx context.Context, rout
 		// Adding the finalizer only when creating a resource means we don't add
 		// it until all dependent resources are available, which means we don't
 		// have to handle unavailable dependencies in the delete flow
-		if err := dependency.EnsureFinalizer(ctx, r.client, routerInterface, finalizer, generic.GetSSAFieldOwnerWithTxn(controllerName, generic.SSATransactionFinalizer)); err != nil {
+		if err := dependency.EnsureFinalizer(ctx, r.client, routerInterface, finalizer, orcstrings.GetSSAFieldOwnerWithTxn(controllerName, orcstrings.SSATransactionFinalizer)); err != nil {
 			return noRequeue, fmt.Errorf("setting finalizer for %s: %w", client.ObjectKeyFromObject(routerInterface), err)
 		}
 
@@ -320,7 +320,7 @@ func (r *orcRouterInterfaceReconciler) reconcileDelete(ctx context.Context, rout
 
 	// Clear the finalizer
 	log.V(3).Info("Router interface deleted")
-	return noRequeue, r.client.Patch(ctx, routerInterface, finalizers.RemoveFinalizerPatch(routerInterface), client.ForceOwnership, generic.GetSSAFieldOwnerWithTxn(controllerName, generic.SSATransactionFinalizer))
+	return noRequeue, r.client.Patch(ctx, routerInterface, finalizers.RemoveFinalizerPatch(routerInterface), client.ForceOwnership, orcstrings.GetSSAFieldOwnerWithTxn(controllerName, orcstrings.SSATransactionFinalizer))
 }
 
 func (r *orcRouterInterfaceReconciler) reconcileDeleteSubnet(ctx context.Context, routerInterface *orcv1alpha1.RouterInterface, routerInterfacePorts []ports.Port, statusOpts *updateStatusOpts) (bool, routers.RemoveInterfaceOptsBuilder, error) {

--- a/internal/controllers/securitygroup/actuator_test.go
+++ b/internal/controllers/securitygroup/actuator_test.go
@@ -26,7 +26,7 @@ import (
 	"github.com/gophercloud/gophercloud/v2/openstack/networking/v2/extensions/security/groups"
 	"github.com/gophercloud/gophercloud/v2/openstack/networking/v2/extensions/security/rules"
 	orcv1alpha1 "github.com/k-orc/openstack-resource-controller/api/v1alpha1"
-	"github.com/k-orc/openstack-resource-controller/internal/controllers/generic"
+	"github.com/k-orc/openstack-resource-controller/internal/controllers/generic/progress"
 	"github.com/k-orc/openstack-resource-controller/internal/osclients/mock"
 	"go.uber.org/mock/gomock"
 	"k8s.io/utils/ptr"
@@ -75,7 +75,7 @@ func Test_securityGroupActuator_updateRules(t *testing.T) {
 		orcObject  orcObjectPT
 		osResource *osResourceT
 		expect     func(*mock.MockNetworkClientMockRecorder)
-		wantEvents []generic.ProgressStatus
+		wantEvents []progress.ProgressStatus
 		wantErrs   []error
 	}{
 		{
@@ -115,8 +115,8 @@ func Test_securityGroupActuator_updateRules(t *testing.T) {
 				}
 				recorder.CreateSecGroupRules(gomock.Any(), []rules.CreateOpts{createOpts}).Return(nil, nil)
 			},
-			wantEvents: []generic.ProgressStatus{
-				generic.WaitingOnOpenStackUpdate(time.Second),
+			wantEvents: []progress.ProgressStatus{
+				progress.WaitingOnOpenStackUpdate(time.Second),
 			},
 		},
 		{
@@ -164,8 +164,8 @@ func Test_securityGroupActuator_updateRules(t *testing.T) {
 			expect: func(recorder *mock.MockNetworkClientMockRecorder) {
 				recorder.DeleteSecGroupRule(gomock.Any(), ruleID).Return(nil)
 			},
-			wantEvents: []generic.ProgressStatus{
-				generic.WaitingOnOpenStackUpdate(time.Second),
+			wantEvents: []progress.ProgressStatus{
+				progress.WaitingOnOpenStackUpdate(time.Second),
 			},
 		},
 		{
@@ -207,8 +207,8 @@ func Test_securityGroupActuator_updateRules(t *testing.T) {
 				recorder.CreateSecGroupRules(gomock.Any(), []rules.CreateOpts{createOpts}).Return(nil, nil)
 				recorder.DeleteSecGroupRule(gomock.Any(), ruleID).Return(nil)
 			},
-			wantEvents: []generic.ProgressStatus{
-				generic.WaitingOnOpenStackUpdate(time.Second),
+			wantEvents: []progress.ProgressStatus{
+				progress.WaitingOnOpenStackUpdate(time.Second),
 			},
 		},
 		{
@@ -259,8 +259,8 @@ func Test_securityGroupActuator_updateRules(t *testing.T) {
 				}
 				recorder.CreateSecGroupRules(gomock.Any(), []rules.CreateOpts{createOpts}).Return(nil, nil)
 			},
-			wantEvents: []generic.ProgressStatus{
-				generic.WaitingOnOpenStackUpdate(time.Second),
+			wantEvents: []progress.ProgressStatus{
+				progress.WaitingOnOpenStackUpdate(time.Second),
 			},
 		},
 		{
@@ -302,8 +302,8 @@ func Test_securityGroupActuator_updateRules(t *testing.T) {
 				recorder.CreateSecGroupRules(gomock.Any(), []rules.CreateOpts{createOpts}).Return(nil, createError)
 				recorder.DeleteSecGroupRule(gomock.Any(), ruleID).Return(nil)
 			},
-			wantEvents: []generic.ProgressStatus{
-				generic.WaitingOnOpenStackUpdate(time.Second),
+			wantEvents: []progress.ProgressStatus{
+				progress.WaitingOnOpenStackUpdate(time.Second),
 			},
 			wantErrs: []error{createError},
 		},
@@ -357,8 +357,8 @@ func Test_securityGroupActuator_updateRules(t *testing.T) {
 				recorder.DeleteSecGroupRule(gomock.Any(), ruleID).Return(deleteError)
 				recorder.DeleteSecGroupRule(gomock.Any(), ruleID2).Return(nil)
 			},
-			wantEvents: []generic.ProgressStatus{
-				generic.WaitingOnOpenStackUpdate(time.Second),
+			wantEvents: []progress.ProgressStatus{
+				progress.WaitingOnOpenStackUpdate(time.Second),
 			},
 			wantErrs: []error{deleteError},
 		},
@@ -401,8 +401,8 @@ func Test_securityGroupActuator_updateRules(t *testing.T) {
 				recorder.CreateSecGroupRules(gomock.Any(), []rules.CreateOpts{createOpts}).Return(nil, createError)
 				recorder.DeleteSecGroupRule(gomock.Any(), ruleID).Return(deleteError)
 			},
-			wantEvents: []generic.ProgressStatus{
-				generic.WaitingOnOpenStackUpdate(time.Second),
+			wantEvents: []progress.ProgressStatus{
+				progress.WaitingOnOpenStackUpdate(time.Second),
 			},
 			wantErrs: []error{createError, deleteError},
 		},

--- a/internal/controllers/securitygroup/controller.go
+++ b/internal/controllers/securitygroup/controller.go
@@ -25,8 +25,8 @@ import (
 
 	orcv1alpha1 "github.com/k-orc/openstack-resource-controller/api/v1alpha1"
 
-	ctrlexport "github.com/k-orc/openstack-resource-controller/internal/controllers/export"
-	"github.com/k-orc/openstack-resource-controller/internal/controllers/generic"
+	"github.com/k-orc/openstack-resource-controller/internal/controllers/generic/interfaces"
+	"github.com/k-orc/openstack-resource-controller/internal/controllers/generic/reconciler"
 	"github.com/k-orc/openstack-resource-controller/internal/scope"
 	"github.com/k-orc/openstack-resource-controller/internal/util/credentials"
 )
@@ -40,7 +40,7 @@ type securitygroupReconcilerConstructor struct {
 	scopeFactory scope.Factory
 }
 
-func New(scopeFactory scope.Factory) ctrlexport.Controller {
+func New(scopeFactory scope.Factory) interfaces.Controller {
 	return securitygroupReconcilerConstructor{
 		scopeFactory: scopeFactory,
 	}
@@ -65,7 +65,7 @@ func (c securitygroupReconcilerConstructor) SetupWithManager(ctx context.Context
 		return err
 	}
 
-	reconciler := generic.NewController(controllerName, mgr.GetClient(), c.scopeFactory, securityGroupHelperFactory{}, securityGroupStatusWriter{})
-	return builder.Complete(&reconciler)
+	r := reconciler.NewController(controllerName, mgr.GetClient(), c.scopeFactory, securityGroupHelperFactory{}, securityGroupStatusWriter{})
+	return builder.Complete(&r)
 
 }

--- a/internal/controllers/securitygroup/status.go
+++ b/internal/controllers/securitygroup/status.go
@@ -20,7 +20,7 @@ import (
 	"github.com/go-logr/logr"
 	metav1 "k8s.io/apimachinery/pkg/apis/meta/v1"
 
-	"github.com/k-orc/openstack-resource-controller/internal/controllers/generic"
+	"github.com/k-orc/openstack-resource-controller/internal/controllers/generic/interfaces"
 	orcapplyconfigv1alpha1 "github.com/k-orc/openstack-resource-controller/pkg/clients/applyconfiguration/api/v1alpha1"
 )
 
@@ -29,9 +29,9 @@ type statusApplyPT = *orcapplyconfigv1alpha1.SecurityGroupStatusApplyConfigurati
 
 type securityGroupStatusWriter struct{}
 
-var _ generic.ResourceStatusWriter[orcObjectPT, *osResourceT, objectApplyPT, statusApplyPT] = securityGroupStatusWriter{}
+var _ interfaces.ResourceStatusWriter[orcObjectPT, *osResourceT, objectApplyPT, statusApplyPT] = securityGroupStatusWriter{}
 
-func (securityGroupStatusWriter) GetApplyConfigConstructor() generic.ORCApplyConfigConstructor[objectApplyPT, statusApplyPT] {
+func (securityGroupStatusWriter) GetApplyConfigConstructor() interfaces.ORCApplyConfigConstructor[objectApplyPT, statusApplyPT] {
 	return orcapplyconfigv1alpha1.SecurityGroup
 }
 

--- a/internal/controllers/securitygroup/zz_generated.adapter.go
+++ b/internal/controllers/securitygroup/zz_generated.adapter.go
@@ -19,7 +19,7 @@ package securitygroup
 
 import (
 	orcv1alpha1 "github.com/k-orc/openstack-resource-controller/api/v1alpha1"
-	"github.com/k-orc/openstack-resource-controller/internal/controllers/generic"
+	"github.com/k-orc/openstack-resource-controller/internal/controllers/generic/interfaces"
 )
 
 // Fundamental types
@@ -33,7 +33,7 @@ type (
 // Derived types
 type (
 	orcObjectPT    = *orcObjectT
-	adapterI       = generic.APIObjectAdapter[orcObjectPT, resourceSpecT, filterT]
+	adapterI       = interfaces.APIObjectAdapter[orcObjectPT, resourceSpecT, filterT]
 	adapterT       = securitygroupAdapter
 )
 

--- a/internal/controllers/securitygroup/zz_generated.controller.go
+++ b/internal/controllers/securitygroup/zz_generated.controller.go
@@ -20,7 +20,7 @@ package securitygroup
 import (
 	corev1 "k8s.io/api/core/v1"
 
-	"github.com/k-orc/openstack-resource-controller/internal/controllers/generic"
+        orcstrings "github.com/k-orc/openstack-resource-controller/internal/util/strings"
 	"github.com/k-orc/openstack-resource-controller/internal/util/dependency"
 )
 
@@ -28,11 +28,11 @@ var (
 	// NOTE: controllerName must be defined in any controller using this template
 
 	// finalizer is the string this controller adds to an object's Finalizers
-	finalizer  = generic.GetFinalizerName(controllerName)
+	finalizer  = orcstrings.GetFinalizerName(controllerName)
 
 	// externalObjectFieldOwner is the field owner we use when using
 	// server-side-apply on objects we don't control
-	externalObjectFieldOwner = generic.GetSSAFieldOwner(controllerName)
+	externalObjectFieldOwner = orcstrings.GetSSAFieldOwner(controllerName)
 
 	credentialsDependency = dependency.NewDeletionGuardDependency[*orcObjectListT, *corev1.Secret](
 		"spec.cloudCredentialsRef.secretName",

--- a/internal/controllers/server/controller.go
+++ b/internal/controllers/server/controller.go
@@ -26,8 +26,8 @@ import (
 	"sigs.k8s.io/controller-runtime/pkg/controller"
 
 	orcv1alpha1 "github.com/k-orc/openstack-resource-controller/api/v1alpha1"
-	ctrlexport "github.com/k-orc/openstack-resource-controller/internal/controllers/export"
-	"github.com/k-orc/openstack-resource-controller/internal/controllers/generic"
+	"github.com/k-orc/openstack-resource-controller/internal/controllers/generic/interfaces"
+	"github.com/k-orc/openstack-resource-controller/internal/controllers/generic/reconciler"
 	"github.com/k-orc/openstack-resource-controller/internal/scope"
 	"github.com/k-orc/openstack-resource-controller/internal/util/credentials"
 	"github.com/k-orc/openstack-resource-controller/internal/util/dependency"
@@ -41,7 +41,7 @@ type serverReconcilerConstructor struct {
 	scopeFactory scope.Factory
 }
 
-func New(scopeFactory scope.Factory) ctrlexport.Controller {
+func New(scopeFactory scope.Factory) interfaces.Controller {
 	return serverReconcilerConstructor{scopeFactory: scopeFactory}
 }
 
@@ -171,6 +171,6 @@ func (c serverReconcilerConstructor) SetupWithManager(ctx context.Context, mgr c
 		return err
 	}
 
-	reconciler := generic.NewController(controllerName, k8sClient, c.scopeFactory, serverHelperFactory{}, serverStatusWriter{})
-	return builder.Complete(&reconciler)
+	r := reconciler.NewController(controllerName, k8sClient, c.scopeFactory, serverHelperFactory{}, serverStatusWriter{})
+	return builder.Complete(&r)
 }

--- a/internal/controllers/server/status.go
+++ b/internal/controllers/server/status.go
@@ -22,7 +22,7 @@ import (
 	"github.com/go-logr/logr"
 	"k8s.io/utils/ptr"
 
-	"github.com/k-orc/openstack-resource-controller/internal/controllers/generic"
+	"github.com/k-orc/openstack-resource-controller/internal/controllers/generic/interfaces"
 	orcapplyconfigv1alpha1 "github.com/k-orc/openstack-resource-controller/pkg/clients/applyconfiguration/api/v1alpha1"
 )
 
@@ -36,9 +36,9 @@ type statusApplyPT = *orcapplyconfigv1alpha1.ServerStatusApplyConfiguration
 
 type serverStatusWriter struct{}
 
-var _ generic.ResourceStatusWriter[orcObjectPT, *osResourceT, objectApplyPT, statusApplyPT] = serverStatusWriter{}
+var _ interfaces.ResourceStatusWriter[orcObjectPT, *osResourceT, objectApplyPT, statusApplyPT] = serverStatusWriter{}
 
-func (serverStatusWriter) GetApplyConfigConstructor() generic.ORCApplyConfigConstructor[objectApplyPT, statusApplyPT] {
+func (serverStatusWriter) GetApplyConfigConstructor() interfaces.ORCApplyConfigConstructor[objectApplyPT, statusApplyPT] {
 	return orcapplyconfigv1alpha1.Server
 }
 

--- a/internal/controllers/server/zz_generated.adapter.go
+++ b/internal/controllers/server/zz_generated.adapter.go
@@ -19,7 +19,7 @@ package server
 
 import (
 	orcv1alpha1 "github.com/k-orc/openstack-resource-controller/api/v1alpha1"
-	"github.com/k-orc/openstack-resource-controller/internal/controllers/generic"
+	"github.com/k-orc/openstack-resource-controller/internal/controllers/generic/interfaces"
 )
 
 // Fundamental types
@@ -33,7 +33,7 @@ type (
 // Derived types
 type (
 	orcObjectPT    = *orcObjectT
-	adapterI       = generic.APIObjectAdapter[orcObjectPT, resourceSpecT, filterT]
+	adapterI       = interfaces.APIObjectAdapter[orcObjectPT, resourceSpecT, filterT]
 	adapterT       = serverAdapter
 )
 

--- a/internal/controllers/server/zz_generated.controller.go
+++ b/internal/controllers/server/zz_generated.controller.go
@@ -20,7 +20,7 @@ package server
 import (
 	corev1 "k8s.io/api/core/v1"
 
-	"github.com/k-orc/openstack-resource-controller/internal/controllers/generic"
+        orcstrings "github.com/k-orc/openstack-resource-controller/internal/util/strings"
 	"github.com/k-orc/openstack-resource-controller/internal/util/dependency"
 )
 
@@ -28,11 +28,11 @@ var (
 	// NOTE: controllerName must be defined in any controller using this template
 
 	// finalizer is the string this controller adds to an object's Finalizers
-	finalizer  = generic.GetFinalizerName(controllerName)
+	finalizer  = orcstrings.GetFinalizerName(controllerName)
 
 	// externalObjectFieldOwner is the field owner we use when using
 	// server-side-apply on objects we don't control
-	externalObjectFieldOwner = generic.GetSSAFieldOwner(controllerName)
+	externalObjectFieldOwner = orcstrings.GetSSAFieldOwner(controllerName)
 
 	credentialsDependency = dependency.NewDeletionGuardDependency[*orcObjectListT, *corev1.Secret](
 		"spec.cloudCredentialsRef.secretName",

--- a/internal/controllers/subnet/controller.go
+++ b/internal/controllers/subnet/controller.go
@@ -30,8 +30,8 @@ import (
 	"sigs.k8s.io/controller-runtime/pkg/reconcile"
 
 	orcv1alpha1 "github.com/k-orc/openstack-resource-controller/api/v1alpha1"
-	ctrlexport "github.com/k-orc/openstack-resource-controller/internal/controllers/export"
-	"github.com/k-orc/openstack-resource-controller/internal/controllers/generic"
+	"github.com/k-orc/openstack-resource-controller/internal/controllers/generic/interfaces"
+	"github.com/k-orc/openstack-resource-controller/internal/controllers/generic/reconciler"
 	"github.com/k-orc/openstack-resource-controller/internal/scope"
 	"github.com/k-orc/openstack-resource-controller/internal/util/credentials"
 	"github.com/k-orc/openstack-resource-controller/internal/util/dependency"
@@ -42,7 +42,7 @@ type subnetReconcilerConstructor struct {
 	scopeFactory scope.Factory
 }
 
-func New(scopeFactory scope.Factory) ctrlexport.Controller {
+func New(scopeFactory scope.Factory) interfaces.Controller {
 	return subnetReconcilerConstructor{scopeFactory: scopeFactory}
 }
 
@@ -106,6 +106,6 @@ func (c subnetReconcilerConstructor) SetupWithManager(ctx context.Context, mgr c
 		return err
 	}
 
-	reconciler := generic.NewController(controllerName, k8sClient, c.scopeFactory, subnetHelperFactory{}, subnetStatusWriter{})
-	return builder.Complete(&reconciler)
+	r := reconciler.NewController(controllerName, k8sClient, c.scopeFactory, subnetHelperFactory{}, subnetStatusWriter{})
+	return builder.Complete(&r)
 }

--- a/internal/controllers/subnet/status.go
+++ b/internal/controllers/subnet/status.go
@@ -19,7 +19,7 @@ package subnet
 import (
 	"github.com/go-logr/logr"
 
-	"github.com/k-orc/openstack-resource-controller/internal/controllers/generic"
+	"github.com/k-orc/openstack-resource-controller/internal/controllers/generic/interfaces"
 	orcapplyconfigv1alpha1 "github.com/k-orc/openstack-resource-controller/pkg/clients/applyconfiguration/api/v1alpha1"
 )
 
@@ -28,9 +28,9 @@ type statusApplyPT = *orcapplyconfigv1alpha1.SubnetStatusApplyConfiguration
 
 type subnetStatusWriter struct{}
 
-var _ generic.ResourceStatusWriter[orcObjectPT, *osResourceT, objectApplyPT, statusApplyPT] = subnetStatusWriter{}
+var _ interfaces.ResourceStatusWriter[orcObjectPT, *osResourceT, objectApplyPT, statusApplyPT] = subnetStatusWriter{}
 
-func (subnetStatusWriter) GetApplyConfigConstructor() generic.ORCApplyConfigConstructor[objectApplyPT, statusApplyPT] {
+func (subnetStatusWriter) GetApplyConfigConstructor() interfaces.ORCApplyConfigConstructor[objectApplyPT, statusApplyPT] {
 	return orcapplyconfigv1alpha1.Subnet
 }
 

--- a/internal/controllers/subnet/zz_generated.adapter.go
+++ b/internal/controllers/subnet/zz_generated.adapter.go
@@ -19,7 +19,7 @@ package subnet
 
 import (
 	orcv1alpha1 "github.com/k-orc/openstack-resource-controller/api/v1alpha1"
-	"github.com/k-orc/openstack-resource-controller/internal/controllers/generic"
+	"github.com/k-orc/openstack-resource-controller/internal/controllers/generic/interfaces"
 )
 
 // Fundamental types
@@ -33,7 +33,7 @@ type (
 // Derived types
 type (
 	orcObjectPT    = *orcObjectT
-	adapterI       = generic.APIObjectAdapter[orcObjectPT, resourceSpecT, filterT]
+	adapterI       = interfaces.APIObjectAdapter[orcObjectPT, resourceSpecT, filterT]
 	adapterT       = subnetAdapter
 )
 

--- a/internal/controllers/subnet/zz_generated.controller.go
+++ b/internal/controllers/subnet/zz_generated.controller.go
@@ -20,7 +20,7 @@ package subnet
 import (
 	corev1 "k8s.io/api/core/v1"
 
-	"github.com/k-orc/openstack-resource-controller/internal/controllers/generic"
+        orcstrings "github.com/k-orc/openstack-resource-controller/internal/util/strings"
 	"github.com/k-orc/openstack-resource-controller/internal/util/dependency"
 )
 
@@ -28,11 +28,11 @@ var (
 	// NOTE: controllerName must be defined in any controller using this template
 
 	// finalizer is the string this controller adds to an object's Finalizers
-	finalizer  = generic.GetFinalizerName(controllerName)
+	finalizer  = orcstrings.GetFinalizerName(controllerName)
 
 	// externalObjectFieldOwner is the field owner we use when using
 	// server-side-apply on objects we don't control
-	externalObjectFieldOwner = generic.GetSSAFieldOwner(controllerName)
+	externalObjectFieldOwner = orcstrings.GetSSAFieldOwner(controllerName)
 
 	credentialsDependency = dependency.NewDeletionGuardDependency[*orcObjectListT, *corev1.Secret](
 		"spec.cloudCredentialsRef.secretName",

--- a/internal/manager/manager.go
+++ b/internal/manager/manager.go
@@ -36,7 +36,7 @@ import (
 	"sigs.k8s.io/controller-runtime/pkg/webhook"
 
 	"github.com/go-logr/logr"
-	"github.com/k-orc/openstack-resource-controller/internal/controllers/export"
+	"github.com/k-orc/openstack-resource-controller/internal/controllers/generic/interfaces"
 	// +kubebuilder:scaffold:imports
 )
 
@@ -51,7 +51,7 @@ type Options struct {
 	WatchNamespaces      []string
 }
 
-func Run(ctx context.Context, opts *Options, restConfig *rest.Config, scheme *runtime.Scheme, setupLog, log logr.Logger, controllers []export.Controller) error {
+func Run(ctx context.Context, opts *Options, restConfig *rest.Config, scheme *runtime.Scheme, setupLog, log logr.Logger, controllers []interfaces.Controller) error {
 	// if the enable-http2 flag is false (the default), http/2 should be disabled
 	// due to its vulnerabilities. More specifically, disabling http/2 will
 	// prevent from being vulnerable to the HTTP/2 Stream Cancellation and

--- a/internal/util/strings/strings.go
+++ b/internal/util/strings/strings.go
@@ -14,7 +14,7 @@ See the License for the specific language governing permissions and
 limitations under the License.
 */
 
-package generic
+package strings
 
 import (
 	"sigs.k8s.io/controller-runtime/pkg/client"


### PR DESCRIPTION
The immediate motivation for doing this is making the interfaces which are now
in `generic/interfaces` more discoverable, as these are the ones a controller
writer needs to implement. However, it's been due for a while.
