### PR TITLE
Bump golangci-lint to v2

### DIFF
--- a/.golangci.yml
+++ b/.golangci.yml
@@ -1,27 +1,8 @@
+version: "2"
 run:
-  timeout: 5m
   allow-parallel-runners: true
-
-issues:
-  # don't skip warning about doc comments
-  # don't exclude the default set of lint
-  exclude-use-default: false
-  # restore some of the defaults
-  # (fill in the rest as needed)
-  exclude-rules:
-    - path: "api/*"
-      linters:
-        - lll
-    - path: "internal/*"
-      linters:
-        - dupl
-        - lll
-    - path-except: "api/*"
-      linters:
-        - kal
-
 linters:
-  disable-all: true
+  default: none
   enable:
     - copyloopvar
     - dupl
@@ -29,9 +10,6 @@ linters:
     - ginkgolinter
     - goconst
     - gocyclo
-    - gofmt
-    - goimports
-    - gosimple
     - govet
     - ineffassign
     - kal
@@ -41,37 +19,62 @@ linters:
     - prealloc
     - revive
     - staticcheck
-    - typecheck
     - unconvert
     - unparam
     - unused
-
-linters-settings:
-  revive:
+  settings:
+    revive:
+      rules:
+        - name: comment-spacings
+    custom:
+      kal:
+        type: module
+        description: KAL is the Kube-API-Linter and lints Kube like APIs based on API conventions and best practices.
+        settings:
+          linters:
+            enable:
+              - commentstart
+              - conditions
+              - integers
+              - jsontags
+              - maxlength
+              # NOTE: we have a number of boolean fields. Should we convert them to
+              # string?
+              # - "nobools"
+              - nofloats
+              - nophase
+              - optionalorrequired
+              - requiredfields
+              - statussubresource
+          lintersConfig:
+            conditions:
+              isFirstField: Warn
+              usePatchStrategy: Ignore
+              useProtobuf: Forbid
+  exclusions:
+    generated: lax
     rules:
-      - name: comment-spacings
-  custom:
-    kal:
-      type: "module"
-      description: KAL is the Kube-API-Linter and lints Kube like APIs based on API conventions and best practices.
-      settings:
-        linters:
-          enable:
-          - "commentstart"
-          - "conditions"
-          - "integers"
-          - "jsontags"
-          - "maxlength"
-          # NOTE: we have a number of boolean fields. Should we convert them to
-          # string?
-          # - "nobools"
-          - "nofloats"
-          - "nophase"
-          - "optionalorrequired"
-          - "requiredfields"
-          - "statussubresource"
-        lintersConfig:
-          conditions:
-            isFirstField: Warn
-            useProtobuf: Forbid
-            usePatchStrategy: Ignore
+      - linters:
+          - lll
+        path: api/*
+      - linters:
+          - dupl
+          - lll
+        path: internal/*
+      - linters:
+          - kal
+        path-except: api/*
+    paths:
+      - third_party$
+      - builtin$
+      - examples$
+formatters:
+  enable:
+    - gofmt
+    - goimports
+  exclusions:
+    generated: lax
+    paths:
+      - third_party$
+      - builtin$
+      - examples$

--- a/.golangci.yml
+++ b/.golangci.yml
@@ -15,6 +15,7 @@ linters:
     - kal
     - lll
     - misspell
+    - nolintlint
     - nakedret
     - prealloc
     - revive

--- a/Makefile
+++ b/Makefile
@@ -240,7 +240,7 @@ KUTTL = $(LOCALBIN)/kubectl-kuttl
 KUSTOMIZE_VERSION ?= v5.6.0
 CONTROLLER_TOOLS_VERSION ?= v0.17.1
 ENVTEST_VERSION ?= release-0.19
-GOLANGCI_LINT_VERSION ?= v1.63.4
+GOLANGCI_LINT_VERSION ?= v2.0.1
 KAL_VERSION ?= v0.0.0-20250226170450-3245ed227194
 MOCKGEN_VERSION ?= v0.5.0
 KUTTL_VERSION ?= v0.22.0
@@ -263,7 +263,7 @@ $(ENVTEST): $(LOCALBIN)
 .PHONY: golangci-lint
 golangci-lint: $(GOLANGCI_LINT) ## Download golangci-lint locally if necessary.
 $(GOLANGCI_LINT): $(LOCALBIN)
-	$(call go-install-tool,$(GOLANGCI_LINT),github.com/golangci/golangci-lint/cmd/golangci-lint,$(GOLANGCI_LINT_VERSION))
+	$(call go-install-tool,$(GOLANGCI_LINT),github.com/golangci/golangci-lint/v2/cmd/golangci-lint,$(GOLANGCI_LINT_VERSION))
 
 define custom-gcl
 version:  $(GOLANGCI_LINT_VERSION)

--- a/cmd/models-schema/main.go
+++ b/cmd/models-schema/main.go
@@ -32,7 +32,7 @@ import (
 func main() {
 	err := output()
 	if err != nil {
-		_, _ = os.Stderr.WriteString(fmt.Sprintf("Failed: %v", err))
+		_, _ = fmt.Fprintf(os.Stderr, "Failed: %v", err)
 		os.Exit(1)
 	}
 }

--- a/internal/controllers/image/suite_test.go
+++ b/internal/controllers/image/suite_test.go
@@ -21,8 +21,8 @@ import (
 	"path/filepath"
 	"testing"
 
-	. "github.com/onsi/ginkgo/v2" //nolint:revive
-	. "github.com/onsi/gomega"    //nolint:revive
+	. "github.com/onsi/ginkgo/v2"
+	. "github.com/onsi/gomega"
 	corev1 "k8s.io/api/core/v1"
 	"k8s.io/apimachinery/pkg/types"
 	"k8s.io/client-go/kubernetes/scheme"

--- a/internal/controllers/image/upload_test.go
+++ b/internal/controllers/image/upload_test.go
@@ -24,8 +24,8 @@ import (
 	"time"
 
 	"github.com/gophercloud/gophercloud/v2/openstack/image/v2/images"
-	. "github.com/onsi/ginkgo/v2" //nolint:revive
-	. "github.com/onsi/gomega"    //nolint:revive
+	. "github.com/onsi/ginkgo/v2"
+	. "github.com/onsi/gomega"
 	"go.uber.org/mock/gomock"
 	corev1 "k8s.io/api/core/v1"
 	"k8s.io/client-go/tools/record"

--- a/internal/controllers/network/actuator.go
+++ b/internal/controllers/network/actuator.go
@@ -76,10 +76,10 @@ func (actuator networkActuator) ListOSResourcesForImport(ctx context.Context, ob
 	listOpts := networks.ListOpts{
 		Name:        string(ptr.Deref(filter.Name, "")),
 		Description: string(ptr.Deref(filter.Description, "")),
-		Tags:        neutrontags.Join(filter.FilterByNeutronTags.Tags),
-		TagsAny:     neutrontags.Join(filter.FilterByNeutronTags.TagsAny),
-		NotTags:     neutrontags.Join(filter.FilterByNeutronTags.NotTags),
-		NotTagsAny:  neutrontags.Join(filter.FilterByNeutronTags.NotTagsAny),
+		Tags:        neutrontags.Join(filter.Tags),
+		TagsAny:     neutrontags.Join(filter.TagsAny),
+		NotTags:     neutrontags.Join(filter.NotTags),
+		NotTagsAny:  neutrontags.Join(filter.NotTagsAny),
 	}
 
 	return nil, actuator.osClient.ListNetwork(ctx, listOpts), nil

--- a/internal/controllers/port/actuator.go
+++ b/internal/controllers/port/actuator.go
@@ -103,10 +103,10 @@ func (actuator portActuator) ListOSResourcesForImport(ctx context.Context, obj o
 		Name:        string(ptr.Deref(filter.Name, "")),
 		Description: string(ptr.Deref(filter.Description, "")),
 		NetworkID:   networkID,
-		Tags:        neutrontags.Join(filter.FilterByNeutronTags.Tags),
-		TagsAny:     neutrontags.Join(filter.FilterByNeutronTags.TagsAny),
-		NotTags:     neutrontags.Join(filter.FilterByNeutronTags.NotTags),
-		NotTagsAny:  neutrontags.Join(filter.FilterByNeutronTags.NotTagsAny),
+		Tags:        neutrontags.Join(filter.Tags),
+		TagsAny:     neutrontags.Join(filter.TagsAny),
+		NotTags:     neutrontags.Join(filter.NotTags),
+		NotTagsAny:  neutrontags.Join(filter.NotTagsAny),
 	}
 
 	return nil, actuator.osClient.ListPort(ctx, listOpts), nil

--- a/internal/controllers/router/actuator.go
+++ b/internal/controllers/router/actuator.go
@@ -78,10 +78,10 @@ func (actuator routerCreateActuator) ListOSResourcesForImport(ctx context.Contex
 	listOpts := routers.ListOpts{
 		Name:        string(ptr.Deref(filter.Name, "")),
 		Description: string(ptr.Deref(filter.Description, "")),
-		Tags:        neutrontags.Join(filter.FilterByNeutronTags.Tags),
-		TagsAny:     neutrontags.Join(filter.FilterByNeutronTags.TagsAny),
-		NotTags:     neutrontags.Join(filter.FilterByNeutronTags.NotTags),
-		NotTagsAny:  neutrontags.Join(filter.FilterByNeutronTags.NotTagsAny),
+		Tags:        neutrontags.Join(filter.Tags),
+		TagsAny:     neutrontags.Join(filter.TagsAny),
+		NotTags:     neutrontags.Join(filter.NotTags),
+		NotTagsAny:  neutrontags.Join(filter.NotTagsAny),
 	}
 
 	return nil, actuator.osClient.ListRouter(ctx, listOpts), nil

--- a/internal/controllers/router/suite_test.go
+++ b/internal/controllers/router/suite_test.go
@@ -21,8 +21,8 @@ import (
 	"path/filepath"
 	"testing"
 
-	. "github.com/onsi/ginkgo/v2" //nolint:revive
-	. "github.com/onsi/gomega"    //nolint:revive
+	. "github.com/onsi/ginkgo/v2"
+	. "github.com/onsi/gomega"
 	corev1 "k8s.io/api/core/v1"
 	"k8s.io/apimachinery/pkg/types"
 	"k8s.io/client-go/kubernetes/scheme"

--- a/internal/controllers/routerinterface/suite_test.go
+++ b/internal/controllers/routerinterface/suite_test.go
@@ -21,8 +21,8 @@ import (
 	"path/filepath"
 	"testing"
 
-	. "github.com/onsi/ginkgo/v2" //nolint:revive
-	. "github.com/onsi/gomega"    //nolint:revive
+	. "github.com/onsi/ginkgo/v2"
+	. "github.com/onsi/gomega"
 	corev1 "k8s.io/api/core/v1"
 	"k8s.io/apimachinery/pkg/types"
 	"k8s.io/client-go/kubernetes/scheme"

--- a/internal/controllers/securitygroup/actuator.go
+++ b/internal/controllers/securitygroup/actuator.go
@@ -77,10 +77,10 @@ func (actuator securityGroupActuator) ListOSResourcesForImport(ctx context.Conte
 	listOpts := groups.ListOpts{
 		Name:        string(ptr.Deref(filter.Name, "")),
 		Description: string(ptr.Deref(filter.Description, "")),
-		Tags:        neutrontags.Join(filter.FilterByNeutronTags.Tags),
-		TagsAny:     neutrontags.Join(filter.FilterByNeutronTags.TagsAny),
-		NotTags:     neutrontags.Join(filter.FilterByNeutronTags.NotTags),
-		NotTagsAny:  neutrontags.Join(filter.FilterByNeutronTags.NotTagsAny),
+		Tags:        neutrontags.Join(filter.Tags),
+		TagsAny:     neutrontags.Join(filter.TagsAny),
+		NotTags:     neutrontags.Join(filter.NotTags),
+		NotTagsAny:  neutrontags.Join(filter.NotTagsAny),
 	}
 	return nil, actuator.osClient.ListSecGroup(ctx, listOpts), nil
 }

--- a/internal/controllers/server/actuator.go
+++ b/internal/controllers/server/actuator.go
@@ -84,10 +84,10 @@ func (actuator serverActuator) ListOSResourcesForAdoption(ctx context.Context, o
 
 func (actuator serverActuator) ListOSResourcesForImport(ctx context.Context, obj orcObjectPT, filter filterT) ([]progress.ProgressStatus, iter.Seq2[*osResourceT, error], error) {
 	listOpts := servers.ListOpts{
-		Tags:       neutrontags.Join(filter.FilterByServerTags.Tags),
-		TagsAny:    neutrontags.Join(filter.FilterByServerTags.TagsAny),
-		NotTags:    neutrontags.Join(filter.FilterByServerTags.NotTags),
-		NotTagsAny: neutrontags.Join(filter.FilterByServerTags.NotTagsAny),
+		Tags:       neutrontags.Join(filter.Tags),
+		TagsAny:    neutrontags.Join(filter.TagsAny),
+		NotTags:    neutrontags.Join(filter.NotTags),
+		NotTagsAny: neutrontags.Join(filter.NotTagsAny),
 	}
 
 	if filter.Name != nil {

--- a/internal/controllers/subnet/actuator.go
+++ b/internal/controllers/subnet/actuator.go
@@ -110,10 +110,10 @@ func (actuator subnetActuator) ListOSResourcesForImport(ctx context.Context, obj
 		IPVersion:   int(ptr.Deref(filter.IPVersion, 0)),
 		GatewayIP:   string(ptr.Deref(filter.GatewayIP, "")),
 		CIDR:        string(ptr.Deref(filter.CIDR, "")),
-		Tags:        neutrontags.Join(filter.FilterByNeutronTags.Tags),
-		TagsAny:     neutrontags.Join(filter.FilterByNeutronTags.TagsAny),
-		NotTags:     neutrontags.Join(filter.FilterByNeutronTags.NotTags),
-		NotTagsAny:  neutrontags.Join(filter.FilterByNeutronTags.NotTagsAny),
+		Tags:        neutrontags.Join(filter.Tags),
+		TagsAny:     neutrontags.Join(filter.TagsAny),
+		NotTags:     neutrontags.Join(filter.NotTags),
+		NotTagsAny:  neutrontags.Join(filter.NotTagsAny),
 	}
 	if filter.IPv6 != nil {
 		listOpts.IPv6AddressMode = string(ptr.Deref(filter.IPv6.AddressMode, ""))

--- a/internal/controllers/subnet/suite_test.go
+++ b/internal/controllers/subnet/suite_test.go
@@ -21,8 +21,8 @@ import (
 	"path/filepath"
 	"testing"
 
-	. "github.com/onsi/ginkgo/v2" //nolint:revive
-	. "github.com/onsi/gomega"    //nolint:revive
+	. "github.com/onsi/ginkgo/v2"
+	. "github.com/onsi/gomega"
 	corev1 "k8s.io/api/core/v1"
 	"k8s.io/apimachinery/pkg/types"
 	"k8s.io/client-go/kubernetes/scheme"

--- a/test/apivalidations/securitygroup_test.go
+++ b/test/apivalidations/securitygroup_test.go
@@ -24,7 +24,6 @@ import (
 	corev1 "k8s.io/api/core/v1"
 	"sigs.k8s.io/controller-runtime/pkg/client"
 
-	"github.com/k-orc/openstack-resource-controller/api/v1alpha1"
 	orcv1alpha1 "github.com/k-orc/openstack-resource-controller/api/v1alpha1"
 	applyconfigv1alpha1 "github.com/k-orc/openstack-resource-controller/pkg/clients/applyconfiguration/api/v1alpha1"
 	"k8s.io/utils/ptr"
@@ -246,17 +245,17 @@ var _ = Describe("ORC SecurityGroup API validations", func() {
 			sgRulePatchSpec := applyconfigv1alpha1.SecurityGroupRule().WithEthertype(ethertype).WithProtocol(protocol)
 			patch.Spec.WithResource(applyconfigv1alpha1.SecurityGroupResourceSpec().WithRules(sgRulePatchSpec.WithPortRange(
 				&applyconfigv1alpha1.PortRangeSpecApplyConfiguration{
-					Min: ptr.To(v1alpha1.PortNumber(256)), Max: ptr.To(v1alpha1.PortNumber(0))})))
+					Min: ptr.To(orcv1alpha1.PortNumber(256)), Max: ptr.To(orcv1alpha1.PortNumber(0))})))
 			Expect(applyObj(ctx, securityGroup, patch)).NotTo(Succeed(), "create security group")
 
 			patch.Spec.WithResource(applyconfigv1alpha1.SecurityGroupResourceSpec().WithRules(sgRulePatchSpec.WithPortRange(
 				&applyconfigv1alpha1.PortRangeSpecApplyConfiguration{
-					Min: ptr.To(v1alpha1.PortNumber(0)), Max: ptr.To(v1alpha1.PortNumber(256))})))
+					Min: ptr.To(orcv1alpha1.PortNumber(0)), Max: ptr.To(orcv1alpha1.PortNumber(256))})))
 			Expect(applyObj(ctx, securityGroup, patch)).NotTo(Succeed(), "create security group")
 
 			patch.Spec.WithResource(applyconfigv1alpha1.SecurityGroupResourceSpec().WithRules(sgRulePatchSpec.WithPortRange(
 				&applyconfigv1alpha1.PortRangeSpecApplyConfiguration{
-					Min: ptr.To(v1alpha1.PortNumber(255)), Max: ptr.To(v1alpha1.PortNumber(255))})))
+					Min: ptr.To(orcv1alpha1.PortNumber(255)), Max: ptr.To(orcv1alpha1.PortNumber(255))})))
 			Expect(applyObj(ctx, securityGroup, patch)).To(Succeed(), "create security group")
 		},
 		Entry(string(orcv1alpha1.ProtocolICMP), orcv1alpha1.ProtocolICMP, orcv1alpha1.EthertypeIPv4),
@@ -284,11 +283,11 @@ var _ = Describe("ORC SecurityGroup API validations", func() {
 		sgRulePatchSpec := baseSGRulePatchSpec().WithProtocol(orcv1alpha1.ProtocolTCP)
 		patch.Spec.WithResource(applyconfigv1alpha1.SecurityGroupResourceSpec().WithRules(sgRulePatchSpec.WithPortRange(
 			&applyconfigv1alpha1.PortRangeSpecApplyConfiguration{
-				Min: ptr.To(v1alpha1.PortNumber(22)), Max: ptr.To(v1alpha1.PortNumber(23))})))
+				Min: ptr.To(orcv1alpha1.PortNumber(22)), Max: ptr.To(orcv1alpha1.PortNumber(23))})))
 		Expect(applyObj(ctx, securityGroup, patch)).To(Succeed(), "create security group")
 		patch.Spec.WithResource(applyconfigv1alpha1.SecurityGroupResourceSpec().WithRules(sgRulePatchSpec.WithPortRange(
 			&applyconfigv1alpha1.PortRangeSpecApplyConfiguration{
-				Min: ptr.To(v1alpha1.PortNumber(22)), Max: ptr.To(v1alpha1.PortNumber(22))})))
+				Min: ptr.To(orcv1alpha1.PortNumber(22)), Max: ptr.To(orcv1alpha1.PortNumber(22))})))
 		Expect(applyObj(ctx, securityGroup, patch)).To(Succeed(), "create security group")
 	})
 
@@ -298,22 +297,22 @@ var _ = Describe("ORC SecurityGroup API validations", func() {
 		sgRulePatchSpec := baseSGRulePatchSpec().WithProtocol(orcv1alpha1.ProtocolTCP)
 		patch.Spec.WithResource(applyconfigv1alpha1.SecurityGroupResourceSpec().WithRules(sgRulePatchSpec.WithPortRange(
 			&applyconfigv1alpha1.PortRangeSpecApplyConfiguration{
-				Min: ptr.To(v1alpha1.PortNumber(51)), Max: ptr.To(v1alpha1.PortNumber(50))})))
+				Min: ptr.To(orcv1alpha1.PortNumber(51)), Max: ptr.To(orcv1alpha1.PortNumber(50))})))
 		Expect(applyObj(ctx, securityGroup, patch)).NotTo(Succeed(), "create security group")
 
 		patch.Spec.WithResource(applyconfigv1alpha1.SecurityGroupResourceSpec().WithRules(sgRulePatchSpec.WithPortRange(
 			&applyconfigv1alpha1.PortRangeSpecApplyConfiguration{
-				Min: ptr.To(v1alpha1.PortNumber(-1))})))
+				Min: ptr.To(orcv1alpha1.PortNumber(-1))})))
 		Expect(applyObj(ctx, securityGroup, patch)).NotTo(Succeed(), "create security group")
 
 		patch.Spec.WithResource(applyconfigv1alpha1.SecurityGroupResourceSpec().WithRules(sgRulePatchSpec.WithPortRange(
 			&applyconfigv1alpha1.PortRangeSpecApplyConfiguration{
-				Min: ptr.To(v1alpha1.PortNumber(50))})))
+				Min: ptr.To(orcv1alpha1.PortNumber(50))})))
 		Expect(applyObj(ctx, securityGroup, patch)).NotTo(Succeed(), "create security group")
 
 		patch.Spec.WithResource(applyconfigv1alpha1.SecurityGroupResourceSpec().WithRules(sgRulePatchSpec.WithPortRange(
 			&applyconfigv1alpha1.PortRangeSpecApplyConfiguration{
-				Max: ptr.To(v1alpha1.PortNumber(50))})))
+				Max: ptr.To(orcv1alpha1.PortNumber(50))})))
 		Expect(applyObj(ctx, securityGroup, patch)).NotTo(Succeed(), "create security group")
 	})
 
@@ -323,7 +322,7 @@ var _ = Describe("ORC SecurityGroup API validations", func() {
 		sgRulePatchSpec := baseSGRulePatchSpec().WithProtocol(orcv1alpha1.ProtocolTCP).WithEthertype(orcv1alpha1.EthertypeIPv4)
 		patch.Spec.WithResource(applyconfigv1alpha1.SecurityGroupResourceSpec().WithRules(sgRulePatchSpec.WithPortRange(
 			&applyconfigv1alpha1.PortRangeSpecApplyConfiguration{
-				Min: ptr.To(v1alpha1.PortNumber(22)), Max: ptr.To(v1alpha1.PortNumber(22))}).WithRemoteIPPrefix("foo")))
+				Min: ptr.To(orcv1alpha1.PortNumber(22)), Max: ptr.To(orcv1alpha1.PortNumber(22))}).WithRemoteIPPrefix("foo")))
 		Expect(applyObj(ctx, securityGroup, patch)).NotTo(Succeed(), "create security group")
 	})
 
@@ -334,13 +333,13 @@ var _ = Describe("ORC SecurityGroup API validations", func() {
 		sgRulePatchSpec = applyconfigv1alpha1.SecurityGroupRule().WithEthertype(orcv1alpha1.EthertypeIPv6)
 		patch.Spec.WithResource(applyconfigv1alpha1.SecurityGroupResourceSpec().WithRules(sgRulePatchSpec.WithPortRange(
 			&applyconfigv1alpha1.PortRangeSpecApplyConfiguration{
-				Min: ptr.To(v1alpha1.PortNumber(22)), Max: ptr.To(v1alpha1.PortNumber(22))}).WithRemoteIPPrefix("192.168.0.1/24")))
+				Min: ptr.To(orcv1alpha1.PortNumber(22)), Max: ptr.To(orcv1alpha1.PortNumber(22))}).WithRemoteIPPrefix("192.168.0.1/24")))
 		Expect(applyObj(ctx, securityGroup, patch)).NotTo(Succeed(), "create security group")
 
 		sgRulePatchSpec = applyconfigv1alpha1.SecurityGroupRule().WithEthertype(orcv1alpha1.EthertypeIPv4)
 		patch.Spec.WithResource(applyconfigv1alpha1.SecurityGroupResourceSpec().WithRules(sgRulePatchSpec.WithPortRange(
 			&applyconfigv1alpha1.PortRangeSpecApplyConfiguration{
-				Min: ptr.To(v1alpha1.PortNumber(22)), Max: ptr.To(v1alpha1.PortNumber(22))}).WithRemoteIPPrefix("2001:db8::/47")))
+				Min: ptr.To(orcv1alpha1.PortNumber(22)), Max: ptr.To(orcv1alpha1.PortNumber(22))}).WithRemoteIPPrefix("2001:db8::/47")))
 		Expect(applyObj(ctx, securityGroup, patch)).NotTo(Succeed(), "create security group")
 	})
 

--- a/test/utils/utils.go
+++ b/test/utils/utils.go
@@ -22,7 +22,7 @@ import (
 	"os/exec"
 	"strings"
 
-	. "github.com/onsi/ginkgo/v2" //nolint:golint,revive
+	. "github.com/onsi/ginkgo/v2" //nolint:staticcheck
 )
 
 const (
@@ -135,6 +135,6 @@ func GetProjectDir() (string, error) {
 	if err != nil {
 		return wd, err
 	}
-	wd = strings.Replace(wd, "/test/e2e", "", -1)
+	wd = strings.ReplaceAll(wd, "/test/e2e", "")
 	return wd, nil
 }


### PR DESCRIPTION
v2 is a new major release of golangci-lint with a new configuration.

- **Bump golangci-lint to v2.0.1 and migrate configuration**
- **lint: Fix new lint failures for golangci-lint v2.0.1**
- **Add nolintlint linter and fixes**
