### PR TITLE
Change image status to be consistent with other resources

### DIFF
--- a/internal/controllers/image/status.go
+++ b/internal/controllers/image/status.go
@@ -164,7 +164,7 @@ func createStatusUpdate(ctx context.Context, orcImage *orcv1alpha1.Image, now me
 		availableCondition.
 			WithStatus(metav1.ConditionTrue).
 			WithReason(orcv1alpha1.ConditionReasonSuccess).
-			WithMessage("Glance image is available")
+			WithMessage("OpenStack resource is available")
 		available = true
 	} else {
 		// Image is not available. Reason and message will be copied from Progressing
@@ -177,7 +177,7 @@ func createStatusUpdate(ctx context.Context, orcImage *orcv1alpha1.Image, now me
 			progressingCondition.
 				WithStatus(metav1.ConditionFalse).
 				WithReason(orcv1alpha1.ConditionReasonSuccess).
-				WithMessage(*availableCondition.Message)
+				WithMessage("OpenStack resource is up to date")
 		} else {
 			progressingCondition.
 				WithStatus(metav1.ConditionTrue).

--- a/internal/controllers/image/status_test.go
+++ b/internal/controllers/image/status_test.go
@@ -37,7 +37,7 @@ import (
 func Test_orcImageReconciler_updateStatus(t *testing.T) {
 	const (
 		progressingMsg      = "Reconciliation is progressing"
-		successMsg          = "Glance image is available"
+		successMsg          = "OpenStack resource is available"
 		hashVerifyFailedMsg = "Hash published by glance does not match expected image hash"
 
 		imageID         = "dc4d187c-a93c-4700-ab32-975c783c4b97"

--- a/internal/controllers/image/tests/image-import-error/00-assert.yaml
+++ b/internal/controllers/image/tests/image-import-error/00-assert.yaml
@@ -8,11 +8,11 @@ status:
     # Message is inconsistent with other resources
     # https://github.com/k-orc/openstack-resource-controller/issues/267
     - type: Available
-      message: Glance image is available
+      message: OpenStack resource is available
       status: "True"
       reason: Success
     - type: Progressing
-      message: Glance image is available
+      message: OpenStack resource is up to date
       status: "False"
       reason: Success
 ---
@@ -25,10 +25,10 @@ status:
     # Message is inconsistent with other resources
     # https://github.com/k-orc/openstack-resource-controller/issues/267
     - type: Available
-      message: Glance image is available
+      message: OpenStack resource is available
       status: "True"
       reason: Success
     - type: Progressing
-      message: Glance image is available
+      message: OpenStack resource is up to date
       status: "False"
       reason: Success

--- a/internal/controllers/image/tests/image-import/01-assert.yaml
+++ b/internal/controllers/image/tests/image-import/01-assert.yaml
@@ -6,11 +6,11 @@ metadata:
 status:
   conditions:
     - type: Available
-      message: Glance image is available
+      message: OpenStack resource is available
       status: "True"
       reason: Success
     - type: Progressing
-      message: Glance image is available
+      message: OpenStack resource is up to date
       status: "False"
       reason: Success
   resource:

--- a/internal/controllers/image/tests/image-import/02-assert.yaml
+++ b/internal/controllers/image/tests/image-import/02-assert.yaml
@@ -22,11 +22,11 @@ status:
     # Message is inconsistent with other resources
     # https://github.com/k-orc/openstack-resource-controller/issues/267
     - type: Available
-      message: Glance image is available
+      message: OpenStack resource is available
       status: "True"
       reason: Success
     - type: Progressing
-      message: Glance image is available
+      message: OpenStack resource is up to date
       status: "False"
       reason: Success
   resource:


### PR DESCRIPTION
Change the status message to to be:
```
status:
  conditions:
  - message: OpenStack resource is available
    reason: Success
    status: "True"
    type: Available
  - message: OpenStack resource is up to date
    reason: Success
    status: "False"
    type: Progressing
```