### PR TITLE
Restore kube 1.29 compatibility

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -1,7 +1,7 @@
 # Image URL to use all building/pushing image targets
 IMG ?= controller:latest
 # ENVTEST_K8S_VERSION refers to the version of kubebuilder assets to be downloaded by envtest binary.
-ENVTEST_K8S_VERSION = 1.32.0
+ENVTEST_K8S_VERSION = 1.29.0
 
 # Get the currently used golang install path (in GOPATH/bin, unless GOBIN is set)
 ifeq (,$(shell go env GOBIN))

--- a/api/v1alpha1/securitygroup_types.go
+++ b/api/v1alpha1/securitygroup_types.go
@@ -92,7 +92,6 @@ type PortRangeStatus struct {
 // +kubebuilder:validation:XValidation:rule="(!has(self.portRange)|| !(self.protocol == 'tcp'|| self.protocol == 'udp' || self.protocol == 'dccp' || self.protocol == 'sctp' || self.protocol == 'udplite') || (self.portRange.min <= self.portRange.max))",message="portRangeMax should be equal or greater than portRange.min"
 // +kubebuilder:validation:XValidation:rule="!(self.protocol == 'icmp' || self.protocol == 'icmpv6') || !has(self.portRange)|| (self.portRange.min >= 0 && self.portRange.min <= 255)",message="When protocol is ICMP or ICMPv6 portRange.min should be between 0 and 255"
 // +kubebuilder:validation:XValidation:rule="!(self.protocol == 'icmp' || self.protocol == 'icmpv6') || !has(self.portRange)|| (self.portRange.max >= 0 && self.portRange.max <= 255)",message="When protocol is ICMP or ICMPv6 portRange.max should be between 0 and 255"
-// +kubebuilder:validation:XValidation:rule="!has(self.remoteIPPrefix) || (isCIDR(self.remoteIPPrefix) && cidr(self.remoteIPPrefix).ip().family() == 4 && self.ethertype == 'IPv4') || (isCIDR(self.remoteIPPrefix) && cidr(self.remoteIPPrefix).ip().family() == 6 && self.ethertype == 'IPv6')",message="remoteIPPrefix should be a valid CIDR and match the ethertype"
 type SecurityGroupRule struct {
 	// description is a human-readable description for the resource.
 	// +optional

--- a/api/v1alpha1/securitygroup_types.go
+++ b/api/v1alpha1/securitygroup_types.go
@@ -87,6 +87,9 @@ type PortRangeStatus struct {
 	Max int32 `json:"max"`
 }
 
+// NOTE: A validation was removed from SecurityGroupRule until we bump minimum k8s to at least v1.31:
+// - remoteIPPrefix matches the address family defined in ethertype: PR #336
+
 // SecurityGroupRule defines a Security Group rule
 // +kubebuilder:validation:MinProperties:=1
 // +kubebuilder:validation:XValidation:rule="(!has(self.portRange)|| !(self.protocol == 'tcp'|| self.protocol == 'udp' || self.protocol == 'dccp' || self.protocol == 'sctp' || self.protocol == 'udplite') || (self.portRange.min <= self.portRange.max))",message="portRangeMax should be equal or greater than portRange.min"

--- a/config/crd/bases/openstack.k-orc.cloud_securitygroups.yaml
+++ b/config/crd/bases/openstack.k-orc.cloud_securitygroups.yaml
@@ -339,12 +339,6 @@ spec:
                         rule: '!(self.protocol == ''icmp'' || self.protocol == ''icmpv6'')
                           || !has(self.portRange)|| (self.portRange.max >= 0 && self.portRange.max
                           <= 255)'
-                      - message: remoteIPPrefix should be a valid CIDR and match the
-                          ethertype
-                        rule: '!has(self.remoteIPPrefix) || (isCIDR(self.remoteIPPrefix)
-                          && cidr(self.remoteIPPrefix).ip().family() == 4 && self.ethertype
-                          == ''IPv4'') || (isCIDR(self.remoteIPPrefix) && cidr(self.remoteIPPrefix).ip().family()
-                          == 6 && self.ethertype == ''IPv6'')'
                     maxItems: 256
                     type: array
                     x-kubernetes-list-type: atomic

--- a/test/apivalidations/securitygroup_test.go
+++ b/test/apivalidations/securitygroup_test.go
@@ -326,23 +326,6 @@ var _ = Describe("ORC SecurityGroup API validations", func() {
 		Expect(applyObj(ctx, securityGroup, patch)).NotTo(Succeed(), "create security group")
 	})
 
-	It("should reject CIDR for RemoteIPPrefix that doesn't match the ethertype", func(ctx context.Context) {
-		var sgRulePatchSpec *applyconfigv1alpha1.SecurityGroupRuleApplyConfiguration
-		securityGroup := securityGroupStub(namespace)
-		patch := baseSecurityGroupPatch(securityGroup)
-		sgRulePatchSpec = applyconfigv1alpha1.SecurityGroupRule().WithEthertype(orcv1alpha1.EthertypeIPv6)
-		patch.Spec.WithResource(applyconfigv1alpha1.SecurityGroupResourceSpec().WithRules(sgRulePatchSpec.WithPortRange(
-			&applyconfigv1alpha1.PortRangeSpecApplyConfiguration{
-				Min: ptr.To(orcv1alpha1.PortNumber(22)), Max: ptr.To(orcv1alpha1.PortNumber(22))}).WithRemoteIPPrefix("192.168.0.1/24")))
-		Expect(applyObj(ctx, securityGroup, patch)).NotTo(Succeed(), "create security group")
-
-		sgRulePatchSpec = applyconfigv1alpha1.SecurityGroupRule().WithEthertype(orcv1alpha1.EthertypeIPv4)
-		patch.Spec.WithResource(applyconfigv1alpha1.SecurityGroupResourceSpec().WithRules(sgRulePatchSpec.WithPortRange(
-			&applyconfigv1alpha1.PortRangeSpecApplyConfiguration{
-				Min: ptr.To(orcv1alpha1.PortNumber(22)), Max: ptr.To(orcv1alpha1.PortNumber(22))}).WithRemoteIPPrefix("2001:db8::/47")))
-		Expect(applyObj(ctx, securityGroup, patch)).NotTo(Succeed(), "create security group")
-	})
-
 	It("should permit valid CIDR that matches the ethertype", func(ctx context.Context) {
 		securityGroup := securityGroupStub(namespace)
 		patch := baseSecurityGroupPatch(securityGroup)


### PR DESCRIPTION
We were using a CEL function that is not available until kubernetes 1.31. Drop the validation to restore kubernetes 1.29 compatibility, and adjust the kubernetes version in the envtest so that we can catch such issues in the future.

We can revert this commit once we bump the minimal required version of kubernetes to be 1.31.