### PR TITLE
README: Add security group rule

### DIFF
--- a/README.md
+++ b/README.md
@@ -62,18 +62,18 @@ kubectl delete -f $ORC_RELEASE
 
 * [Deploy your first OpenStack resource using ORC](https://k-orc.cloud/getting-started/)
 
-## Supported resources
+## Supported OpenStack resources
 
-| **controller** | **1.x** | **main** |
-|:--------------:|:-------:|:--------:|
-| flavor         |         |     ✔    |
-| image          |    ✔    |     ✔    |
-| network        |         |     ◐    |
-| port           |         |     ◐    |
-| router         |         |     ◐    |
-| security group |         |     ✔    |
-| server         |         |     ◐    |
-| subnet         |         |     ◐    |
+| **controller**              | **1.x** | **2.x** | **main** |
+|:---------------------------:|:-------:|:-------:|:--------:|
+| flavor                      |         |    ✔    |     ✔    |
+| image                       |    ✔    |    ✔    |     ✔    |
+| network                     |         |    ◐    |     ◐    |
+| port                        |         |    ◐    |     ◐    |
+| router                      |         |    ◐    |     ◐    |
+| security group (incl. rule) |         |    ✔    |     ✔    |
+| server                      |         |    ◐    |     ◐    |
+| subnet                      |         |    ◐    |     ◐    |
 
 ✔: mostly implemented
 


### PR DESCRIPTION
We've technically implemented security group rules as part of the security group object, and they don't have dedicated objects, but it is still worth documenting as supported in the README.

Also create a separate column for v2.x now that it is released.

Fixes #344