### PR TITLE
Make ResourceSpec immutable until they are truly mutable

### DIFF
--- a/api/v1alpha1/image_types.go
+++ b/api/v1alpha1/image_types.go
@@ -277,6 +277,7 @@ type ImageHash struct {
 // +kubebuilder:validation:XValidation:rule="has(self.tags) ? self.tags == oldSelf.tags : !has(oldSelf.tags)",message="tags is immutable"
 // +kubebuilder:validation:XValidation:rule="has(self.visibility) ? self.visibility == oldSelf.visibility : !has(oldSelf.visibility)",message="visibility is immutable"
 // +kubebuilder:validation:XValidation:rule="has(self.properties) ? self.properties == oldSelf.properties : !has(oldSelf.properties)",message="properties is immutable"
+// +kubebuilder:validation:XValidation:rule="self == oldSelf",message="ImageResourceSpec is immutable"
 type ImageResourceSpec struct {
 	// name will be the name of the created Glance image. If not specified, the
 	// name of the Image object will be used.

--- a/api/v1alpha1/network_types.go
+++ b/api/v1alpha1/network_types.go
@@ -54,6 +54,7 @@ type DNSDomain string
 type MTU int32
 
 // NetworkResourceSpec contains the desired state of a network
+// +kubebuilder:validation:XValidation:rule="self == oldSelf",message="NetworkResourceSpec is immutable"
 type NetworkResourceSpec struct {
 	// name will be the name of the created resource. If not specified, the
 	// name of the ORC object will be used.

--- a/api/v1alpha1/port_types.go
+++ b/api/v1alpha1/port_types.go
@@ -88,6 +88,7 @@ type FixedIPStatus struct {
 	SubnetID string `json:"subnetID,omitempty"`
 }
 
+// +kubebuilder:validation:XValidation:rule="self == oldSelf",message="PortResourceSpec is immutable"
 type PortResourceSpec struct {
 	// name is a human-readable name of the port. If not set, the object's name will be used.
 	// +optional

--- a/api/v1alpha1/router_interface_types.go
+++ b/api/v1alpha1/router_interface_types.go
@@ -74,6 +74,7 @@ const (
 )
 
 // +kubebuilder:validation:XValidation:rule="self.type == 'Subnet' ? has(self.subnetRef) : !has(self.subnetRef)",message="subnetRef is required when type is 'Subnet' and not permitted otherwise"
+// +kubebuilder:validation:XValidation:rule="self == oldSelf",message="RouterInterfaceResourceSpec is immutable"
 type RouterInterfaceSpec struct {
 	// type specifies the type of the router interface.
 	// +required

--- a/api/v1alpha1/router_types.go
+++ b/api/v1alpha1/router_types.go
@@ -44,6 +44,7 @@ type ExternalGatewayStatus struct {
 	NetworkID string `json:"networkID,omitempty"`
 }
 
+// +kubebuilder:validation:XValidation:rule="self == oldSelf",message="RouterResourceSpec is immutable"
 type RouterResourceSpec struct {
 	// name is a human-readable name of the router. If not set, the
 	// object's name will be used.

--- a/api/v1alpha1/securitygroup_types.go
+++ b/api/v1alpha1/securitygroup_types.go
@@ -188,20 +188,24 @@ type SecurityGroupResourceSpec struct {
 	// name will be the name of the created resource. If not specified, the
 	// name of the ORC object will be used.
 	// +optional
+	// +kubebuilder:validation:XValidation:rule="self == oldSelf",message="Property is immutable"
 	Name *OpenStackName `json:"name,omitempty"`
 
 	// description is a human-readable description for the resource.
 	// +optional
+	// +kubebuilder:validation:XValidation:rule="self == oldSelf",message="Property is immutable"
 	Description *NeutronDescription `json:"description,omitempty"`
 
 	// tags is a list of tags which will be applied to the security group.
 	// +kubebuilder:validation:MaxItems:=32
 	// +listType=set
 	// +optional
+	// +kubebuilder:validation:XValidation:rule="self == oldSelf",message="Property is immutable"
 	Tags []NeutronTag `json:"tags,omitempty"`
 
 	// stateful indicates if the security group is stateful or stateless.
 	// +optional
+	// +kubebuilder:validation:XValidation:rule="self == oldSelf",message="Property is immutable"
 	Stateful *bool `json:"stateful,omitempty"`
 
 	// rules is a list of security group rules belonging to this SG.

--- a/api/v1alpha1/server_types.go
+++ b/api/v1alpha1/server_types.go
@@ -61,6 +61,7 @@ type ServerPortSpec struct {
 }
 
 // ServerResourceSpec contains the desired state of a server
+// +kubebuilder:validation:XValidation:rule="self == oldSelf",message="ServerResourceSpec is immutable"
 type ServerResourceSpec struct {
 	// name will be the name of the created resource. If not specified, the
 	// name of the ORC object will be used.

--- a/api/v1alpha1/subnet_types.go
+++ b/api/v1alpha1/subnet_types.go
@@ -59,6 +59,7 @@ type SubnetFilter struct {
 	FilterByNeutronTags `json:",inline"`
 }
 
+// +kubebuilder:validation:XValidation:rule="self == oldSelf",message="SubnetResourceSpec is immutable"
 type SubnetResourceSpec struct {
 	// name is a human-readable name of the subnet. If not set, the object's name will be used.
 	// +optional

--- a/config/crd/bases/openstack.k-orc.cloud_images.yaml
+++ b/config/crd/bases/openstack.k-orc.cloud_images.yaml
@@ -453,6 +453,8 @@ spec:
                 - message: properties is immutable
                   rule: 'has(self.properties) ? self.properties == oldSelf.properties
                     : !has(oldSelf.properties)'
+                - message: ImageResourceSpec is immutable
+                  rule: self == oldSelf
             required:
             - cloudCredentialsRef
             type: object

--- a/config/crd/bases/openstack.k-orc.cloud_networks.yaml
+++ b/config/crd/bases/openstack.k-orc.cloud_networks.yaml
@@ -286,6 +286,9 @@ spec:
                     type: array
                     x-kubernetes-list-type: set
                 type: object
+                x-kubernetes-validations:
+                - message: NetworkResourceSpec is immutable
+                  rule: self == oldSelf
             required:
             - cloudCredentialsRef
             type: object

--- a/config/crd/bases/openstack.k-orc.cloud_ports.yaml
+++ b/config/crd/bases/openstack.k-orc.cloud_ports.yaml
@@ -306,6 +306,9 @@ spec:
                     type: array
                     x-kubernetes-list-type: set
                 type: object
+                x-kubernetes-validations:
+                - message: PortResourceSpec is immutable
+                  rule: self == oldSelf
             required:
             - cloudCredentialsRef
             - networkRef

--- a/config/crd/bases/openstack.k-orc.cloud_routerinterfaces.yaml
+++ b/config/crd/bases/openstack.k-orc.cloud_routerinterfaces.yaml
@@ -77,6 +77,8 @@ spec:
             - message: subnetRef is required when type is 'Subnet' and not permitted
                 otherwise
               rule: 'self.type == ''Subnet'' ? has(self.subnetRef) : !has(self.subnetRef)'
+            - message: RouterInterfaceResourceSpec is immutable
+              rule: self == oldSelf
           status:
             description: status defines the observed state of the resource.
             properties:

--- a/config/crd/bases/openstack.k-orc.cloud_routers.yaml
+++ b/config/crd/bases/openstack.k-orc.cloud_routers.yaml
@@ -272,6 +272,9 @@ spec:
                     type: array
                     x-kubernetes-list-type: set
                 type: object
+                x-kubernetes-validations:
+                - message: RouterResourceSpec is immutable
+                  rule: self == oldSelf
             required:
             - cloudCredentialsRef
             type: object

--- a/config/crd/bases/openstack.k-orc.cloud_securitygroups.yaml
+++ b/config/crd/bases/openstack.k-orc.cloud_securitygroups.yaml
@@ -212,6 +212,9 @@ spec:
                     maxLength: 255
                     minLength: 1
                     type: string
+                    x-kubernetes-validations:
+                    - message: Property is immutable
+                      rule: self == oldSelf
                   name:
                     description: |-
                       name will be the name of the created resource. If not specified, the
@@ -220,6 +223,9 @@ spec:
                     minLength: 1
                     pattern: ^[^,]+$
                     type: string
+                    x-kubernetes-validations:
+                    - message: Property is immutable
+                      rule: self == oldSelf
                   rules:
                     description: rules is a list of security group rules belonging
                       to this SG.
@@ -346,6 +352,9 @@ spec:
                     description: stateful indicates if the security group is stateful
                       or stateless.
                     type: boolean
+                    x-kubernetes-validations:
+                    - message: Property is immutable
+                      rule: self == oldSelf
                   tags:
                     description: tags is a list of tags which will be applied to the
                       security group.
@@ -359,6 +368,9 @@ spec:
                     maxItems: 32
                     type: array
                     x-kubernetes-list-type: set
+                    x-kubernetes-validations:
+                    - message: Property is immutable
+                      rule: self == oldSelf
                 type: object
             required:
             - cloudCredentialsRef

--- a/config/crd/bases/openstack.k-orc.cloud_servers.yaml
+++ b/config/crd/bases/openstack.k-orc.cloud_servers.yaml
@@ -258,6 +258,9 @@ spec:
                 - imageRef
                 - ports
                 type: object
+                x-kubernetes-validations:
+                - message: ServerResourceSpec is immutable
+                  rule: self == oldSelf
             required:
             - cloudCredentialsRef
             type: object

--- a/config/crd/bases/openstack.k-orc.cloud_subnets.yaml
+++ b/config/crd/bases/openstack.k-orc.cloud_subnets.yaml
@@ -423,6 +423,9 @@ spec:
                 - cidr
                 - ipVersion
                 type: object
+                x-kubernetes-validations:
+                - message: SubnetResourceSpec is immutable
+                  rule: self == oldSelf
             required:
             - cloudCredentialsRef
             - networkRef


### PR DESCRIPTION
Until we implement mutability for the different resources, add a CEL validation that enforce immutability, to avoid confusion.