### PR TITLE
Add kuttl tests for Port controller

### DIFF
--- a/internal/controllers/port/controller.go
+++ b/internal/controllers/port/controller.go
@@ -51,11 +51,10 @@ var (
 	subnetDependency = dependency.NewDeletionGuardDependency[*orcv1alpha1.PortList, *orcv1alpha1.Subnet](
 		"spec.resource.addresses[].subnetRef",
 		func(port *orcv1alpha1.Port) []string {
-			var subnets []string
 			if port.Spec.Resource == nil {
 				return nil
 			}
-			subnets = make([]string, len(port.Spec.Resource.Addresses))
+			subnets := make([]string, len(port.Spec.Resource.Addresses))
 			for i := range port.Spec.Resource.Addresses {
 				subnets[i] = string(port.Spec.Resource.Addresses[i].SubnetRef)
 			}
@@ -67,11 +66,10 @@ var (
 	securityGroupDependency = dependency.NewDeletionGuardDependency[*orcv1alpha1.PortList, *orcv1alpha1.SecurityGroup](
 		"spec.resource.securityGroupRefs",
 		func(port *orcv1alpha1.Port) []string {
-			var securityGroups []string
 			if port.Spec.Resource == nil {
 				return nil
 			}
-			securityGroups = make([]string, len(port.Spec.Resource.SecurityGroupRefs))
+			securityGroups := make([]string, len(port.Spec.Resource.SecurityGroupRefs))
 			for i := range port.Spec.Resource.SecurityGroupRefs {
 				securityGroups[i] = string(port.Spec.Resource.SecurityGroupRefs[i])
 			}

--- a/internal/controllers/port/tests/port-create-full/00-assert.yaml
+++ b/internal/controllers/port/tests/port-create-full/00-assert.yaml
@@ -1,0 +1,44 @@
+---
+apiVersion: openstack.k-orc.cloud/v1alpha1
+kind: Port
+metadata:
+  name: port-create-full
+status:
+  resource:
+    name: port-create-full-override
+    description: Port from "create full" test
+    adminStateUp: true
+    allowedAddressPairs:
+      - ip: 192.168.122.14
+        mac: 92:42:9c:13:98:82
+    deviceID: ""
+    deviceOwner: ""
+    propagateUplinkStatus: false
+    status: DOWN
+    tags:
+      - tag1
+---
+apiVersion: kuttl.dev/v1beta1
+kind: TestAssert
+resourceRefs:
+    - apiVersion: openstack.k-orc.cloud/v1alpha1
+      kind: port
+      name: port-create-full
+      ref: port
+    - apiVersion: openstack.k-orc.cloud/v1alpha1
+      kind: subnet
+      name: port-create-full
+      ref: subnet      
+    - apiVersion: openstack.k-orc.cloud/v1alpha1
+      kind: securitygroup
+      name: port-create-full
+      ref: sg     
+assertAll:
+    - celExpr: "port.status.id != ''"
+    - celExpr: "port.status.resource.createdAt != ''"
+    - celExpr: "port.status.resource.updatedAt != ''"
+    - celExpr: "port.status.resource.macAddress != ''"
+    - celExpr: "port.status.resource.revisionNumber > 0"
+    - celExpr: "port.status.resource.fixedIPs[0].subnetID == subnet.status.id"
+    - celExpr: "port.status.resource.fixedIPs[0].ip == '192.168.155.122'"
+    - celExpr: "port.status.resource.securityGroups[0] == sg.status.id"

--- a/internal/controllers/port/tests/port-create-full/00-port.yaml
+++ b/internal/controllers/port/tests/port-create-full/00-port.yaml
@@ -1,0 +1,68 @@
+---
+apiVersion: openstack.k-orc.cloud/v1alpha1
+kind: Network
+metadata:
+  name: port-create-full
+spec:
+  cloudCredentialsRef:
+    cloudName: openstack
+    secretName: openstack-clouds
+  managementPolicy: managed
+  resource: {}
+---
+apiVersion: openstack.k-orc.cloud/v1alpha1
+kind: Subnet
+metadata:
+  name: port-create-full
+spec:
+  cloudCredentialsRef:
+    cloudName: openstack
+    secretName: openstack-clouds
+  managementPolicy: managed
+  networkRef: port-create-full
+  resource:
+    ipVersion: 4
+    cidr: 192.168.155.0/24
+---
+apiVersion: openstack.k-orc.cloud/v1alpha1
+kind: SecurityGroup
+metadata:
+  name: port-create-full
+spec:
+  cloudCredentialsRef:
+    cloudName: openstack
+    secretName: openstack-clouds
+  managementPolicy: managed
+  resource:
+    stateful: true
+    rules:
+    - direction: ingress
+      protocol: tcp
+      portRange:
+        min: 22
+        max: 22
+      ethertype: IPv4
+---
+apiVersion: openstack.k-orc.cloud/v1alpha1
+kind: Port
+metadata:
+  name: port-create-full
+spec:
+  cloudCredentialsRef:
+    cloudName: openstack
+    secretName: openstack-clouds
+  managementPolicy: managed
+  networkRef: port-create-full
+  resource:
+    name: port-create-full-override
+    description: Port from "create full" test
+    allowedAddressPairs:
+      - ip: "192.168.122.14"
+        mac: "92:42:9c:13:98:82"
+    tags:
+    - tag1
+    securityGroupRefs:
+    - port-create-full
+    addresses:
+    - subnetRef: port-create-full
+      ip: 192.168.155.122

--- a/internal/controllers/port/tests/port-create-full/00-prerequisites.yaml
+++ b/internal/controllers/port/tests/port-create-full/00-prerequisites.yaml
@@ -1,0 +1,49 @@
+apiVersion: kuttl.dev/v1beta1
+kind: TestStep
+commands:
+  - command: kubectl create secret generic openstack-clouds --from-file=clouds.yaml=${E2E_KUTTL_OSCLOUDS} ${E2E_KUTTL_CACERT_OPT}
+    namespaced: true
+---
+apiVersion: openstack.k-orc.cloud/v1alpha1
+kind: Network
+metadata:
+  name: port-create-full
+spec:
+  cloudCredentialsRef:
+    cloudName: openstack
+    secretName: openstack-clouds
+  managementPolicy: managed
+  resource: {}
+---
+apiVersion: openstack.k-orc.cloud/v1alpha1
+kind: Subnet
+metadata:
+  name: port-create-full
+spec:
+  cloudCredentialsRef:
+    cloudName: openstack
+    secretName: openstack-clouds
+  managementPolicy: managed
+  networkRef: port-create-full
+  resource:
+    ipVersion: 4
+    cidr: 192.168.155.0/24
+---
+apiVersion: openstack.k-orc.cloud/v1alpha1
+kind: SecurityGroup
+metadata:
+  name: port-create-full
+spec:
+  cloudCredentialsRef:
+    cloudName: openstack
+    secretName: openstack-clouds
+  managementPolicy: managed
+  resource:
+    stateful: true
+    rules:
+    - direction: ingress
+      protocol: tcp
+      portRange:
+        min: 22
+        max: 22
+      ethertype: IPv4

--- a/internal/controllers/port/tests/port-create-full/README.md
+++ b/internal/controllers/port/tests/port-create-full/README.md
@@ -1,0 +1,7 @@
+# Create a port with all the options
+
+## Step 00
+
+Create a port using all available fields, and verify that the observed state corresponds to the spec.
+
+Also validate that the OpenStack resource uses the name from the spec when it is specified.

--- a/internal/controllers/port/tests/port-create-minimal/00-assert.yaml
+++ b/internal/controllers/port/tests/port-create-minimal/00-assert.yaml
@@ -1,0 +1,29 @@
+---
+apiVersion: openstack.k-orc.cloud/v1alpha1
+kind: Port
+metadata:
+  name: port-create-minimal
+status:
+  resource:
+    name: port-create-minimal
+    adminStateUp: true
+    description: ""
+    deviceID: ""
+    deviceOwner: ""
+    propagateUplinkStatus: false
+    revisionNumber: 1
+    status: DOWN
+---
+apiVersion: kuttl.dev/v1beta1
+kind: TestAssert
+resourceRefs:
+    - apiVersion: openstack.k-orc.cloud/v1alpha1
+      kind: port
+      name: port-create-minimal
+      ref: port
+assertAll:
+    - celExpr: "port.status.id != ''"
+    - celExpr: "port.status.resource.createdAt != ''"
+    - celExpr: "port.status.resource.updatedAt != ''"
+    - celExpr: "port.status.resource.macAddress != ''"
+    - celExpr: "!has(port.status.resource.fixedIPs)"

--- a/internal/controllers/port/tests/port-create-minimal/00-port.yaml
+++ b/internal/controllers/port/tests/port-create-minimal/00-port.yaml
@@ -1,0 +1,12 @@
+---
+apiVersion: openstack.k-orc.cloud/v1alpha1
+kind: Port
+metadata:
+  name: port-create-minimal
+spec:
+  cloudCredentialsRef:
+    cloudName: openstack
+    secretName: openstack-clouds
+  managementPolicy: managed
+  networkRef: port-create-minimal
+  resource: {}

--- a/internal/controllers/port/tests/port-create-minimal/00-prerequisites.yaml
+++ b/internal/controllers/port/tests/port-create-minimal/00-prerequisites.yaml
@@ -1,0 +1,31 @@
+apiVersion: kuttl.dev/v1beta1
+kind: TestStep
+commands:
+  - command: kubectl create secret generic openstack-clouds --from-file=clouds.yaml=${E2E_KUTTL_OSCLOUDS} ${E2E_KUTTL_CACERT_OPT}
+    namespaced: true
+---
+apiVersion: openstack.k-orc.cloud/v1alpha1
+kind: Network
+metadata:
+  name: port-create-minimal
+spec:
+  cloudCredentialsRef:
+    cloudName: openstack
+    secretName: openstack-clouds
+  managementPolicy: managed
+  resource:
+    name: port-create-minimal
+---
+apiVersion: openstack.k-orc.cloud/v1alpha1
+kind: Subnet
+metadata:
+  name: port-create-minimal
+spec:
+  cloudCredentialsRef:
+    cloudName: openstack
+    secretName: openstack-clouds
+  managementPolicy: managed
+  networkRef: port-create-minimal
+  resource:
+    ipVersion: 4
+    cidr: 192.168.155.0/24

--- a/internal/controllers/port/tests/port-create-minimal/01-assert.yaml
+++ b/internal/controllers/port/tests/port-create-minimal/01-assert.yaml
@@ -1,0 +1,11 @@
+---
+apiVersion: kuttl.dev/v1beta1
+kind: TestAssert
+resourceRefs:
+    - apiVersion: v1
+      kind: Secret
+      name: openstack-clouds
+      ref: secret
+assertAll:
+    - celExpr: "secret.metadata.deletionTimestamp != 0"
+    - celExpr: "'openstack.k-orc.cloud/port' in secret.metadata.finalizers"

--- a/internal/controllers/port/tests/port-create-minimal/01-delete-secret.yaml
+++ b/internal/controllers/port/tests/port-create-minimal/01-delete-secret.yaml
@@ -1,0 +1,6 @@
+apiVersion: kuttl.dev/v1beta1
+kind: TestStep
+commands:
+  # We expect the deletion to hang due to the finalizer, so use --wait=false
+  - command: kubectl delete secret openstack-clouds --wait=false
+    namespaced: true

--- a/internal/controllers/port/tests/port-create-minimal/README.md
+++ b/internal/controllers/port/tests/port-create-minimal/README.md
@@ -1,0 +1,11 @@
+# Create a port with the minimum options
+
+## Step 00
+
+Create a minimal port, that sets only the required fields, and verify that the observed state corresponds to the spec.
+
+Also validate that the OpenStack resource uses the name of the ORC object when it is not specified.
+
+## Step 01
+
+Try deleting the secret and ensure that it is not deleted thanks to the finalizer.

--- a/internal/controllers/port/tests/port-import-error/00-assert.yaml
+++ b/internal/controllers/port/tests/port-import-error/00-assert.yaml
@@ -1,0 +1,30 @@
+---
+apiVersion: openstack.k-orc.cloud/v1alpha1
+kind: Port
+metadata:
+  name: port-import-error-external-1
+status:
+  conditions:
+    - type: Available
+      message: OpenStack resource is available
+      status: "True"
+      reason: Success
+    - type: Progressing
+      message: OpenStack resource is up to date
+      status: "False"
+      reason: Success
+---
+apiVersion: openstack.k-orc.cloud/v1alpha1
+kind: Port
+metadata:
+  name: port-import-error-external-2
+status:
+  conditions:
+    - type: Available
+      message: OpenStack resource is available
+      status: "True"
+      reason: Success
+    - type: Progressing
+      message: OpenStack resource is up to date
+      status: "False"
+      reason: Success

--- a/internal/controllers/port/tests/port-import-error/00-create-port.yaml
+++ b/internal/controllers/port/tests/port-import-error/00-create-port.yaml
@@ -1,0 +1,28 @@
+---
+apiVersion: openstack.k-orc.cloud/v1alpha1
+kind: Port
+metadata:
+  name: port-import-error-external-1
+spec:
+  cloudCredentialsRef:
+    cloudName: openstack
+    secretName: openstack-clouds
+  managementPolicy: managed
+  networkRef: port-import-error
+  resource:
+    tags:
+      - tag1    
+---
+apiVersion: openstack.k-orc.cloud/v1alpha1
+kind: Port
+metadata:
+  name: port-import-error-external-2
+spec:
+  cloudCredentialsRef:
+    cloudName: openstack
+    secretName: openstack-clouds
+  managementPolicy: managed
+  networkRef: port-import-error
+  resource:
+    tags:
+      - tag1    

--- a/internal/controllers/port/tests/port-import-error/00-prerequisites.yaml
+++ b/internal/controllers/port/tests/port-import-error/00-prerequisites.yaml
@@ -1,0 +1,31 @@
+apiVersion: kuttl.dev/v1beta1
+kind: TestStep
+commands:
+  - command: kubectl create secret generic openstack-clouds --from-file=clouds.yaml=${E2E_KUTTL_OSCLOUDS} ${E2E_KUTTL_CACERT_OPT}
+    namespaced: true
+---
+apiVersion: openstack.k-orc.cloud/v1alpha1
+kind: Network
+metadata:
+  name: port-import-error
+spec:
+  cloudCredentialsRef:
+    cloudName: openstack
+    secretName: openstack-clouds
+  managementPolicy: managed
+  resource:
+    name: port-import-error
+---
+apiVersion: openstack.k-orc.cloud/v1alpha1
+kind: Subnet
+metadata:
+  name: port-import-error
+spec:
+  cloudCredentialsRef:
+    cloudName: openstack
+    secretName: openstack-clouds
+  managementPolicy: managed
+  networkRef: port-import-error
+  resource:
+    ipVersion: 4
+    cidr: 192.168.155.0/24    

--- a/internal/controllers/port/tests/port-import-error/01-assert.yaml
+++ b/internal/controllers/port/tests/port-import-error/01-assert.yaml
@@ -1,0 +1,15 @@
+---
+apiVersion: openstack.k-orc.cloud/v1alpha1
+kind: Port
+metadata:
+  name: port-import-error
+status:
+  conditions:
+    - type: Available
+      message: found more than one matching OpenStack resource during import
+      status: "False"
+      reason: InvalidConfiguration
+    - type: Progressing
+      message: found more than one matching OpenStack resource during import
+      status: "False"
+      reason: InvalidConfiguration

--- a/internal/controllers/port/tests/port-import-error/01-import-port.yaml
+++ b/internal/controllers/port/tests/port-import-error/01-import-port.yaml
@@ -1,0 +1,15 @@
+---
+apiVersion: openstack.k-orc.cloud/v1alpha1
+kind: Port
+metadata:
+  name: port-import-error
+spec:
+  cloudCredentialsRef:
+    cloudName: openstack
+    secretName: openstack-clouds
+  managementPolicy: unmanaged
+  networkRef: port-import-error
+  import:
+    filter:
+      tags:
+        - tag1

--- a/internal/controllers/port/tests/port-import-error/README.md
+++ b/internal/controllers/port/tests/port-import-error/README.md
@@ -1,0 +1,9 @@
+# Import Port with more than one matching resources
+
+## Step 00
+
+Create two ports with identical specs.
+
+## Step 01
+
+Ensure that an imported port with a filter matching the resources returns an error.

--- a/internal/controllers/port/tests/port-import/00-assert.yaml
+++ b/internal/controllers/port/tests/port-import/00-assert.yaml
@@ -1,0 +1,15 @@
+---
+apiVersion: openstack.k-orc.cloud/v1alpha1
+kind: Port
+metadata:
+  name: port-import
+status:
+  conditions:
+    - type: Available
+      message: Waiting for OpenStack resource to be created externally
+      status: "False"
+      reason: Progressing
+    - type: Progressing
+      message: Waiting for OpenStack resource to be created externally
+      status: "True"
+      reason: Progressing

--- a/internal/controllers/port/tests/port-import/00-import-port.yaml
+++ b/internal/controllers/port/tests/port-import/00-import-port.yaml
@@ -1,0 +1,18 @@
+---
+apiVersion: openstack.k-orc.cloud/v1alpha1
+kind: Port
+metadata:
+  name: port-import
+spec:
+  cloudCredentialsRef:
+    cloudName: openstack
+    secretName: openstack-clouds
+  managementPolicy: unmanaged
+  # TODO: Remove when https://github.com/k-orc/openstack-resource-controller/issues/298 is fixed
+  networkRef: port-import
+  import:
+    filter:
+      name: port-import-external
+      description: Port from "port-import" test
+      tags:
+        - tag1

--- a/internal/controllers/port/tests/port-import/00-prerequisites.yaml
+++ b/internal/controllers/port/tests/port-import/00-prerequisites.yaml
@@ -1,0 +1,31 @@
+apiVersion: kuttl.dev/v1beta1
+kind: TestStep
+commands:
+  - command: kubectl create secret generic openstack-clouds --from-file=clouds.yaml=${E2E_KUTTL_OSCLOUDS} ${E2E_KUTTL_CACERT_OPT}
+    namespaced: true
+---
+apiVersion: openstack.k-orc.cloud/v1alpha1
+kind: Network
+metadata:
+  name: port-import
+spec:
+  cloudCredentialsRef:
+    cloudName: openstack
+    secretName: openstack-clouds
+  managementPolicy: managed
+  resource:
+    name: port-import
+---
+apiVersion: openstack.k-orc.cloud/v1alpha1
+kind: Subnet
+metadata:
+  name: port-import
+spec:
+  cloudCredentialsRef:
+    cloudName: openstack
+    secretName: openstack-clouds
+  managementPolicy: managed
+  networkRef: port-import
+  resource:
+    ipVersion: 4
+    cidr: 192.168.155.0/24    

--- a/internal/controllers/port/tests/port-import/01-assert.yaml
+++ b/internal/controllers/port/tests/port-import/01-assert.yaml
@@ -1,0 +1,32 @@
+---
+apiVersion: openstack.k-orc.cloud/v1alpha1
+kind: Port
+metadata:
+  name: port-import-external-not-this-one
+status:
+  conditions:
+    - type: Available
+      message: OpenStack resource is available
+      status: "True"
+      reason: Success
+    - type: Progressing
+      message: OpenStack resource is up to date
+      status: "False"
+      reason: Success
+  resource:
+    name: port-import-external-not-this-one
+---
+apiVersion: openstack.k-orc.cloud/v1alpha1
+kind: Port
+metadata:
+  name: port-import
+status:
+  conditions:
+    - type: Available
+      message: Waiting for OpenStack resource to be created externally
+      status: "False"
+      reason: Progressing
+    - type: Progressing
+      message: Waiting for OpenStack resource to be created externally
+      status: "True"
+      reason: Progressing

--- a/internal/controllers/port/tests/port-import/01-create-trap-port.yaml
+++ b/internal/controllers/port/tests/port-import/01-create-trap-port.yaml
@@ -1,0 +1,18 @@
+---
+# This `port-import-external-not-this-one` resource serves two purposes:
+# - ensure that we can successfully create another resource which name is a substring of it (i.e. it's not being adopted)
+# - ensure that importing a resource which name is a substring of it will not pick this one.
+apiVersion: openstack.k-orc.cloud/v1alpha1
+kind: Port
+metadata:
+  name: port-import-external-not-this-one
+spec:
+  cloudCredentialsRef:
+    cloudName: openstack
+    secretName: openstack-clouds
+  managementPolicy: managed
+  networkRef: port-import
+  resource:
+    description: Port from "port-import" test
+    tags:
+      - tag1

--- a/internal/controllers/port/tests/port-import/02-assert.yaml
+++ b/internal/controllers/port/tests/port-import/02-assert.yaml
@@ -1,0 +1,34 @@
+---
+apiVersion: kuttl.dev/v1beta1
+kind: TestAssert
+resourceRefs:
+    - apiVersion: openstack.k-orc.cloud/v1alpha1
+      kind: Port
+      name: port-import-external
+      ref: port1
+    - apiVersion: openstack.k-orc.cloud/v1alpha1
+      kind: Port
+      name: port-import-external-not-this-one
+      ref: port2
+assertAll:
+    - celExpr: "port1.status.id != port2.status.id"
+---
+apiVersion: openstack.k-orc.cloud/v1alpha1
+kind: Port
+metadata:
+  name: port-import
+status:
+  conditions:
+    - type: Available
+      message: OpenStack resource is available
+      status: "True"
+      reason: Success
+    - type: Progressing
+      message: OpenStack resource is up to date
+      status: "False"
+      reason: Success
+  resource:
+    name: port-import-external
+    description: Port from "port-import" test
+    tags:
+    - tag1

--- a/internal/controllers/port/tests/port-import/02-create-port.yaml
+++ b/internal/controllers/port/tests/port-import/02-create-port.yaml
@@ -1,0 +1,15 @@
+---
+apiVersion: openstack.k-orc.cloud/v1alpha1
+kind: Port
+metadata:
+  name: port-import-external
+spec:
+  cloudCredentialsRef:
+    cloudName: openstack
+    secretName: openstack-clouds
+  managementPolicy: managed
+  networkRef: port-import
+  resource:
+    description: Port from "port-import" test
+    tags:
+      - tag1

--- a/internal/controllers/port/tests/port-import/README.md
+++ b/internal/controllers/port/tests/port-import/README.md
@@ -1,0 +1,18 @@
+# Import Port
+
+## Step 00
+
+Import a port using non-admin credentials, matching all of the available filter's fields, and verify it is waiting for the external resource to be created.
+
+## Step 01
+
+Create a port which name is a superstring of the one specified in the import filter, and otherwise matching the filter, and verify that it's not being imported.
+
+## Step 02
+
+Create a port matching the filter and verify that the observed status on the imported port corresponds to the spec of the created port.
+Also verify that the created port didn't adopt the one which name is a superstring of it.
+
+## TODO
+
+Possibly check that adding a new port matching the import filter does not cause issues after it successfully imported the first one.

--- a/kuttl-test.yaml
+++ b/kuttl-test.yaml
@@ -4,6 +4,7 @@ testDirs:
 - ./internal/controllers/flavor/tests/
 - ./internal/controllers/image/tests/
 - ./internal/controllers/network/tests/
+- ./internal/controllers/port/tests/
 - ./internal/controllers/router/tests/
 - ./internal/controllers/securitygroup/tests/
 - ./internal/controllers/server/tests/


### PR DESCRIPTION
- Introduced new kuttl-based end-to-end tests for the Port controller.
- Added test cases for:
  - Creating a full-featured Port (`create-full`).
  - Creating a minimal Port (`create-minimal`).
  - Handling errors when multiple matching Ports exist (`import-error`).
  - Importing a Port with a filtering mechanism (`import`).
- Each test suite includes:
  - Port YAML definitions.
  - Assertions to validate expected behavior.
  - Secrets creation for cloud credentials.
- Updated `kuttl-test.yaml` to include the Port test suite.

These tests ensure that Port resources are properly created, imported, and validated against OpenStack environments.