### PR TITLE
Update installation method in getting started docs

### DIFF
--- a/README.md
+++ b/README.md
@@ -46,16 +46,16 @@ ORC heavily uses [CEL validations](https://kubernetes.io/docs/tasks/extend-kuber
 
 ### Installation
 
-To install a released version of ORC, the simplest is probably to use the provided kustomization file:
+To install a released version of ORC, the simplest is probably to use the provided `install.yaml` file:
 
 ```
-export ORC_RELEASE="https://github.com/k-orc/openstack-resource-controller/dist?ref=v2.0.2"
-kubectl apply --server-side -k $ORC_RELEASE
+export ORC_RELEASE="https://github.com/k-orc/openstack-resource-controller/releases/latest/download/install.yaml"
+kubectl apply --server-side -f $ORC_RELEASE
 ```
 
-You may later uninstall ORC using the same kustomization file:
+You may later uninstall ORC using the same `install.yaml` file:
 ```
-kubectl delete -k $ORC_RELEASE
+kubectl delete -f $ORC_RELEASE
 ```
 
 ### Usage

--- a/RELEASE.md
+++ b/RELEASE.md
@@ -4,10 +4,7 @@ Generate the new `install.yaml` manifest, and tag the release:
 ```bash
 export VERSION=vX.Y.Z
 make build-installer IMG=quay.io/orc/openstack-resource-controller:$VERSION
-
-... Update `Installation` in `README.md` to refer to the new release version.
-
-git add dist README.md
+git add dist
 git commit -m "Release $VERSION"
 git tag -s -a $VERSION -m $VERSION
 git push origin

--- a/website/docs/getting-started.md
+++ b/website/docs/getting-started.md
@@ -8,10 +8,11 @@
 
 ## Deploy ORC to your Kubernetes cluster
 
-From a fresh checkout of the git repository, from the `main` branch, run:
+To install the latest released version of ORC, the simplest is probably to use the provided `install.yaml` file:
 
 ```sh
-make deploy IMG=quay.io/orc/openstack-resource-controller:branch-main
+export ORC_RELEASE="https://github.com/k-orc/openstack-resource-controller/releases/latest/download/install.yaml"
+kubectl apply --server-side -f $ORC_RELEASE
 ```
 
 ## Create a Kubernetes secret containing a `clouds.yaml`
@@ -191,5 +192,5 @@ resources and undeploy ORC:
 kubectl delete subnet subnet-1
 kubectl delete network network-1
 kubectl delete secret openstack-clouds
-make undeploy
+kubectl delete -f $ORC_RELEASE
 ```


### PR DESCRIPTION
The previously documented method for deploying ORC does not work with v2 as it is missing a kustomization file:

```
$ export ORC_RELEASE="https://github.com/k-orc/openstack-resource-controller/dist?ref=v2.0.2"
$ kubectl apply --server-side -k $ORC_RELEASE
error: unable to find one of 'kustomization.yaml', 'kustomization.yml' or 'Kustomization' in directory '/tmp/kustomize-50497731/dist'
```

Instead, point to the `install.yaml` from the latest released artifact.