### PR TITLE
✨ feat(securitygroup): Add kuttl tests for SecurityGroup controller

### DIFF
--- a/internal/controllers/securitygroup/tests/create-full/00-assert.yaml
+++ b/internal/controllers/securitygroup/tests/create-full/00-assert.yaml
@@ -1,0 +1,22 @@
+---
+apiVersion: openstack.k-orc.cloud/v1alpha1
+kind: SecurityGroup
+metadata:
+  name: create-full
+status:
+  resource:
+    name: create-full-override
+    description: SecurityGroup from "create full" test
+    stateful: false
+    rules:
+    - direction: ingress
+      description: Ingress rule from "create full" test
+      ethertype: IPv4
+      protocol: tcp
+      portRange:
+        min: 80
+        max: 80
+      remoteIPPrefix: 1.2.3.4/32
+    tags:
+    - tag1
+    - tag2

--- a/internal/controllers/securitygroup/tests/create-full/00-secret.yaml
+++ b/internal/controllers/securitygroup/tests/create-full/00-secret.yaml
@@ -1,0 +1,5 @@
+apiVersion: kuttl.dev/v1beta1
+kind: TestStep
+commands:
+  - command: kubectl create secret generic openstack-clouds --from-file=clouds.yaml=${E2E_KUTTL_OSCLOUDS} ${E2E_KUTTL_CACERT_OPT}
+    namespaced: true

--- a/internal/controllers/securitygroup/tests/create-full/00-securitygroup.yaml
+++ b/internal/controllers/securitygroup/tests/create-full/00-securitygroup.yaml
@@ -1,0 +1,26 @@
+---
+apiVersion: openstack.k-orc.cloud/v1alpha1
+kind: SecurityGroup
+metadata:
+  name: create-full
+spec:
+  cloudCredentialsRef:
+    cloudName: openstack
+    secretName: openstack-clouds
+  managementPolicy: managed
+  resource:
+    name: create-full-override
+    description: SecurityGroup from "create full" test
+    stateful: false
+    rules:
+    - direction: ingress
+      description: Ingress rule from "create full" test
+      ethertype: IPv4
+      protocol: tcp
+      portRange:
+        min: 80
+        max: 80
+      remoteIPPrefix: 1.2.3.4/32
+    tags:
+    - tag1
+    - tag2

--- a/internal/controllers/securitygroup/tests/create-full/README.md
+++ b/internal/controllers/securitygroup/tests/create-full/README.md
@@ -1,0 +1,7 @@
+# Create a security group with all the options
+
+## Step 00
+
+Create a security group using all available fields, and verify that the observed state corresponds to the spec.
+
+Also validate that the OpenStack resource uses the name from the spec when it is specified.

--- a/internal/controllers/securitygroup/tests/create-minimal/00-assert.yaml
+++ b/internal/controllers/securitygroup/tests/create-minimal/00-assert.yaml
@@ -1,0 +1,8 @@
+---
+apiVersion: openstack.k-orc.cloud/v1alpha1
+kind: SecurityGroup
+metadata:
+  name: create-minimal
+status:
+  resource:
+    name: create-minimal

--- a/internal/controllers/securitygroup/tests/create-minimal/00-secret.yaml
+++ b/internal/controllers/securitygroup/tests/create-minimal/00-secret.yaml
@@ -1,0 +1,5 @@
+apiVersion: kuttl.dev/v1beta1
+kind: TestStep
+commands:
+  - command: kubectl create secret generic openstack-clouds --from-file=clouds.yaml=${E2E_KUTTL_OSCLOUDS} ${E2E_KUTTL_CACERT_OPT}
+    namespaced: true

--- a/internal/controllers/securitygroup/tests/create-minimal/00-securitygroup.yaml
+++ b/internal/controllers/securitygroup/tests/create-minimal/00-securitygroup.yaml
@@ -1,0 +1,11 @@
+---
+apiVersion: openstack.k-orc.cloud/v1alpha1
+kind: SecurityGroup
+metadata:
+  name: create-minimal
+spec:
+  cloudCredentialsRef:
+    cloudName: openstack
+    secretName: openstack-clouds
+  managementPolicy: managed
+  resource: {}

--- a/internal/controllers/securitygroup/tests/create-minimal/01-assert.yaml
+++ b/internal/controllers/securitygroup/tests/create-minimal/01-assert.yaml
@@ -1,0 +1,11 @@
+---
+apiVersion: kuttl.dev/v1beta1
+kind: TestAssert
+resourceRefs:
+    - apiVersion: v1
+      kind: Secret
+      name: openstack-clouds
+      ref: secret
+assertAll:
+    - celExpr: "secret.metadata.deletionTimestamp != 0"
+    - celExpr: "'openstack.k-orc.cloud/securitygroup' in secret.metadata.finalizers"

--- a/internal/controllers/securitygroup/tests/create-minimal/01-delete-secret.yaml
+++ b/internal/controllers/securitygroup/tests/create-minimal/01-delete-secret.yaml
@@ -1,0 +1,6 @@
+apiVersion: kuttl.dev/v1beta1
+kind: TestStep
+commands:
+  # We expect the deletion to hang due to the finalizer, so use --wait=false
+  - command: kubectl delete secret openstack-clouds --wait=false
+    namespaced: true

--- a/internal/controllers/securitygroup/tests/create-minimal/README.md
+++ b/internal/controllers/securitygroup/tests/create-minimal/README.md
@@ -1,0 +1,11 @@
+# Create a security group with the minimum options
+
+## Step 00
+
+Create a minimal security group, that sets only the required fields, and verify that the observed state corresponds to the spec.
+
+Also validate that the OpenStack resource uses the name of the ORC object when it is not specified.
+
+## Step 01
+
+Try deleting the secret and ensure that it is not deleted thanks to the finalizer.

--- a/internal/controllers/securitygroup/tests/import-error/00-assert.yaml
+++ b/internal/controllers/securitygroup/tests/import-error/00-assert.yaml
@@ -1,0 +1,30 @@
+---
+apiVersion: openstack.k-orc.cloud/v1alpha1
+kind: SecurityGroup
+metadata:
+  name: import-error-external-1
+status:
+  conditions:
+    - type: Available
+      message: OpenStack resource is available
+      status: "True"
+      reason: Success
+    - type: Progressing
+      message: OpenStack resource is up to date
+      status: "False"
+      reason: Success
+---
+apiVersion: openstack.k-orc.cloud/v1alpha1
+kind: SecurityGroup
+metadata:
+  name: import-error-external-2
+status:
+  conditions:
+    - type: Available
+      message: OpenStack resource is available
+      status: "True"
+      reason: Success
+    - type: Progressing
+      message: OpenStack resource is up to date
+      status: "False"
+      reason: Success

--- a/internal/controllers/securitygroup/tests/import-error/00-create-securitygroups.yaml
+++ b/internal/controllers/securitygroup/tests/import-error/00-create-securitygroups.yaml
@@ -1,0 +1,26 @@
+---
+apiVersion: openstack.k-orc.cloud/v1alpha1
+kind: SecurityGroup
+metadata:
+  name: import-error-external-1
+spec:
+  cloudCredentialsRef:
+    cloudName: openstack
+    secretName: openstack-clouds
+  managementPolicy: managed
+  resource:
+    name: import-error-external-1
+    description: SecurityGroup from "import-error" test
+---
+apiVersion: openstack.k-orc.cloud/v1alpha1
+kind: SecurityGroup
+metadata:
+  name: import-error-external-2
+spec:
+  cloudCredentialsRef:
+    cloudName: openstack
+    secretName: openstack-clouds
+  managementPolicy: managed
+  resource:
+    name: import-error-external-2
+    description: SecurityGroup from "import-error" test

--- a/internal/controllers/securitygroup/tests/import-error/00-secret.yaml
+++ b/internal/controllers/securitygroup/tests/import-error/00-secret.yaml
@@ -1,0 +1,5 @@
+apiVersion: kuttl.dev/v1beta1
+kind: TestStep
+commands:
+  - command: kubectl create secret generic openstack-clouds --from-file=clouds.yaml=${E2E_KUTTL_OSCLOUDS} ${E2E_KUTTL_CACERT_OPT}
+    namespaced: true

--- a/internal/controllers/securitygroup/tests/import-error/01-assert.yaml
+++ b/internal/controllers/securitygroup/tests/import-error/01-assert.yaml
@@ -1,0 +1,15 @@
+---
+apiVersion: openstack.k-orc.cloud/v1alpha1
+kind: SecurityGroup
+metadata:
+  name: import-error
+status:
+  conditions:
+    - type: Available
+      message: found more than one matching OpenStack resource during import
+      status: "False"
+      reason: InvalidConfiguration
+    - type: Progressing
+      message: found more than one matching OpenStack resource during import
+      status: "False"
+      reason: InvalidConfiguration

--- a/internal/controllers/securitygroup/tests/import-error/01-import-securitygroup.yaml
+++ b/internal/controllers/securitygroup/tests/import-error/01-import-securitygroup.yaml
@@ -1,0 +1,13 @@
+---
+apiVersion: openstack.k-orc.cloud/v1alpha1
+kind: SecurityGroup
+metadata:
+  name: import-error
+spec:
+  cloudCredentialsRef:
+    cloudName: openstack
+    secretName: openstack-clouds
+  managementPolicy: unmanaged
+  import:
+    filter:
+      description: SecurityGroup from "import-error" test

--- a/internal/controllers/securitygroup/tests/import-error/README.md
+++ b/internal/controllers/securitygroup/tests/import-error/README.md
@@ -1,0 +1,9 @@
+# Import security group with more than one matching resources
+
+## Step 00
+
+Create two security groups with identical specs.
+
+## Step 01
+
+Ensure that an imported security group with a filter matching the resources returns an error.

--- a/internal/controllers/securitygroup/tests/import/00-assert.yaml
+++ b/internal/controllers/securitygroup/tests/import/00-assert.yaml
@@ -1,0 +1,15 @@
+---
+apiVersion: openstack.k-orc.cloud/v1alpha1
+kind: SecurityGroup
+metadata:
+  name: import
+status:
+  conditions:
+    - type: Available
+      message: Waiting for OpenStack resource to be created externally
+      status: "False"
+      reason: Progressing
+    - type: Progressing
+      message: Waiting for OpenStack resource to be created externally
+      status: "True"
+      reason: Progressing

--- a/internal/controllers/securitygroup/tests/import/00-import-securitygroup.yaml
+++ b/internal/controllers/securitygroup/tests/import/00-import-securitygroup.yaml
@@ -1,0 +1,17 @@
+---
+apiVersion: openstack.k-orc.cloud/v1alpha1
+kind: SecurityGroup
+metadata:
+  name: import
+spec:
+  cloudCredentialsRef:
+    cloudName: openstack
+    secretName: openstack-clouds
+  managementPolicy: unmanaged
+  import:
+    filter:
+      name: import-external
+      description: SecurityGroup from "import" test
+      tags:
+      - tag1
+      - tag2

--- a/internal/controllers/securitygroup/tests/import/00-secret.yaml
+++ b/internal/controllers/securitygroup/tests/import/00-secret.yaml
@@ -1,0 +1,5 @@
+apiVersion: kuttl.dev/v1beta1
+kind: TestStep
+commands:
+  - command: kubectl create secret generic openstack-clouds --from-file=clouds.yaml=${E2E_KUTTL_OSCLOUDS} ${E2E_KUTTL_CACERT_OPT}
+    namespaced: true

--- a/internal/controllers/securitygroup/tests/import/01-assert.yaml
+++ b/internal/controllers/securitygroup/tests/import/01-assert.yaml
@@ -1,0 +1,32 @@
+---
+apiVersion: openstack.k-orc.cloud/v1alpha1
+kind: SecurityGroup
+metadata:
+  name: import-external-not-this-one
+status:
+  conditions:
+    - type: Available
+      message: OpenStack resource is available
+      status: "True"
+      reason: Success
+    - type: Progressing
+      message: OpenStack resource is up to date
+      status: "False"
+      reason: Success
+  resource:
+    name: import-external-not-this-one
+---
+apiVersion: openstack.k-orc.cloud/v1alpha1
+kind: SecurityGroup
+metadata:
+  name: import
+status:
+  conditions:
+    - type: Available
+      message: Waiting for OpenStack resource to be created externally
+      status: "False"
+      reason: Progressing
+    - type: Progressing
+      message: Waiting for OpenStack resource to be created externally
+      status: "True"
+      reason: Progressing

--- a/internal/controllers/securitygroup/tests/import/01-create-trap-securitygroup.yaml
+++ b/internal/controllers/securitygroup/tests/import/01-create-trap-securitygroup.yaml
@@ -1,0 +1,19 @@
+---
+# This `import-external-not-this-one` resource serves two purposes:
+# - ensure that we can successfully create another resource which name is a substring of it (i.e. it's not being adopted)
+# - ensure that importing a resource which name is a substring of it will not pick this one.
+apiVersion: openstack.k-orc.cloud/v1alpha1
+kind: SecurityGroup
+metadata:
+  name: import-external-not-this-one
+spec:
+  cloudCredentialsRef:
+    cloudName: openstack
+    secretName: openstack-clouds
+  managementPolicy: managed
+  resource:
+    name: import-external-not-this-one
+    description: SecurityGroup from "import" test
+    tags:
+    - tag1
+    - tag2

--- a/internal/controllers/securitygroup/tests/import/02-assert.yaml
+++ b/internal/controllers/securitygroup/tests/import/02-assert.yaml
@@ -1,0 +1,35 @@
+---
+apiVersion: kuttl.dev/v1beta1
+kind: TestAssert
+resourceRefs:
+    - apiVersion: openstack.k-orc.cloud/v1alpha1
+      kind: SecurityGroup
+      name: import-external
+      ref: securitygroup1
+    - apiVersion: openstack.k-orc.cloud/v1alpha1
+      kind: SecurityGroup
+      name: import-external-not-this-one
+      ref: securitygroup2
+assertAll:
+    - celExpr: "securitygroup1.status.id != securitygroup2.status.id"
+---
+apiVersion: openstack.k-orc.cloud/v1alpha1
+kind: SecurityGroup
+metadata:
+  name: import
+status:
+  conditions:
+    - type: Available
+      message: OpenStack resource is available
+      status: "True"
+      reason: Success
+    - type: Progressing
+      message: OpenStack resource is up to date
+      status: "False"
+      reason: Success
+  resource:
+    name: import-external
+    description: SecurityGroup from "import" test
+    tags:
+    - tag1
+    - tag2

--- a/internal/controllers/securitygroup/tests/import/02-create-securitygroup.yaml
+++ b/internal/controllers/securitygroup/tests/import/02-create-securitygroup.yaml
@@ -1,0 +1,16 @@
+---
+apiVersion: openstack.k-orc.cloud/v1alpha1
+kind: SecurityGroup
+metadata:
+  name: import-external
+spec:
+  cloudCredentialsRef:
+    cloudName: openstack
+    secretName: openstack-clouds
+  managementPolicy: managed
+  resource:
+    name: import-external
+    description: SecurityGroup from "import" test
+    tags:
+    - tag1
+    - tag2

--- a/internal/controllers/securitygroup/tests/import/README.md
+++ b/internal/controllers/securitygroup/tests/import/README.md
@@ -1,0 +1,18 @@
+# Import security group
+
+## Step 00
+
+Import a security group using non-admin credentials, matching all of the available filter's fields, and verify it is waiting for the external resource to be created.
+
+## Step 01
+
+Create a security group which name is a superstring of the one specified in the import filter, and otherwise matching the filter, and verify that it's not being imported.
+
+## Step 02
+
+Create a security group matching the filter and verify that the observed status on the imported security group corresponds to the spec of the created security group.
+Also verify that the created security group didn't adopt the one which name is a superstring of it.
+
+## TODO
+
+Possibly check that adding a new security group matching the import filter does not cause issues after it successfully imported the first one.

--- a/internal/controllers/securitygroup/tests/update/00-assert.yaml
+++ b/internal/controllers/securitygroup/tests/update/00-assert.yaml
@@ -1,0 +1,22 @@
+---
+apiVersion: openstack.k-orc.cloud/v1alpha1
+kind: SecurityGroup
+metadata:
+  name: update
+status:
+  resource:
+    name: update-override
+    description: SecurityGroup from "update" test
+    stateful: false
+    rules:
+    - direction: ingress
+      description: Ingress rule from "update" test for http
+      ethertype: IPv4
+      protocol: tcp
+      portRange:
+        min: 80
+        max: 80
+      remoteIPPrefix: 1.2.3.4/32
+    tags:
+    - tag1
+    - tag2

--- a/internal/controllers/securitygroup/tests/update/00-secret.yaml
+++ b/internal/controllers/securitygroup/tests/update/00-secret.yaml
@@ -1,0 +1,5 @@
+apiVersion: kuttl.dev/v1beta1
+kind: TestStep
+commands:
+  - command: kubectl create secret generic openstack-clouds --from-file=clouds.yaml=${E2E_KUTTL_OSCLOUDS} ${E2E_KUTTL_CACERT_OPT}
+    namespaced: true

--- a/internal/controllers/securitygroup/tests/update/00-securitygroup.yaml
+++ b/internal/controllers/securitygroup/tests/update/00-securitygroup.yaml
@@ -1,0 +1,26 @@
+---
+apiVersion: openstack.k-orc.cloud/v1alpha1
+kind: SecurityGroup
+metadata:
+  name: update
+spec:
+  cloudCredentialsRef:
+    cloudName: openstack
+    secretName: openstack-clouds
+  managementPolicy: managed
+  resource:
+    name: update-override
+    description: SecurityGroup from "update" test
+    stateful: false
+    rules:
+    - direction: ingress
+      description: Ingress rule from "update" test for http
+      ethertype: IPv4
+      protocol: tcp
+      portRange:
+        min: 80
+        max: 80
+      remoteIPPrefix: 1.2.3.4/32
+    tags:
+    - tag1
+    - tag2

--- a/internal/controllers/securitygroup/tests/update/01-assert.yaml
+++ b/internal/controllers/securitygroup/tests/update/01-assert.yaml
@@ -1,0 +1,22 @@
+---
+apiVersion: openstack.k-orc.cloud/v1alpha1
+kind: SecurityGroup
+metadata:
+  name: update
+status:
+  resource:
+    name: update-override
+    description: SecurityGroup from "update" test
+    stateful: false
+    rules:
+    - direction: ingress
+      description: Ingress rule from "update" test for https
+      ethertype: IPv4
+      protocol: tcp
+      portRange:
+        min: 443
+        max: 443
+      remoteIPPrefix: 1.2.3.4/32
+    tags:
+    - tag1
+    - tag2

--- a/internal/controllers/securitygroup/tests/update/01-securitygroup.yaml
+++ b/internal/controllers/securitygroup/tests/update/01-securitygroup.yaml
@@ -1,0 +1,26 @@
+---
+apiVersion: openstack.k-orc.cloud/v1alpha1
+kind: SecurityGroup
+metadata:
+  name: update
+spec:
+  cloudCredentialsRef:
+    cloudName: openstack
+    secretName: openstack-clouds
+  managementPolicy: managed
+  resource:
+    name: update-override
+    description: SecurityGroup from "update" test
+    stateful: false
+    rules:
+    - direction: ingress
+      description: Ingress rule from "update" test for https
+      ethertype: IPv4
+      protocol: tcp
+      portRange:
+        min: 443
+        max: 443
+      remoteIPPrefix: 1.2.3.4/32
+    tags:
+    - tag1
+    - tag2

--- a/internal/controllers/securitygroup/tests/update/README.md
+++ b/internal/controllers/securitygroup/tests/update/README.md
@@ -1,0 +1,11 @@
+# Create a security group with all the options and update its rules
+
+## Step 00
+
+Create a security group using all available fields, and verify that the observed state corresponds to the spec.
+
+Also validate that the OpenStack resource uses the name from the spec when it is specified.
+
+## Step 01
+
+Update the security group by changing a rule, and verify that the observed state corresponds to the spec.

--- a/kuttl-test.yaml
+++ b/kuttl-test.yaml
@@ -4,5 +4,6 @@ testDirs:
 - ./internal/controllers/flavor/tests/
 - ./internal/controllers/image/tests/
 - ./internal/controllers/network/tests/
+- ./internal/controllers/securitygroup/tests/
 - ./internal/controllers/subnet/tests/
 timeout: 120


### PR DESCRIPTION
- Introduced new kuttl-based end-to-end tests for the SecurityGroup controller.
- Added test cases for:
  - Creating a full-featured SecurityGroup (`create-full`).
  - Creating a minimal SecurityGroup (`create-minimal`).
  - Creating an update SecurityGroup (`update`) (rules are mutable).
  - Handling errors when multiple matching SecurityGroups exist (`import-error`).
  - Importing a SecurityGroup with a filtering mechanism (`import`).
- Each test suite includes:
  - SecurityGroup YAML definitions.
  - Assertions to validate expected behavior.
  - Secrets creation for cloud credentials.
  - Cleanup and validation steps.
- Updated `kuttl-test.yaml` to include the SecurityGroup test suite.

These tests ensure that SecurityGroup resources are properly created, imported, and validated against OpenStack environments.