### PR TITLE
Usability improvements to ResourceStatusWriter

### DIFF
--- a/internal/controllers/flavor/status.go
+++ b/internal/controllers/flavor/status.go
@@ -21,7 +21,7 @@ import (
 	"github.com/gophercloud/gophercloud/v2/openstack/compute/v2/flavors"
 
 	orcv1alpha1 "github.com/k-orc/openstack-resource-controller/api/v1alpha1"
-	generic "github.com/k-orc/openstack-resource-controller/internal/controllers/generic/interfaces"
+	"github.com/k-orc/openstack-resource-controller/internal/controllers/generic/interfaces"
 	orcapplyconfigv1alpha1 "github.com/k-orc/openstack-resource-controller/pkg/clients/applyconfiguration/api/v1alpha1"
 )
 
@@ -30,9 +30,9 @@ type flavorStatusWriter struct{}
 type objectApplyT = orcapplyconfigv1alpha1.FlavorApplyConfiguration
 type statusApplyT = orcapplyconfigv1alpha1.FlavorStatusApplyConfiguration
 
-var _ generic.ResourceStatusWriter[*orcv1alpha1.Flavor, *flavors.Flavor, *objectApplyT, *statusApplyT] = flavorStatusWriter{}
+var _ interfaces.ResourceStatusWriter[*orcv1alpha1.Flavor, *flavors.Flavor, *objectApplyT, *statusApplyT] = flavorStatusWriter{}
 
-func (flavorStatusWriter) GetApplyConfigConstructor() generic.ORCApplyConfigConstructor[*objectApplyT, *statusApplyT] {
+func (flavorStatusWriter) GetApplyConfigConstructor() interfaces.ORCApplyConfigConstructor[*objectApplyT, *statusApplyT] {
 	return orcapplyconfigv1alpha1.Flavor
 }
 

--- a/internal/controllers/flavor/status.go
+++ b/internal/controllers/flavor/status.go
@@ -32,8 +32,8 @@ type statusApplyT = orcapplyconfigv1alpha1.FlavorStatusApplyConfiguration
 
 var _ interfaces.ResourceStatusWriter[*orcv1alpha1.Flavor, *flavors.Flavor, *objectApplyT, *statusApplyT] = flavorStatusWriter{}
 
-func (flavorStatusWriter) GetApplyConfigConstructor() interfaces.ORCApplyConfigConstructor[*objectApplyT, *statusApplyT] {
-	return orcapplyconfigv1alpha1.Flavor
+func (flavorStatusWriter) GetApplyConfig(name, namespace string) *objectApplyT {
+	return orcapplyconfigv1alpha1.Flavor(name, namespace)
 }
 
 func (flavorStatusWriter) ResourceIsAvailable(_ *orcv1alpha1.Flavor, osResource *flavors.Flavor) bool {

--- a/internal/controllers/flavor/status.go
+++ b/internal/controllers/flavor/status.go
@@ -19,6 +19,7 @@ package flavor
 import (
 	"github.com/go-logr/logr"
 	"github.com/gophercloud/gophercloud/v2/openstack/compute/v2/flavors"
+	metav1 "k8s.io/apimachinery/pkg/apis/meta/v1"
 
 	orcv1alpha1 "github.com/k-orc/openstack-resource-controller/api/v1alpha1"
 	"github.com/k-orc/openstack-resource-controller/internal/controllers/generic/interfaces"
@@ -36,8 +37,17 @@ func (flavorStatusWriter) GetApplyConfig(name, namespace string) *objectApplyT {
 	return orcapplyconfigv1alpha1.Flavor(name, namespace)
 }
 
-func (flavorStatusWriter) ResourceIsAvailable(_ *orcv1alpha1.Flavor, osResource *flavors.Flavor) bool {
-	return osResource != nil
+func (flavorStatusWriter) ResourceAvailableStatus(orcObject *orcv1alpha1.Flavor, osResource *flavors.Flavor) metav1.ConditionStatus {
+	if osResource == nil {
+		if orcObject.Status.ID == nil {
+			return metav1.ConditionFalse
+		} else {
+			return metav1.ConditionUnknown
+		}
+	}
+
+	// Flavor is available as soon as it exists
+	return metav1.ConditionTrue
 }
 
 func (flavorStatusWriter) ApplyResourceStatus(_ logr.Logger, osResource *flavors.Flavor, statusApply *statusApplyT) {

--- a/internal/controllers/generic/interfaces/status.go
+++ b/internal/controllers/generic/interfaces/status.go
@@ -34,10 +34,8 @@ type ORCStatusApplyConfig[statusApplyPT any] interface {
 	WithID(id string) statusApplyPT
 }
 
-type ORCApplyConfigConstructor[objectApplyPT ORCApplyConfig[objectApplyPT, statusApplyPT], statusApplyPT ORCStatusApplyConfig[statusApplyPT]] func(name, namespace string) objectApplyPT
-
 type ResourceStatusWriter[objectPT orcv1alpha1.ObjectWithConditions, osResourcePT any, objectApplyPT ORCApplyConfig[objectApplyPT, statusApplyPT], statusApplyPT ORCStatusApplyConfig[statusApplyPT]] interface {
-	GetApplyConfigConstructor() ORCApplyConfigConstructor[objectApplyPT, statusApplyPT]
 	ResourceIsAvailable(orcObject objectPT, osResource osResourcePT) bool
+	GetApplyConfig(name, namespace string) objectApplyPT
 	ApplyResourceStatus(log logr.Logger, osResource osResourcePT, statusApply statusApplyPT)
 }

--- a/internal/controllers/generic/interfaces/status.go
+++ b/internal/controllers/generic/interfaces/status.go
@@ -25,18 +25,33 @@ import (
 	orcv1alpha1 "github.com/k-orc/openstack-resource-controller/api/v1alpha1"
 )
 
+// ORCApplyConfig is an interface implemented by any apply configuration for an
+// ORC API object. Specifically its WithStatus method is constrained to return
+// an ORCStatusApplyConfig.
 type ORCApplyConfig[objectApplyPT any, statusApplyPT ORCStatusApplyConfig[statusApplyPT]] interface {
 	WithUID(types.UID) objectApplyPT
 	WithStatus(statusApplyPT) objectApplyPT
 }
 
+// ORCStatusApplyConfig is an interface implemented by the status of any apply
+// configuration for an ORC API object. It has Conditions and an ID field.
 type ORCStatusApplyConfig[statusApplyPT any] interface {
 	WithConditions(...*applyconfigv1.ConditionApplyConfiguration) statusApplyPT
 	WithID(id string) statusApplyPT
 }
 
+// ResourceStatusWriter defines methods for writing an ORC object status
 type ResourceStatusWriter[objectPT orcv1alpha1.ObjectWithConditions, osResourcePT any, objectApplyPT ORCApplyConfig[objectApplyPT, statusApplyPT], statusApplyPT ORCStatusApplyConfig[statusApplyPT]] interface {
+	// GetApplyConfig returns an ORCApplyConfig for this object for use in an
+	// SSA transaction, initialised with a name and a namespace.
 	GetApplyConfig(name, namespace string) objectApplyPT
+
+	// ResourceAvailableStatus returns what the status of the Available
+	// condition should be set to based on the observed state of the given
+	// orcObject and osResource.
 	ResourceAvailableStatus(orcObject objectPT, osResource osResourcePT) metav1.ConditionStatus
+
+	// ApplyResourceStatus writes status.resource to the given status apply
+	// configuration based on the given osResource
 	ApplyResourceStatus(log logr.Logger, osResource osResourcePT, statusApply statusApplyPT)
 }

--- a/internal/controllers/generic/interfaces/status.go
+++ b/internal/controllers/generic/interfaces/status.go
@@ -18,6 +18,7 @@ package interfaces
 
 import (
 	"github.com/go-logr/logr"
+	metav1 "k8s.io/apimachinery/pkg/apis/meta/v1"
 	"k8s.io/apimachinery/pkg/types"
 	applyconfigv1 "k8s.io/client-go/applyconfigurations/meta/v1"
 
@@ -35,7 +36,7 @@ type ORCStatusApplyConfig[statusApplyPT any] interface {
 }
 
 type ResourceStatusWriter[objectPT orcv1alpha1.ObjectWithConditions, osResourcePT any, objectApplyPT ORCApplyConfig[objectApplyPT, statusApplyPT], statusApplyPT ORCStatusApplyConfig[statusApplyPT]] interface {
-	ResourceIsAvailable(orcObject objectPT, osResource osResourcePT) bool
 	GetApplyConfig(name, namespace string) objectApplyPT
+	ResourceAvailableStatus(orcObject objectPT, osResource osResourcePT) metav1.ConditionStatus
 	ApplyResourceStatus(log logr.Logger, osResource osResourcePT, statusApply statusApplyPT)
 }

--- a/internal/controllers/generic/status/conditions.go
+++ b/internal/controllers/generic/status/conditions.go
@@ -33,9 +33,10 @@ type WithConditionsApplyConfiguration[T any] interface {
 	WithConditions(...*applyconfigv1.ConditionApplyConfiguration) T
 }
 
-func SetCommonConditions[T any](orcObject orcv1alpha1.ObjectWithConditions, applyConfig WithConditionsApplyConfiguration[T], isAvailable bool, progressStatus []progress.ProgressStatus, err error, now metav1.Time) {
+func SetCommonConditions[T any](orcObject orcv1alpha1.ObjectWithConditions, applyConfig WithConditionsApplyConfiguration[T], availableStatus metav1.ConditionStatus, progressStatus []progress.ProgressStatus, err error, now metav1.Time) {
 	availableCondition := applyconfigv1.Condition().
 		WithType(orcv1alpha1.ConditionAvailable).
+		WithStatus(availableStatus).
 		WithObservedGeneration(orcObject.GetGeneration())
 	progressingCondition := applyconfigv1.Condition().
 		WithType(orcv1alpha1.ConditionProgressing).
@@ -77,15 +78,13 @@ func SetCommonConditions[T any](orcObject orcv1alpha1.ObjectWithConditions, appl
 			WithMessage("OpenStack resource is up to date")
 	}
 
-	if isAvailable {
+	if availableStatus == metav1.ConditionTrue {
 		availableCondition.
-			WithStatus(metav1.ConditionTrue).
 			WithReason(orcv1alpha1.ConditionReasonSuccess).
 			WithMessage("OpenStack resource is available")
 	} else {
 		// Copy reason and message from progressing
 		availableCondition.
-			WithStatus(metav1.ConditionFalse).
 			WithReason(*progressingCondition.Reason).
 			WithMessage(*progressingCondition.Message)
 	}

--- a/internal/controllers/generic/status/status.go
+++ b/internal/controllers/generic/status/status.go
@@ -55,7 +55,7 @@ func SetStatusID[
 	var status statusApplyPT = new(statusApplyT)
 	status.WithID(resourceID)
 
-	applyConfig := statusWriter.GetApplyConfigConstructor()(orcObject.GetName(), orcObject.GetNamespace()).
+	applyConfig := statusWriter.GetApplyConfig(orcObject.GetName(), orcObject.GetNamespace()).
 		WithUID(orcObject.GetUID()).
 		WithStatus(status)
 
@@ -86,7 +86,7 @@ func UpdateStatus[
 
 	// Create a new apply configuration for this status transaction
 	var applyConfigStatus statusApplyPT = new(statusApply)
-	applyConfig := statusWriter.GetApplyConfigConstructor()(orcObject.GetName(), orcObject.GetNamespace()).
+	applyConfig := statusWriter.GetApplyConfig(orcObject.GetName(), orcObject.GetNamespace()).
 		WithStatus(applyConfigStatus)
 
 	// Write resource status to the apply configuration

--- a/internal/controllers/generic/status/status.go
+++ b/internal/controllers/generic/status/status.go
@@ -95,7 +95,7 @@ func UpdateStatus[
 	}
 
 	// Set common conditions
-	available := statusWriter.ResourceIsAvailable(orcObject, osResource)
+	available := statusWriter.ResourceAvailableStatus(orcObject, osResource)
 	SetCommonConditions(orcObject, applyConfigStatus, available, progressStatus, err, now)
 
 	// Patch orcObject with the status transaction

--- a/internal/controllers/network/status.go
+++ b/internal/controllers/network/status.go
@@ -36,8 +36,8 @@ type networkStatusWriter struct{}
 
 var _ interfaces.ResourceStatusWriter[*orcv1alpha1.Network, *osclients.NetworkExt, *orcapplyconfigv1alpha1.NetworkApplyConfiguration, *orcapplyconfigv1alpha1.NetworkStatusApplyConfiguration] = networkStatusWriter{}
 
-func (networkStatusWriter) GetApplyConfigConstructor() interfaces.ORCApplyConfigConstructor[*orcapplyconfigv1alpha1.NetworkApplyConfiguration, *orcapplyconfigv1alpha1.NetworkStatusApplyConfiguration] {
-	return orcapplyconfigv1alpha1.Network
+func (networkStatusWriter) GetApplyConfig(name, namespace string) *orcapplyconfigv1alpha1.NetworkApplyConfiguration {
+	return orcapplyconfigv1alpha1.Network(name, namespace)
 }
 
 func (networkStatusWriter) ResourceIsAvailable(orcObject *orcv1alpha1.Network, osResource *osclients.NetworkExt) bool {

--- a/internal/controllers/network/status.go
+++ b/internal/controllers/network/status.go
@@ -40,8 +40,19 @@ func (networkStatusWriter) GetApplyConfig(name, namespace string) *orcapplyconfi
 	return orcapplyconfigv1alpha1.Network(name, namespace)
 }
 
-func (networkStatusWriter) ResourceIsAvailable(orcObject *orcv1alpha1.Network, osResource *osclients.NetworkExt) bool {
-	return osResource != nil && osResource.Status == NetworkStatusActive
+func (networkStatusWriter) ResourceAvailableStatus(orcObject *orcv1alpha1.Network, osResource *osclients.NetworkExt) metav1.ConditionStatus {
+	if osResource == nil {
+		if orcObject.Status.ID == nil {
+			return metav1.ConditionFalse
+		} else {
+			return metav1.ConditionUnknown
+		}
+	}
+
+	if osResource.Status == NetworkStatusActive {
+		return metav1.ConditionTrue
+	}
+	return metav1.ConditionFalse
 }
 
 func (networkStatusWriter) ApplyResourceStatus(log logr.Logger, osResource *osclients.NetworkExt, statusApply *orcapplyconfigv1alpha1.NetworkStatusApplyConfiguration) {

--- a/internal/controllers/port/status.go
+++ b/internal/controllers/port/status.go
@@ -36,8 +36,8 @@ type portStatusWriter struct{}
 
 var _ interfaces.ResourceStatusWriter[orcObjectPT, *osResourceT, objectApplyPT, statusApplyPT] = portStatusWriter{}
 
-func (portStatusWriter) GetApplyConfigConstructor() interfaces.ORCApplyConfigConstructor[objectApplyPT, statusApplyPT] {
-	return orcapplyconfigv1alpha1.Port
+func (portStatusWriter) GetApplyConfig(name, namespace string) objectApplyPT {
+	return orcapplyconfigv1alpha1.Port(name, namespace)
 }
 
 func (portStatusWriter) ResourceIsAvailable(orcObject orcObjectPT, osResource *osResourceT) bool {

--- a/internal/controllers/port/status.go
+++ b/internal/controllers/port/status.go
@@ -40,12 +40,20 @@ func (portStatusWriter) GetApplyConfig(name, namespace string) objectApplyPT {
 	return orcapplyconfigv1alpha1.Port(name, namespace)
 }
 
-func (portStatusWriter) ResourceIsAvailable(orcObject orcObjectPT, osResource *osResourceT) bool {
-	// Both active and down ports
-	return orcObject.Status.ID != nil && osResource != nil &&
-		(osResource.Status == PortStatusActive ||
-			osResource.Status == PortStatusDown)
+func (portStatusWriter) ResourceAvailableStatus(orcObject orcObjectPT, osResource *osResourceT) metav1.ConditionStatus {
+	if osResource == nil {
+		if orcObject.Status.ID == nil {
+			return metav1.ConditionFalse
+		} else {
+			return metav1.ConditionUnknown
+		}
+	}
 
+	// Both active and down ports are Available
+	if osResource.Status == PortStatusActive || osResource.Status == PortStatusDown {
+		return metav1.ConditionTrue
+	}
+	return metav1.ConditionFalse
 }
 
 func (portStatusWriter) ApplyResourceStatus(log logr.Logger, osResource *osResourceT, statusApply statusApplyPT) {

--- a/internal/controllers/router/status.go
+++ b/internal/controllers/router/status.go
@@ -18,6 +18,7 @@ package router
 
 import (
 	"github.com/go-logr/logr"
+	metav1 "k8s.io/apimachinery/pkg/apis/meta/v1"
 
 	"github.com/k-orc/openstack-resource-controller/internal/controllers/generic/interfaces"
 	orcapplyconfigv1alpha1 "github.com/k-orc/openstack-resource-controller/pkg/clients/applyconfiguration/api/v1alpha1"
@@ -38,8 +39,19 @@ func (routerStatusWriter) GetApplyConfig(name, namespace string) objectApplyPT {
 	return orcapplyconfigv1alpha1.Router(name, namespace)
 }
 
-func (routerStatusWriter) ResourceIsAvailable(orcObject orcObjectPT, osResource *osResourceT) bool {
-	return orcObject.Status.ID != nil && osResource != nil && osResource.Status == RouterStatusActive
+func (routerStatusWriter) ResourceAvailableStatus(orcObject orcObjectPT, osResource *osResourceT) metav1.ConditionStatus {
+	if osResource == nil {
+		if orcObject.Status.ID == nil {
+			return metav1.ConditionFalse
+		} else {
+			return metav1.ConditionUnknown
+		}
+	}
+
+	if osResource.Status == RouterStatusActive {
+		return metav1.ConditionTrue
+	}
+	return metav1.ConditionFalse
 }
 
 func (routerStatusWriter) ApplyResourceStatus(log logr.Logger, osResource *osResourceT, statusApply statusApplyPT) {

--- a/internal/controllers/router/status.go
+++ b/internal/controllers/router/status.go
@@ -34,8 +34,8 @@ type routerStatusWriter struct{}
 
 var _ interfaces.ResourceStatusWriter[orcObjectPT, *osResourceT, objectApplyPT, statusApplyPT] = routerStatusWriter{}
 
-func (routerStatusWriter) GetApplyConfigConstructor() interfaces.ORCApplyConfigConstructor[objectApplyPT, statusApplyPT] {
-	return orcapplyconfigv1alpha1.Router
+func (routerStatusWriter) GetApplyConfig(name, namespace string) objectApplyPT {
+	return orcapplyconfigv1alpha1.Router(name, namespace)
 }
 
 func (routerStatusWriter) ResourceIsAvailable(orcObject orcObjectPT, osResource *osResourceT) bool {

--- a/internal/controllers/routerinterface/status.go
+++ b/internal/controllers/routerinterface/status.go
@@ -40,10 +40,10 @@ type updateStatusOpts struct {
 	err    error
 }
 
-func getStatusSummary(routerInterface *orcv1alpha1.RouterInterface, opts *updateStatusOpts) (_ bool, progressStatus []progress.ProgressStatus) {
+func getStatusSummary(routerInterface *orcv1alpha1.RouterInterface, opts *updateStatusOpts) (_ metav1.ConditionStatus, progressStatus []progress.ProgressStatus) {
 	// Probably a programming error?
 	if routerInterface == nil {
-		return false, nil
+		return metav1.ConditionFalse, nil
 	}
 
 	if routerInterface.Spec.Type == orcv1alpha1.RouterInterfaceTypeSubnet {
@@ -54,10 +54,10 @@ func getStatusSummary(routerInterface *orcv1alpha1.RouterInterface, opts *update
 		}
 	}
 
-	available := false
+	available := metav1.ConditionFalse
 	if opts.port != nil {
 		if opts.port.Status == port.PortStatusActive {
-			available = true
+			available = metav1.ConditionTrue
 		} else {
 			progressStatus = append(progressStatus, progress.WaitingOnOpenStackReady(portStatusPollingPeriod))
 		}

--- a/internal/controllers/securitygroup/status.go
+++ b/internal/controllers/securitygroup/status.go
@@ -31,8 +31,8 @@ type securityGroupStatusWriter struct{}
 
 var _ interfaces.ResourceStatusWriter[orcObjectPT, *osResourceT, objectApplyPT, statusApplyPT] = securityGroupStatusWriter{}
 
-func (securityGroupStatusWriter) GetApplyConfigConstructor() interfaces.ORCApplyConfigConstructor[objectApplyPT, statusApplyPT] {
-	return orcapplyconfigv1alpha1.SecurityGroup
+func (securityGroupStatusWriter) GetApplyConfig(name, namespace string) objectApplyPT {
+	return orcapplyconfigv1alpha1.SecurityGroup(name, namespace)
 }
 
 func (securityGroupStatusWriter) ResourceIsAvailable(_ orcObjectPT, osResource *osResourceT) bool {

--- a/internal/controllers/securitygroup/status.go
+++ b/internal/controllers/securitygroup/status.go
@@ -35,8 +35,17 @@ func (securityGroupStatusWriter) GetApplyConfig(name, namespace string) objectAp
 	return orcapplyconfigv1alpha1.SecurityGroup(name, namespace)
 }
 
-func (securityGroupStatusWriter) ResourceIsAvailable(_ orcObjectPT, osResource *osResourceT) bool {
-	return osResource != nil
+func (securityGroupStatusWriter) ResourceAvailableStatus(orcObject orcObjectPT, osResource *osResourceT) metav1.ConditionStatus {
+	if osResource == nil {
+		if orcObject.Status.ID == nil {
+			return metav1.ConditionFalse
+		} else {
+			return metav1.ConditionUnknown
+		}
+	}
+
+	// SecurityGroup is available as soon as it exists
+	return metav1.ConditionTrue
 }
 
 func (securityGroupStatusWriter) ApplyResourceStatus(log logr.Logger, osResource *osResourceT, statusApply statusApplyPT) {

--- a/internal/controllers/server/status.go
+++ b/internal/controllers/server/status.go
@@ -20,6 +20,7 @@ import (
 	"fmt"
 
 	"github.com/go-logr/logr"
+	metav1 "k8s.io/apimachinery/pkg/apis/meta/v1"
 	"k8s.io/utils/ptr"
 
 	"github.com/k-orc/openstack-resource-controller/internal/controllers/generic/interfaces"
@@ -42,8 +43,19 @@ func (serverStatusWriter) GetApplyConfig(name, namespace string) objectApplyPT {
 	return orcapplyconfigv1alpha1.Server(name, namespace)
 }
 
-func (serverStatusWriter) ResourceIsAvailable(orcObject orcObjectPT, osResource *osResourceT) bool {
-	return orcObject.Status.ID != nil && osResource != nil && osResource.Status == ServerStatusActive
+func (serverStatusWriter) ResourceAvailableStatus(orcObject orcObjectPT, osResource *osResourceT) metav1.ConditionStatus {
+	if osResource == nil {
+		if orcObject.Status.ID == nil {
+			return metav1.ConditionFalse
+		} else {
+			return metav1.ConditionUnknown
+		}
+	}
+
+	if osResource.Status == ServerStatusActive {
+		return metav1.ConditionTrue
+	}
+	return metav1.ConditionFalse
 }
 
 func (serverStatusWriter) ApplyResourceStatus(log logr.Logger, osResource *osResourceT, statusApply statusApplyPT) {

--- a/internal/controllers/server/status.go
+++ b/internal/controllers/server/status.go
@@ -38,8 +38,8 @@ type serverStatusWriter struct{}
 
 var _ interfaces.ResourceStatusWriter[orcObjectPT, *osResourceT, objectApplyPT, statusApplyPT] = serverStatusWriter{}
 
-func (serverStatusWriter) GetApplyConfigConstructor() interfaces.ORCApplyConfigConstructor[objectApplyPT, statusApplyPT] {
-	return orcapplyconfigv1alpha1.Server
+func (serverStatusWriter) GetApplyConfig(name, namespace string) objectApplyPT {
+	return orcapplyconfigv1alpha1.Server(name, namespace)
 }
 
 func (serverStatusWriter) ResourceIsAvailable(orcObject orcObjectPT, osResource *osResourceT) bool {

--- a/internal/controllers/subnet/status.go
+++ b/internal/controllers/subnet/status.go
@@ -30,8 +30,8 @@ type subnetStatusWriter struct{}
 
 var _ interfaces.ResourceStatusWriter[orcObjectPT, *osResourceT, objectApplyPT, statusApplyPT] = subnetStatusWriter{}
 
-func (subnetStatusWriter) GetApplyConfigConstructor() interfaces.ORCApplyConfigConstructor[objectApplyPT, statusApplyPT] {
-	return orcapplyconfigv1alpha1.Subnet
+func (subnetStatusWriter) GetApplyConfig(name, namespace string) objectApplyPT {
+	return orcapplyconfigv1alpha1.Subnet(name, namespace)
 }
 
 func (subnetStatusWriter) ResourceIsAvailable(orcObject orcObjectPT, osResource *osResourceT) bool {

--- a/internal/controllers/subnet/status.go
+++ b/internal/controllers/subnet/status.go
@@ -18,6 +18,7 @@ package subnet
 
 import (
 	"github.com/go-logr/logr"
+	metav1 "k8s.io/apimachinery/pkg/apis/meta/v1"
 
 	"github.com/k-orc/openstack-resource-controller/internal/controllers/generic/interfaces"
 	orcapplyconfigv1alpha1 "github.com/k-orc/openstack-resource-controller/pkg/clients/applyconfiguration/api/v1alpha1"
@@ -34,9 +35,17 @@ func (subnetStatusWriter) GetApplyConfig(name, namespace string) objectApplyPT {
 	return orcapplyconfigv1alpha1.Subnet(name, namespace)
 }
 
-func (subnetStatusWriter) ResourceIsAvailable(orcObject orcObjectPT, osResource *osResourceT) bool {
+func (subnetStatusWriter) ResourceAvailableStatus(orcObject orcObjectPT, osResource *osResourceT) metav1.ConditionStatus {
+	if osResource == nil {
+		if orcObject.Status.ID == nil {
+			return metav1.ConditionFalse
+		} else {
+			return metav1.ConditionUnknown
+		}
+	}
+
 	// Subnet is available as soon as it exists
-	return osResource != nil
+	return metav1.ConditionTrue
 }
 
 func (subnetStatusWriter) ApplyResourceStatus(log logr.Logger, osResource *osResourceT, statusApply statusApplyPT) {


### PR DESCRIPTION
This PR makes 2 changes to ResourceStatusWriter and adds godoc.

- **Replace GetApplyConfigConstructor with GetApplyConfig**
  This removes a level of indirection in ResourceStatusWriter.
- **Replace ResourceIsAvailable with ResourceAvailableStatus**
  This allows us to write an Unknown status for the Available condition.
