### PR TITLE
Set request ID for all API calls

### DIFF
--- a/internal/osclients/loadbalancer.go
+++ b/internal/osclients/loadbalancer.go
@@ -33,28 +33,28 @@ import (
 )
 
 type LbClient interface {
-	CreateLoadBalancer(opts loadbalancers.CreateOptsBuilder) (*loadbalancers.LoadBalancer, error)
-	ListLoadBalancers(opts loadbalancers.ListOptsBuilder) ([]loadbalancers.LoadBalancer, error)
-	GetLoadBalancer(id string) (*loadbalancers.LoadBalancer, error)
-	DeleteLoadBalancer(id string, opts loadbalancers.DeleteOptsBuilder) error
-	CreateListener(opts listeners.CreateOptsBuilder) (*listeners.Listener, error)
-	ListListeners(opts listeners.ListOptsBuilder) ([]listeners.Listener, error)
-	UpdateListener(id string, opts listeners.UpdateOpts) (*listeners.Listener, error)
-	GetListener(id string) (*listeners.Listener, error)
-	DeleteListener(id string) error
-	CreatePool(opts pools.CreateOptsBuilder) (*pools.Pool, error)
-	ListPools(opts pools.ListOptsBuilder) ([]pools.Pool, error)
-	GetPool(id string) (*pools.Pool, error)
-	DeletePool(id string) error
-	CreatePoolMember(poolID string, opts pools.CreateMemberOptsBuilder) (*pools.Member, error)
-	ListPoolMember(poolID string, opts pools.ListMembersOptsBuilder) ([]pools.Member, error)
-	DeletePoolMember(poolID string, lbMemberID string) error
-	CreateMonitor(opts monitors.CreateOptsBuilder) (*monitors.Monitor, error)
-	ListMonitors(opts monitors.ListOptsBuilder) ([]monitors.Monitor, error)
-	DeleteMonitor(id string) error
-	ListLoadBalancerProviders() ([]providers.Provider, error)
-	ListOctaviaVersions() ([]apiversions.APIVersion, error)
-	ListLoadBalancerFlavors() ([]flavors.Flavor, error)
+	CreateLoadBalancer(ctx context.Context, opts loadbalancers.CreateOptsBuilder) (*loadbalancers.LoadBalancer, error)
+	ListLoadBalancers(ctx context.Context, opts loadbalancers.ListOptsBuilder) ([]loadbalancers.LoadBalancer, error)
+	GetLoadBalancer(ctx context.Context, id string) (*loadbalancers.LoadBalancer, error)
+	DeleteLoadBalancer(ctx context.Context, id string, opts loadbalancers.DeleteOptsBuilder) error
+	CreateListener(ctx context.Context, opts listeners.CreateOptsBuilder) (*listeners.Listener, error)
+	ListListeners(ctx context.Context, opts listeners.ListOptsBuilder) ([]listeners.Listener, error)
+	UpdateListener(ctx context.Context, id string, opts listeners.UpdateOpts) (*listeners.Listener, error)
+	GetListener(ctx context.Context, id string) (*listeners.Listener, error)
+	DeleteListener(ctx context.Context, id string) error
+	CreatePool(ctx context.Context, opts pools.CreateOptsBuilder) (*pools.Pool, error)
+	ListPools(ctx context.Context, opts pools.ListOptsBuilder) ([]pools.Pool, error)
+	GetPool(ctx context.Context, id string) (*pools.Pool, error)
+	DeletePool(ctx context.Context, id string) error
+	CreatePoolMember(ctx context.Context, poolID string, opts pools.CreateMemberOptsBuilder) (*pools.Member, error)
+	ListPoolMember(ctx context.Context, poolID string, opts pools.ListMembersOptsBuilder) ([]pools.Member, error)
+	DeletePoolMember(ctx context.Context, poolID string, lbMemberID string) error
+	CreateMonitor(ctx context.Context, opts monitors.CreateOptsBuilder) (*monitors.Monitor, error)
+	ListMonitors(ctx context.Context, opts monitors.ListOptsBuilder) ([]monitors.Monitor, error)
+	DeleteMonitor(ctx context.Context, id string) error
+	ListLoadBalancerProviders(ctx context.Context) ([]providers.Provider, error)
+	ListOctaviaVersions(ctx context.Context) ([]apiversions.APIVersion, error)
+	ListLoadBalancerFlavors(ctx context.Context) ([]flavors.Flavor, error)
 }
 
 type lbClient struct {
@@ -74,120 +74,120 @@ func NewLbClient(providerClient *gophercloud.ProviderClient, providerClientOpts 
 	return &lbClient{loadbalancerClient}, nil
 }
 
-func (l lbClient) CreateLoadBalancer(opts loadbalancers.CreateOptsBuilder) (*loadbalancers.LoadBalancer, error) {
-	return loadbalancers.Create(context.TODO(), l.serviceClient, opts).Extract()
+func (l lbClient) CreateLoadBalancer(ctx context.Context, opts loadbalancers.CreateOptsBuilder) (*loadbalancers.LoadBalancer, error) {
+	return loadbalancers.Create(ctx, l.serviceClient, opts).Extract()
 }
 
-func (l lbClient) ListLoadBalancers(opts loadbalancers.ListOptsBuilder) ([]loadbalancers.LoadBalancer, error) {
-	allPages, err := loadbalancers.List(l.serviceClient, opts).AllPages(context.TODO())
+func (l lbClient) ListLoadBalancers(ctx context.Context, opts loadbalancers.ListOptsBuilder) ([]loadbalancers.LoadBalancer, error) {
+	allPages, err := loadbalancers.List(l.serviceClient, opts).AllPages(ctx)
 	if err != nil {
 		return nil, err
 	}
 	return loadbalancers.ExtractLoadBalancers(allPages)
 }
 
-func (l lbClient) GetLoadBalancer(id string) (*loadbalancers.LoadBalancer, error) {
-	return loadbalancers.Get(context.TODO(), l.serviceClient, id).Extract()
+func (l lbClient) GetLoadBalancer(ctx context.Context, id string) (*loadbalancers.LoadBalancer, error) {
+	return loadbalancers.Get(ctx, l.serviceClient, id).Extract()
 }
 
-func (l lbClient) DeleteLoadBalancer(id string, opts loadbalancers.DeleteOptsBuilder) error {
-	return loadbalancers.Delete(context.TODO(), l.serviceClient, id, opts).ExtractErr()
+func (l lbClient) DeleteLoadBalancer(ctx context.Context, id string, opts loadbalancers.DeleteOptsBuilder) error {
+	return loadbalancers.Delete(ctx, l.serviceClient, id, opts).ExtractErr()
 }
 
-func (l lbClient) CreateListener(opts listeners.CreateOptsBuilder) (*listeners.Listener, error) {
-	return listeners.Create(context.TODO(), l.serviceClient, opts).Extract()
+func (l lbClient) CreateListener(ctx context.Context, opts listeners.CreateOptsBuilder) (*listeners.Listener, error) {
+	return listeners.Create(ctx, l.serviceClient, opts).Extract()
 }
 
-func (l lbClient) UpdateListener(id string, opts listeners.UpdateOpts) (*listeners.Listener, error) {
-	return listeners.Update(context.TODO(), l.serviceClient, id, opts).Extract()
+func (l lbClient) UpdateListener(ctx context.Context, id string, opts listeners.UpdateOpts) (*listeners.Listener, error) {
+	return listeners.Update(ctx, l.serviceClient, id, opts).Extract()
 }
 
-func (l lbClient) ListListeners(opts listeners.ListOptsBuilder) ([]listeners.Listener, error) {
-	allPages, err := listeners.List(l.serviceClient, opts).AllPages(context.TODO())
+func (l lbClient) ListListeners(ctx context.Context, opts listeners.ListOptsBuilder) ([]listeners.Listener, error) {
+	allPages, err := listeners.List(l.serviceClient, opts).AllPages(ctx)
 	if err != nil {
 		return nil, err
 	}
 	return listeners.ExtractListeners(allPages)
 }
 
-func (l lbClient) GetListener(id string) (*listeners.Listener, error) {
-	return listeners.Get(context.TODO(), l.serviceClient, id).Extract()
+func (l lbClient) GetListener(ctx context.Context, id string) (*listeners.Listener, error) {
+	return listeners.Get(ctx, l.serviceClient, id).Extract()
 }
 
-func (l lbClient) DeleteListener(id string) error {
-	return listeners.Delete(context.TODO(), l.serviceClient, id).ExtractErr()
+func (l lbClient) DeleteListener(ctx context.Context, id string) error {
+	return listeners.Delete(ctx, l.serviceClient, id).ExtractErr()
 }
 
-func (l lbClient) CreatePool(opts pools.CreateOptsBuilder) (*pools.Pool, error) {
-	return pools.Create(context.TODO(), l.serviceClient, opts).Extract()
+func (l lbClient) CreatePool(ctx context.Context, opts pools.CreateOptsBuilder) (*pools.Pool, error) {
+	return pools.Create(ctx, l.serviceClient, opts).Extract()
 }
 
-func (l lbClient) ListPools(opts pools.ListOptsBuilder) ([]pools.Pool, error) {
-	allPages, err := pools.List(l.serviceClient, opts).AllPages(context.TODO())
+func (l lbClient) ListPools(ctx context.Context, opts pools.ListOptsBuilder) ([]pools.Pool, error) {
+	allPages, err := pools.List(l.serviceClient, opts).AllPages(ctx)
 	if err != nil {
 		return nil, err
 	}
 	return pools.ExtractPools(allPages)
 }
 
-func (l lbClient) GetPool(id string) (*pools.Pool, error) {
-	return pools.Get(context.TODO(), l.serviceClient, id).Extract()
+func (l lbClient) GetPool(ctx context.Context, id string) (*pools.Pool, error) {
+	return pools.Get(ctx, l.serviceClient, id).Extract()
 }
 
-func (l lbClient) DeletePool(id string) error {
-	return pools.Delete(context.TODO(), l.serviceClient, id).ExtractErr()
+func (l lbClient) DeletePool(ctx context.Context, id string) error {
+	return pools.Delete(ctx, l.serviceClient, id).ExtractErr()
 }
 
-func (l lbClient) CreatePoolMember(poolID string, lbMemberOpts pools.CreateMemberOptsBuilder) (*pools.Member, error) {
-	return pools.CreateMember(context.TODO(), l.serviceClient, poolID, lbMemberOpts).Extract()
+func (l lbClient) CreatePoolMember(ctx context.Context, poolID string, lbMemberOpts pools.CreateMemberOptsBuilder) (*pools.Member, error) {
+	return pools.CreateMember(ctx, l.serviceClient, poolID, lbMemberOpts).Extract()
 }
 
-func (l lbClient) ListPoolMember(poolID string, opts pools.ListMembersOptsBuilder) ([]pools.Member, error) {
-	allPages, err := pools.ListMembers(l.serviceClient, poolID, opts).AllPages(context.TODO())
+func (l lbClient) ListPoolMember(ctx context.Context, poolID string, opts pools.ListMembersOptsBuilder) ([]pools.Member, error) {
+	allPages, err := pools.ListMembers(l.serviceClient, poolID, opts).AllPages(ctx)
 	if err != nil {
 		return nil, err
 	}
 	return pools.ExtractMembers(allPages)
 }
 
-func (l lbClient) DeletePoolMember(poolID string, lbMemberID string) error {
-	return pools.DeleteMember(context.TODO(), l.serviceClient, poolID, lbMemberID).ExtractErr()
+func (l lbClient) DeletePoolMember(ctx context.Context, poolID string, lbMemberID string) error {
+	return pools.DeleteMember(ctx, l.serviceClient, poolID, lbMemberID).ExtractErr()
 }
 
-func (l lbClient) CreateMonitor(opts monitors.CreateOptsBuilder) (*monitors.Monitor, error) {
-	return monitors.Create(context.TODO(), l.serviceClient, opts).Extract()
+func (l lbClient) CreateMonitor(ctx context.Context, opts monitors.CreateOptsBuilder) (*monitors.Monitor, error) {
+	return monitors.Create(ctx, l.serviceClient, opts).Extract()
 }
 
-func (l lbClient) ListMonitors(opts monitors.ListOptsBuilder) ([]monitors.Monitor, error) {
-	allPages, err := monitors.List(l.serviceClient, opts).AllPages(context.TODO())
+func (l lbClient) ListMonitors(ctx context.Context, opts monitors.ListOptsBuilder) ([]monitors.Monitor, error) {
+	allPages, err := monitors.List(l.serviceClient, opts).AllPages(ctx)
 	if err != nil {
 		return nil, err
 	}
 	return monitors.ExtractMonitors(allPages)
 }
 
-func (l lbClient) DeleteMonitor(id string) error {
-	return monitors.Delete(context.TODO(), l.serviceClient, id).ExtractErr()
+func (l lbClient) DeleteMonitor(ctx context.Context, id string) error {
+	return monitors.Delete(ctx, l.serviceClient, id).ExtractErr()
 }
 
-func (l lbClient) ListLoadBalancerProviders() ([]providers.Provider, error) {
-	allPages, err := providers.List(l.serviceClient, providers.ListOpts{}).AllPages(context.TODO())
+func (l lbClient) ListLoadBalancerProviders(ctx context.Context) ([]providers.Provider, error) {
+	allPages, err := providers.List(l.serviceClient, providers.ListOpts{}).AllPages(ctx)
 	if err != nil {
 		return nil, fmt.Errorf("listing providers: %v", err)
 	}
 	return providers.ExtractProviders(allPages)
 }
 
-func (l lbClient) ListOctaviaVersions() ([]apiversions.APIVersion, error) {
-	allPages, err := apiversions.List(l.serviceClient).AllPages(context.TODO())
+func (l lbClient) ListOctaviaVersions(ctx context.Context) ([]apiversions.APIVersion, error) {
+	allPages, err := apiversions.List(l.serviceClient).AllPages(ctx)
 	if err != nil {
 		return nil, err
 	}
 	return apiversions.ExtractAPIVersions(allPages)
 }
 
-func (l lbClient) ListLoadBalancerFlavors() ([]flavors.Flavor, error) {
-	allPages, err := flavors.List(l.serviceClient, flavors.ListOpts{}).AllPages(context.TODO())
+func (l lbClient) ListLoadBalancerFlavors(ctx context.Context) ([]flavors.Flavor, error) {
+	allPages, err := flavors.List(l.serviceClient, flavors.ListOpts{}).AllPages(ctx)
 	if err != nil {
 		return nil, fmt.Errorf("listing flavors: %v", err)
 	}

--- a/internal/osclients/mock/compute.go
+++ b/internal/osclients/mock/compute.go
@@ -92,17 +92,17 @@ func (mr *MockComputeClientMockRecorder) CreateServer(ctx, createOpts, scheduler
 }
 
 // DeleteAttachedInterface mocks base method.
-func (m *MockComputeClient) DeleteAttachedInterface(serverID, portID string) error {
+func (m *MockComputeClient) DeleteAttachedInterface(ctx context.Context, serverID, portID string) error {
 	m.ctrl.T.Helper()
-	ret := m.ctrl.Call(m, "DeleteAttachedInterface", serverID, portID)
+	ret := m.ctrl.Call(m, "DeleteAttachedInterface", ctx, serverID, portID)
 	ret0, _ := ret[0].(error)
 	return ret0
 }
 
 // DeleteAttachedInterface indicates an expected call of DeleteAttachedInterface.
-func (mr *MockComputeClientMockRecorder) DeleteAttachedInterface(serverID, portID any) *gomock.Call {
+func (mr *MockComputeClientMockRecorder) DeleteAttachedInterface(ctx, serverID, portID any) *gomock.Call {
 	mr.mock.ctrl.T.Helper()
-	return mr.mock.ctrl.RecordCallWithMethodType(mr.mock, "DeleteAttachedInterface", reflect.TypeOf((*MockComputeClient)(nil).DeleteAttachedInterface), serverID, portID)
+	return mr.mock.ctrl.RecordCallWithMethodType(mr.mock, "DeleteAttachedInterface", reflect.TypeOf((*MockComputeClient)(nil).DeleteAttachedInterface), ctx, serverID, portID)
 }
 
 // DeleteFlavor mocks base method.
@@ -164,33 +164,33 @@ func (mr *MockComputeClientMockRecorder) GetServer(ctx, serverID any) *gomock.Ca
 }
 
 // ListAttachedInterfaces mocks base method.
-func (m *MockComputeClient) ListAttachedInterfaces(serverID string) ([]attachinterfaces.Interface, error) {
+func (m *MockComputeClient) ListAttachedInterfaces(ctx context.Context, serverID string) ([]attachinterfaces.Interface, error) {
 	m.ctrl.T.Helper()
-	ret := m.ctrl.Call(m, "ListAttachedInterfaces", serverID)
+	ret := m.ctrl.Call(m, "ListAttachedInterfaces", ctx, serverID)
 	ret0, _ := ret[0].([]attachinterfaces.Interface)
 	ret1, _ := ret[1].(error)
 	return ret0, ret1
 }
 
 // ListAttachedInterfaces indicates an expected call of ListAttachedInterfaces.
-func (mr *MockComputeClientMockRecorder) ListAttachedInterfaces(serverID any) *gomock.Call {
+func (mr *MockComputeClientMockRecorder) ListAttachedInterfaces(ctx, serverID any) *gomock.Call {
 	mr.mock.ctrl.T.Helper()
-	return mr.mock.ctrl.RecordCallWithMethodType(mr.mock, "ListAttachedInterfaces", reflect.TypeOf((*MockComputeClient)(nil).ListAttachedInterfaces), serverID)
+	return mr.mock.ctrl.RecordCallWithMethodType(mr.mock, "ListAttachedInterfaces", reflect.TypeOf((*MockComputeClient)(nil).ListAttachedInterfaces), ctx, serverID)
 }
 
 // ListAvailabilityZones mocks base method.
-func (m *MockComputeClient) ListAvailabilityZones() ([]availabilityzones.AvailabilityZone, error) {
+func (m *MockComputeClient) ListAvailabilityZones(ctx context.Context) ([]availabilityzones.AvailabilityZone, error) {
 	m.ctrl.T.Helper()
-	ret := m.ctrl.Call(m, "ListAvailabilityZones")
+	ret := m.ctrl.Call(m, "ListAvailabilityZones", ctx)
 	ret0, _ := ret[0].([]availabilityzones.AvailabilityZone)
 	ret1, _ := ret[1].(error)
 	return ret0, ret1
 }
 
 // ListAvailabilityZones indicates an expected call of ListAvailabilityZones.
-func (mr *MockComputeClientMockRecorder) ListAvailabilityZones() *gomock.Call {
+func (mr *MockComputeClientMockRecorder) ListAvailabilityZones(ctx any) *gomock.Call {
 	mr.mock.ctrl.T.Helper()
-	return mr.mock.ctrl.RecordCallWithMethodType(mr.mock, "ListAvailabilityZones", reflect.TypeOf((*MockComputeClient)(nil).ListAvailabilityZones))
+	return mr.mock.ctrl.RecordCallWithMethodType(mr.mock, "ListAvailabilityZones", reflect.TypeOf((*MockComputeClient)(nil).ListAvailabilityZones), ctx)
 }
 
 // ListFlavors mocks base method.
@@ -208,18 +208,18 @@ func (mr *MockComputeClientMockRecorder) ListFlavors(ctx, listOpts any) *gomock.
 }
 
 // ListServerGroups mocks base method.
-func (m *MockComputeClient) ListServerGroups() ([]servergroups.ServerGroup, error) {
+func (m *MockComputeClient) ListServerGroups(ctx context.Context) ([]servergroups.ServerGroup, error) {
 	m.ctrl.T.Helper()
-	ret := m.ctrl.Call(m, "ListServerGroups")
+	ret := m.ctrl.Call(m, "ListServerGroups", ctx)
 	ret0, _ := ret[0].([]servergroups.ServerGroup)
 	ret1, _ := ret[1].(error)
 	return ret0, ret1
 }
 
 // ListServerGroups indicates an expected call of ListServerGroups.
-func (mr *MockComputeClientMockRecorder) ListServerGroups() *gomock.Call {
+func (mr *MockComputeClientMockRecorder) ListServerGroups(ctx any) *gomock.Call {
 	mr.mock.ctrl.T.Helper()
-	return mr.mock.ctrl.RecordCallWithMethodType(mr.mock, "ListServerGroups", reflect.TypeOf((*MockComputeClient)(nil).ListServerGroups))
+	return mr.mock.ctrl.RecordCallWithMethodType(mr.mock, "ListServerGroups", reflect.TypeOf((*MockComputeClient)(nil).ListServerGroups), ctx)
 }
 
 // ListServers mocks base method.

--- a/internal/osclients/mock/loadbalancer.go
+++ b/internal/osclients/mock/loadbalancer.go
@@ -25,6 +25,7 @@ limitations under the License.
 package mock
 
 import (
+	context "context"
 	reflect "reflect"
 
 	apiversions "github.com/gophercloud/gophercloud/v2/openstack/loadbalancer/v2/apiversions"
@@ -62,326 +63,326 @@ func (m *MockLbClient) EXPECT() *MockLbClientMockRecorder {
 }
 
 // CreateListener mocks base method.
-func (m *MockLbClient) CreateListener(opts listeners.CreateOptsBuilder) (*listeners.Listener, error) {
+func (m *MockLbClient) CreateListener(ctx context.Context, opts listeners.CreateOptsBuilder) (*listeners.Listener, error) {
 	m.ctrl.T.Helper()
-	ret := m.ctrl.Call(m, "CreateListener", opts)
+	ret := m.ctrl.Call(m, "CreateListener", ctx, opts)
 	ret0, _ := ret[0].(*listeners.Listener)
 	ret1, _ := ret[1].(error)
 	return ret0, ret1
 }
 
 // CreateListener indicates an expected call of CreateListener.
-func (mr *MockLbClientMockRecorder) CreateListener(opts any) *gomock.Call {
+func (mr *MockLbClientMockRecorder) CreateListener(ctx, opts any) *gomock.Call {
 	mr.mock.ctrl.T.Helper()
-	return mr.mock.ctrl.RecordCallWithMethodType(mr.mock, "CreateListener", reflect.TypeOf((*MockLbClient)(nil).CreateListener), opts)
+	return mr.mock.ctrl.RecordCallWithMethodType(mr.mock, "CreateListener", reflect.TypeOf((*MockLbClient)(nil).CreateListener), ctx, opts)
 }
 
 // CreateLoadBalancer mocks base method.
-func (m *MockLbClient) CreateLoadBalancer(opts loadbalancers.CreateOptsBuilder) (*loadbalancers.LoadBalancer, error) {
+func (m *MockLbClient) CreateLoadBalancer(ctx context.Context, opts loadbalancers.CreateOptsBuilder) (*loadbalancers.LoadBalancer, error) {
 	m.ctrl.T.Helper()
-	ret := m.ctrl.Call(m, "CreateLoadBalancer", opts)
+	ret := m.ctrl.Call(m, "CreateLoadBalancer", ctx, opts)
 	ret0, _ := ret[0].(*loadbalancers.LoadBalancer)
 	ret1, _ := ret[1].(error)
 	return ret0, ret1
 }
 
 // CreateLoadBalancer indicates an expected call of CreateLoadBalancer.
-func (mr *MockLbClientMockRecorder) CreateLoadBalancer(opts any) *gomock.Call {
+func (mr *MockLbClientMockRecorder) CreateLoadBalancer(ctx, opts any) *gomock.Call {
 	mr.mock.ctrl.T.Helper()
-	return mr.mock.ctrl.RecordCallWithMethodType(mr.mock, "CreateLoadBalancer", reflect.TypeOf((*MockLbClient)(nil).CreateLoadBalancer), opts)
+	return mr.mock.ctrl.RecordCallWithMethodType(mr.mock, "CreateLoadBalancer", reflect.TypeOf((*MockLbClient)(nil).CreateLoadBalancer), ctx, opts)
 }
 
 // CreateMonitor mocks base method.
-func (m *MockLbClient) CreateMonitor(opts monitors.CreateOptsBuilder) (*monitors.Monitor, error) {
+func (m *MockLbClient) CreateMonitor(ctx context.Context, opts monitors.CreateOptsBuilder) (*monitors.Monitor, error) {
 	m.ctrl.T.Helper()
-	ret := m.ctrl.Call(m, "CreateMonitor", opts)
+	ret := m.ctrl.Call(m, "CreateMonitor", ctx, opts)
 	ret0, _ := ret[0].(*monitors.Monitor)
 	ret1, _ := ret[1].(error)
 	return ret0, ret1
 }
 
 // CreateMonitor indicates an expected call of CreateMonitor.
-func (mr *MockLbClientMockRecorder) CreateMonitor(opts any) *gomock.Call {
+func (mr *MockLbClientMockRecorder) CreateMonitor(ctx, opts any) *gomock.Call {
 	mr.mock.ctrl.T.Helper()
-	return mr.mock.ctrl.RecordCallWithMethodType(mr.mock, "CreateMonitor", reflect.TypeOf((*MockLbClient)(nil).CreateMonitor), opts)
+	return mr.mock.ctrl.RecordCallWithMethodType(mr.mock, "CreateMonitor", reflect.TypeOf((*MockLbClient)(nil).CreateMonitor), ctx, opts)
 }
 
 // CreatePool mocks base method.
-func (m *MockLbClient) CreatePool(opts pools.CreateOptsBuilder) (*pools.Pool, error) {
+func (m *MockLbClient) CreatePool(ctx context.Context, opts pools.CreateOptsBuilder) (*pools.Pool, error) {
 	m.ctrl.T.Helper()
-	ret := m.ctrl.Call(m, "CreatePool", opts)
+	ret := m.ctrl.Call(m, "CreatePool", ctx, opts)
 	ret0, _ := ret[0].(*pools.Pool)
 	ret1, _ := ret[1].(error)
 	return ret0, ret1
 }
 
 // CreatePool indicates an expected call of CreatePool.
-func (mr *MockLbClientMockRecorder) CreatePool(opts any) *gomock.Call {
+func (mr *MockLbClientMockRecorder) CreatePool(ctx, opts any) *gomock.Call {
 	mr.mock.ctrl.T.Helper()
-	return mr.mock.ctrl.RecordCallWithMethodType(mr.mock, "CreatePool", reflect.TypeOf((*MockLbClient)(nil).CreatePool), opts)
+	return mr.mock.ctrl.RecordCallWithMethodType(mr.mock, "CreatePool", reflect.TypeOf((*MockLbClient)(nil).CreatePool), ctx, opts)
 }
 
 // CreatePoolMember mocks base method.
-func (m *MockLbClient) CreatePoolMember(poolID string, opts pools.CreateMemberOptsBuilder) (*pools.Member, error) {
+func (m *MockLbClient) CreatePoolMember(ctx context.Context, poolID string, opts pools.CreateMemberOptsBuilder) (*pools.Member, error) {
 	m.ctrl.T.Helper()
-	ret := m.ctrl.Call(m, "CreatePoolMember", poolID, opts)
+	ret := m.ctrl.Call(m, "CreatePoolMember", ctx, poolID, opts)
 	ret0, _ := ret[0].(*pools.Member)
 	ret1, _ := ret[1].(error)
 	return ret0, ret1
 }
 
 // CreatePoolMember indicates an expected call of CreatePoolMember.
-func (mr *MockLbClientMockRecorder) CreatePoolMember(poolID, opts any) *gomock.Call {
+func (mr *MockLbClientMockRecorder) CreatePoolMember(ctx, poolID, opts any) *gomock.Call {
 	mr.mock.ctrl.T.Helper()
-	return mr.mock.ctrl.RecordCallWithMethodType(mr.mock, "CreatePoolMember", reflect.TypeOf((*MockLbClient)(nil).CreatePoolMember), poolID, opts)
+	return mr.mock.ctrl.RecordCallWithMethodType(mr.mock, "CreatePoolMember", reflect.TypeOf((*MockLbClient)(nil).CreatePoolMember), ctx, poolID, opts)
 }
 
 // DeleteListener mocks base method.
-func (m *MockLbClient) DeleteListener(id string) error {
+func (m *MockLbClient) DeleteListener(ctx context.Context, id string) error {
 	m.ctrl.T.Helper()
-	ret := m.ctrl.Call(m, "DeleteListener", id)
+	ret := m.ctrl.Call(m, "DeleteListener", ctx, id)
 	ret0, _ := ret[0].(error)
 	return ret0
 }
 
 // DeleteListener indicates an expected call of DeleteListener.
-func (mr *MockLbClientMockRecorder) DeleteListener(id any) *gomock.Call {
+func (mr *MockLbClientMockRecorder) DeleteListener(ctx, id any) *gomock.Call {
 	mr.mock.ctrl.T.Helper()
-	return mr.mock.ctrl.RecordCallWithMethodType(mr.mock, "DeleteListener", reflect.TypeOf((*MockLbClient)(nil).DeleteListener), id)
+	return mr.mock.ctrl.RecordCallWithMethodType(mr.mock, "DeleteListener", reflect.TypeOf((*MockLbClient)(nil).DeleteListener), ctx, id)
 }
 
 // DeleteLoadBalancer mocks base method.
-func (m *MockLbClient) DeleteLoadBalancer(id string, opts loadbalancers.DeleteOptsBuilder) error {
+func (m *MockLbClient) DeleteLoadBalancer(ctx context.Context, id string, opts loadbalancers.DeleteOptsBuilder) error {
 	m.ctrl.T.Helper()
-	ret := m.ctrl.Call(m, "DeleteLoadBalancer", id, opts)
+	ret := m.ctrl.Call(m, "DeleteLoadBalancer", ctx, id, opts)
 	ret0, _ := ret[0].(error)
 	return ret0
 }
 
 // DeleteLoadBalancer indicates an expected call of DeleteLoadBalancer.
-func (mr *MockLbClientMockRecorder) DeleteLoadBalancer(id, opts any) *gomock.Call {
+func (mr *MockLbClientMockRecorder) DeleteLoadBalancer(ctx, id, opts any) *gomock.Call {
 	mr.mock.ctrl.T.Helper()
-	return mr.mock.ctrl.RecordCallWithMethodType(mr.mock, "DeleteLoadBalancer", reflect.TypeOf((*MockLbClient)(nil).DeleteLoadBalancer), id, opts)
+	return mr.mock.ctrl.RecordCallWithMethodType(mr.mock, "DeleteLoadBalancer", reflect.TypeOf((*MockLbClient)(nil).DeleteLoadBalancer), ctx, id, opts)
 }
 
 // DeleteMonitor mocks base method.
-func (m *MockLbClient) DeleteMonitor(id string) error {
+func (m *MockLbClient) DeleteMonitor(ctx context.Context, id string) error {
 	m.ctrl.T.Helper()
-	ret := m.ctrl.Call(m, "DeleteMonitor", id)
+	ret := m.ctrl.Call(m, "DeleteMonitor", ctx, id)
 	ret0, _ := ret[0].(error)
 	return ret0
 }
 
 // DeleteMonitor indicates an expected call of DeleteMonitor.
-func (mr *MockLbClientMockRecorder) DeleteMonitor(id any) *gomock.Call {
+func (mr *MockLbClientMockRecorder) DeleteMonitor(ctx, id any) *gomock.Call {
 	mr.mock.ctrl.T.Helper()
-	return mr.mock.ctrl.RecordCallWithMethodType(mr.mock, "DeleteMonitor", reflect.TypeOf((*MockLbClient)(nil).DeleteMonitor), id)
+	return mr.mock.ctrl.RecordCallWithMethodType(mr.mock, "DeleteMonitor", reflect.TypeOf((*MockLbClient)(nil).DeleteMonitor), ctx, id)
 }
 
 // DeletePool mocks base method.
-func (m *MockLbClient) DeletePool(id string) error {
+func (m *MockLbClient) DeletePool(ctx context.Context, id string) error {
 	m.ctrl.T.Helper()
-	ret := m.ctrl.Call(m, "DeletePool", id)
+	ret := m.ctrl.Call(m, "DeletePool", ctx, id)
 	ret0, _ := ret[0].(error)
 	return ret0
 }
 
 // DeletePool indicates an expected call of DeletePool.
-func (mr *MockLbClientMockRecorder) DeletePool(id any) *gomock.Call {
+func (mr *MockLbClientMockRecorder) DeletePool(ctx, id any) *gomock.Call {
 	mr.mock.ctrl.T.Helper()
-	return mr.mock.ctrl.RecordCallWithMethodType(mr.mock, "DeletePool", reflect.TypeOf((*MockLbClient)(nil).DeletePool), id)
+	return mr.mock.ctrl.RecordCallWithMethodType(mr.mock, "DeletePool", reflect.TypeOf((*MockLbClient)(nil).DeletePool), ctx, id)
 }
 
 // DeletePoolMember mocks base method.
-func (m *MockLbClient) DeletePoolMember(poolID, lbMemberID string) error {
+func (m *MockLbClient) DeletePoolMember(ctx context.Context, poolID, lbMemberID string) error {
 	m.ctrl.T.Helper()
-	ret := m.ctrl.Call(m, "DeletePoolMember", poolID, lbMemberID)
+	ret := m.ctrl.Call(m, "DeletePoolMember", ctx, poolID, lbMemberID)
 	ret0, _ := ret[0].(error)
 	return ret0
 }
 
 // DeletePoolMember indicates an expected call of DeletePoolMember.
-func (mr *MockLbClientMockRecorder) DeletePoolMember(poolID, lbMemberID any) *gomock.Call {
+func (mr *MockLbClientMockRecorder) DeletePoolMember(ctx, poolID, lbMemberID any) *gomock.Call {
 	mr.mock.ctrl.T.Helper()
-	return mr.mock.ctrl.RecordCallWithMethodType(mr.mock, "DeletePoolMember", reflect.TypeOf((*MockLbClient)(nil).DeletePoolMember), poolID, lbMemberID)
+	return mr.mock.ctrl.RecordCallWithMethodType(mr.mock, "DeletePoolMember", reflect.TypeOf((*MockLbClient)(nil).DeletePoolMember), ctx, poolID, lbMemberID)
 }
 
 // GetListener mocks base method.
-func (m *MockLbClient) GetListener(id string) (*listeners.Listener, error) {
+func (m *MockLbClient) GetListener(ctx context.Context, id string) (*listeners.Listener, error) {
 	m.ctrl.T.Helper()
-	ret := m.ctrl.Call(m, "GetListener", id)
+	ret := m.ctrl.Call(m, "GetListener", ctx, id)
 	ret0, _ := ret[0].(*listeners.Listener)
 	ret1, _ := ret[1].(error)
 	return ret0, ret1
 }
 
 // GetListener indicates an expected call of GetListener.
-func (mr *MockLbClientMockRecorder) GetListener(id any) *gomock.Call {
+func (mr *MockLbClientMockRecorder) GetListener(ctx, id any) *gomock.Call {
 	mr.mock.ctrl.T.Helper()
-	return mr.mock.ctrl.RecordCallWithMethodType(mr.mock, "GetListener", reflect.TypeOf((*MockLbClient)(nil).GetListener), id)
+	return mr.mock.ctrl.RecordCallWithMethodType(mr.mock, "GetListener", reflect.TypeOf((*MockLbClient)(nil).GetListener), ctx, id)
 }
 
 // GetLoadBalancer mocks base method.
-func (m *MockLbClient) GetLoadBalancer(id string) (*loadbalancers.LoadBalancer, error) {
+func (m *MockLbClient) GetLoadBalancer(ctx context.Context, id string) (*loadbalancers.LoadBalancer, error) {
 	m.ctrl.T.Helper()
-	ret := m.ctrl.Call(m, "GetLoadBalancer", id)
+	ret := m.ctrl.Call(m, "GetLoadBalancer", ctx, id)
 	ret0, _ := ret[0].(*loadbalancers.LoadBalancer)
 	ret1, _ := ret[1].(error)
 	return ret0, ret1
 }
 
 // GetLoadBalancer indicates an expected call of GetLoadBalancer.
-func (mr *MockLbClientMockRecorder) GetLoadBalancer(id any) *gomock.Call {
+func (mr *MockLbClientMockRecorder) GetLoadBalancer(ctx, id any) *gomock.Call {
 	mr.mock.ctrl.T.Helper()
-	return mr.mock.ctrl.RecordCallWithMethodType(mr.mock, "GetLoadBalancer", reflect.TypeOf((*MockLbClient)(nil).GetLoadBalancer), id)
+	return mr.mock.ctrl.RecordCallWithMethodType(mr.mock, "GetLoadBalancer", reflect.TypeOf((*MockLbClient)(nil).GetLoadBalancer), ctx, id)
 }
 
 // GetPool mocks base method.
-func (m *MockLbClient) GetPool(id string) (*pools.Pool, error) {
+func (m *MockLbClient) GetPool(ctx context.Context, id string) (*pools.Pool, error) {
 	m.ctrl.T.Helper()
-	ret := m.ctrl.Call(m, "GetPool", id)
+	ret := m.ctrl.Call(m, "GetPool", ctx, id)
 	ret0, _ := ret[0].(*pools.Pool)
 	ret1, _ := ret[1].(error)
 	return ret0, ret1
 }
 
 // GetPool indicates an expected call of GetPool.
-func (mr *MockLbClientMockRecorder) GetPool(id any) *gomock.Call {
+func (mr *MockLbClientMockRecorder) GetPool(ctx, id any) *gomock.Call {
 	mr.mock.ctrl.T.Helper()
-	return mr.mock.ctrl.RecordCallWithMethodType(mr.mock, "GetPool", reflect.TypeOf((*MockLbClient)(nil).GetPool), id)
+	return mr.mock.ctrl.RecordCallWithMethodType(mr.mock, "GetPool", reflect.TypeOf((*MockLbClient)(nil).GetPool), ctx, id)
 }
 
 // ListListeners mocks base method.
-func (m *MockLbClient) ListListeners(opts listeners.ListOptsBuilder) ([]listeners.Listener, error) {
+func (m *MockLbClient) ListListeners(ctx context.Context, opts listeners.ListOptsBuilder) ([]listeners.Listener, error) {
 	m.ctrl.T.Helper()
-	ret := m.ctrl.Call(m, "ListListeners", opts)
+	ret := m.ctrl.Call(m, "ListListeners", ctx, opts)
 	ret0, _ := ret[0].([]listeners.Listener)
 	ret1, _ := ret[1].(error)
 	return ret0, ret1
 }
 
 // ListListeners indicates an expected call of ListListeners.
-func (mr *MockLbClientMockRecorder) ListListeners(opts any) *gomock.Call {
+func (mr *MockLbClientMockRecorder) ListListeners(ctx, opts any) *gomock.Call {
 	mr.mock.ctrl.T.Helper()
-	return mr.mock.ctrl.RecordCallWithMethodType(mr.mock, "ListListeners", reflect.TypeOf((*MockLbClient)(nil).ListListeners), opts)
+	return mr.mock.ctrl.RecordCallWithMethodType(mr.mock, "ListListeners", reflect.TypeOf((*MockLbClient)(nil).ListListeners), ctx, opts)
 }
 
 // ListLoadBalancerFlavors mocks base method.
-func (m *MockLbClient) ListLoadBalancerFlavors() ([]flavors.Flavor, error) {
+func (m *MockLbClient) ListLoadBalancerFlavors(ctx context.Context) ([]flavors.Flavor, error) {
 	m.ctrl.T.Helper()
-	ret := m.ctrl.Call(m, "ListLoadBalancerFlavors")
+	ret := m.ctrl.Call(m, "ListLoadBalancerFlavors", ctx)
 	ret0, _ := ret[0].([]flavors.Flavor)
 	ret1, _ := ret[1].(error)
 	return ret0, ret1
 }
 
 // ListLoadBalancerFlavors indicates an expected call of ListLoadBalancerFlavors.
-func (mr *MockLbClientMockRecorder) ListLoadBalancerFlavors() *gomock.Call {
+func (mr *MockLbClientMockRecorder) ListLoadBalancerFlavors(ctx any) *gomock.Call {
 	mr.mock.ctrl.T.Helper()
-	return mr.mock.ctrl.RecordCallWithMethodType(mr.mock, "ListLoadBalancerFlavors", reflect.TypeOf((*MockLbClient)(nil).ListLoadBalancerFlavors))
+	return mr.mock.ctrl.RecordCallWithMethodType(mr.mock, "ListLoadBalancerFlavors", reflect.TypeOf((*MockLbClient)(nil).ListLoadBalancerFlavors), ctx)
 }
 
 // ListLoadBalancerProviders mocks base method.
-func (m *MockLbClient) ListLoadBalancerProviders() ([]providers.Provider, error) {
+func (m *MockLbClient) ListLoadBalancerProviders(ctx context.Context) ([]providers.Provider, error) {
 	m.ctrl.T.Helper()
-	ret := m.ctrl.Call(m, "ListLoadBalancerProviders")
+	ret := m.ctrl.Call(m, "ListLoadBalancerProviders", ctx)
 	ret0, _ := ret[0].([]providers.Provider)
 	ret1, _ := ret[1].(error)
 	return ret0, ret1
 }
 
 // ListLoadBalancerProviders indicates an expected call of ListLoadBalancerProviders.
-func (mr *MockLbClientMockRecorder) ListLoadBalancerProviders() *gomock.Call {
+func (mr *MockLbClientMockRecorder) ListLoadBalancerProviders(ctx any) *gomock.Call {
 	mr.mock.ctrl.T.Helper()
-	return mr.mock.ctrl.RecordCallWithMethodType(mr.mock, "ListLoadBalancerProviders", reflect.TypeOf((*MockLbClient)(nil).ListLoadBalancerProviders))
+	return mr.mock.ctrl.RecordCallWithMethodType(mr.mock, "ListLoadBalancerProviders", reflect.TypeOf((*MockLbClient)(nil).ListLoadBalancerProviders), ctx)
 }
 
 // ListLoadBalancers mocks base method.
-func (m *MockLbClient) ListLoadBalancers(opts loadbalancers.ListOptsBuilder) ([]loadbalancers.LoadBalancer, error) {
+func (m *MockLbClient) ListLoadBalancers(ctx context.Context, opts loadbalancers.ListOptsBuilder) ([]loadbalancers.LoadBalancer, error) {
 	m.ctrl.T.Helper()
-	ret := m.ctrl.Call(m, "ListLoadBalancers", opts)
+	ret := m.ctrl.Call(m, "ListLoadBalancers", ctx, opts)
 	ret0, _ := ret[0].([]loadbalancers.LoadBalancer)
 	ret1, _ := ret[1].(error)
 	return ret0, ret1
 }
 
 // ListLoadBalancers indicates an expected call of ListLoadBalancers.
-func (mr *MockLbClientMockRecorder) ListLoadBalancers(opts any) *gomock.Call {
+func (mr *MockLbClientMockRecorder) ListLoadBalancers(ctx, opts any) *gomock.Call {
 	mr.mock.ctrl.T.Helper()
-	return mr.mock.ctrl.RecordCallWithMethodType(mr.mock, "ListLoadBalancers", reflect.TypeOf((*MockLbClient)(nil).ListLoadBalancers), opts)
+	return mr.mock.ctrl.RecordCallWithMethodType(mr.mock, "ListLoadBalancers", reflect.TypeOf((*MockLbClient)(nil).ListLoadBalancers), ctx, opts)
 }
 
 // ListMonitors mocks base method.
-func (m *MockLbClient) ListMonitors(opts monitors.ListOptsBuilder) ([]monitors.Monitor, error) {
+func (m *MockLbClient) ListMonitors(ctx context.Context, opts monitors.ListOptsBuilder) ([]monitors.Monitor, error) {
 	m.ctrl.T.Helper()
-	ret := m.ctrl.Call(m, "ListMonitors", opts)
+	ret := m.ctrl.Call(m, "ListMonitors", ctx, opts)
 	ret0, _ := ret[0].([]monitors.Monitor)
 	ret1, _ := ret[1].(error)
 	return ret0, ret1
 }
 
 // ListMonitors indicates an expected call of ListMonitors.
-func (mr *MockLbClientMockRecorder) ListMonitors(opts any) *gomock.Call {
+func (mr *MockLbClientMockRecorder) ListMonitors(ctx, opts any) *gomock.Call {
 	mr.mock.ctrl.T.Helper()
-	return mr.mock.ctrl.RecordCallWithMethodType(mr.mock, "ListMonitors", reflect.TypeOf((*MockLbClient)(nil).ListMonitors), opts)
+	return mr.mock.ctrl.RecordCallWithMethodType(mr.mock, "ListMonitors", reflect.TypeOf((*MockLbClient)(nil).ListMonitors), ctx, opts)
 }
 
 // ListOctaviaVersions mocks base method.
-func (m *MockLbClient) ListOctaviaVersions() ([]apiversions.APIVersion, error) {
+func (m *MockLbClient) ListOctaviaVersions(ctx context.Context) ([]apiversions.APIVersion, error) {
 	m.ctrl.T.Helper()
-	ret := m.ctrl.Call(m, "ListOctaviaVersions")
+	ret := m.ctrl.Call(m, "ListOctaviaVersions", ctx)
 	ret0, _ := ret[0].([]apiversions.APIVersion)
 	ret1, _ := ret[1].(error)
 	return ret0, ret1
 }
 
 // ListOctaviaVersions indicates an expected call of ListOctaviaVersions.
-func (mr *MockLbClientMockRecorder) ListOctaviaVersions() *gomock.Call {
+func (mr *MockLbClientMockRecorder) ListOctaviaVersions(ctx any) *gomock.Call {
 	mr.mock.ctrl.T.Helper()
-	return mr.mock.ctrl.RecordCallWithMethodType(mr.mock, "ListOctaviaVersions", reflect.TypeOf((*MockLbClient)(nil).ListOctaviaVersions))
+	return mr.mock.ctrl.RecordCallWithMethodType(mr.mock, "ListOctaviaVersions", reflect.TypeOf((*MockLbClient)(nil).ListOctaviaVersions), ctx)
 }
 
 // ListPoolMember mocks base method.
-func (m *MockLbClient) ListPoolMember(poolID string, opts pools.ListMembersOptsBuilder) ([]pools.Member, error) {
+func (m *MockLbClient) ListPoolMember(ctx context.Context, poolID string, opts pools.ListMembersOptsBuilder) ([]pools.Member, error) {
 	m.ctrl.T.Helper()
-	ret := m.ctrl.Call(m, "ListPoolMember", poolID, opts)
+	ret := m.ctrl.Call(m, "ListPoolMember", ctx, poolID, opts)
 	ret0, _ := ret[0].([]pools.Member)
 	ret1, _ := ret[1].(error)
 	return ret0, ret1
 }
 
 // ListPoolMember indicates an expected call of ListPoolMember.
-func (mr *MockLbClientMockRecorder) ListPoolMember(poolID, opts any) *gomock.Call {
+func (mr *MockLbClientMockRecorder) ListPoolMember(ctx, poolID, opts any) *gomock.Call {
 	mr.mock.ctrl.T.Helper()
-	return mr.mock.ctrl.RecordCallWithMethodType(mr.mock, "ListPoolMember", reflect.TypeOf((*MockLbClient)(nil).ListPoolMember), poolID, opts)
+	return mr.mock.ctrl.RecordCallWithMethodType(mr.mock, "ListPoolMember", reflect.TypeOf((*MockLbClient)(nil).ListPoolMember), ctx, poolID, opts)
 }
 
 // ListPools mocks base method.
-func (m *MockLbClient) ListPools(opts pools.ListOptsBuilder) ([]pools.Pool, error) {
+func (m *MockLbClient) ListPools(ctx context.Context, opts pools.ListOptsBuilder) ([]pools.Pool, error) {
 	m.ctrl.T.Helper()
-	ret := m.ctrl.Call(m, "ListPools", opts)
+	ret := m.ctrl.Call(m, "ListPools", ctx, opts)
 	ret0, _ := ret[0].([]pools.Pool)
 	ret1, _ := ret[1].(error)
 	return ret0, ret1
 }
 
 // ListPools indicates an expected call of ListPools.
-func (mr *MockLbClientMockRecorder) ListPools(opts any) *gomock.Call {
+func (mr *MockLbClientMockRecorder) ListPools(ctx, opts any) *gomock.Call {
 	mr.mock.ctrl.T.Helper()
-	return mr.mock.ctrl.RecordCallWithMethodType(mr.mock, "ListPools", reflect.TypeOf((*MockLbClient)(nil).ListPools), opts)
+	return mr.mock.ctrl.RecordCallWithMethodType(mr.mock, "ListPools", reflect.TypeOf((*MockLbClient)(nil).ListPools), ctx, opts)
 }
 
 // UpdateListener mocks base method.
-func (m *MockLbClient) UpdateListener(id string, opts listeners.UpdateOpts) (*listeners.Listener, error) {
+func (m *MockLbClient) UpdateListener(ctx context.Context, id string, opts listeners.UpdateOpts) (*listeners.Listener, error) {
 	m.ctrl.T.Helper()
-	ret := m.ctrl.Call(m, "UpdateListener", id, opts)
+	ret := m.ctrl.Call(m, "UpdateListener", ctx, id, opts)
 	ret0, _ := ret[0].(*listeners.Listener)
 	ret1, _ := ret[1].(error)
 	return ret0, ret1
 }
 
 // UpdateListener indicates an expected call of UpdateListener.
-func (mr *MockLbClientMockRecorder) UpdateListener(id, opts any) *gomock.Call {
+func (mr *MockLbClientMockRecorder) UpdateListener(ctx, id, opts any) *gomock.Call {
 	mr.mock.ctrl.T.Helper()
-	return mr.mock.ctrl.RecordCallWithMethodType(mr.mock, "UpdateListener", reflect.TypeOf((*MockLbClient)(nil).UpdateListener), id, opts)
+	return mr.mock.ctrl.RecordCallWithMethodType(mr.mock, "UpdateListener", reflect.TypeOf((*MockLbClient)(nil).UpdateListener), ctx, id, opts)
 }

--- a/internal/osclients/mock/networking.go
+++ b/internal/osclients/mock/networking.go
@@ -83,18 +83,18 @@ func (mr *MockNetworkClientMockRecorder) AddRouterInterface(ctx, id, opts any) *
 }
 
 // CreateFloatingIP mocks base method.
-func (m *MockNetworkClient) CreateFloatingIP(opts floatingips.CreateOptsBuilder) (*floatingips.FloatingIP, error) {
+func (m *MockNetworkClient) CreateFloatingIP(ctx context.Context, opts floatingips.CreateOptsBuilder) (*floatingips.FloatingIP, error) {
 	m.ctrl.T.Helper()
-	ret := m.ctrl.Call(m, "CreateFloatingIP", opts)
+	ret := m.ctrl.Call(m, "CreateFloatingIP", ctx, opts)
 	ret0, _ := ret[0].(*floatingips.FloatingIP)
 	ret1, _ := ret[1].(error)
 	return ret0, ret1
 }
 
 // CreateFloatingIP indicates an expected call of CreateFloatingIP.
-func (mr *MockNetworkClientMockRecorder) CreateFloatingIP(opts any) *gomock.Call {
+func (mr *MockNetworkClientMockRecorder) CreateFloatingIP(ctx, opts any) *gomock.Call {
 	mr.mock.ctrl.T.Helper()
-	return mr.mock.ctrl.RecordCallWithMethodType(mr.mock, "CreateFloatingIP", reflect.TypeOf((*MockNetworkClient)(nil).CreateFloatingIP), opts)
+	return mr.mock.ctrl.RecordCallWithMethodType(mr.mock, "CreateFloatingIP", reflect.TypeOf((*MockNetworkClient)(nil).CreateFloatingIP), ctx, opts)
 }
 
 // CreateNetwork mocks base method.
@@ -188,32 +188,32 @@ func (mr *MockNetworkClientMockRecorder) CreateSubnet(ctx, opts any) *gomock.Cal
 }
 
 // CreateTrunk mocks base method.
-func (m *MockNetworkClient) CreateTrunk(opts trunks.CreateOptsBuilder) (*trunks.Trunk, error) {
+func (m *MockNetworkClient) CreateTrunk(ctx context.Context, opts trunks.CreateOptsBuilder) (*trunks.Trunk, error) {
 	m.ctrl.T.Helper()
-	ret := m.ctrl.Call(m, "CreateTrunk", opts)
+	ret := m.ctrl.Call(m, "CreateTrunk", ctx, opts)
 	ret0, _ := ret[0].(*trunks.Trunk)
 	ret1, _ := ret[1].(error)
 	return ret0, ret1
 }
 
 // CreateTrunk indicates an expected call of CreateTrunk.
-func (mr *MockNetworkClientMockRecorder) CreateTrunk(opts any) *gomock.Call {
+func (mr *MockNetworkClientMockRecorder) CreateTrunk(ctx, opts any) *gomock.Call {
 	mr.mock.ctrl.T.Helper()
-	return mr.mock.ctrl.RecordCallWithMethodType(mr.mock, "CreateTrunk", reflect.TypeOf((*MockNetworkClient)(nil).CreateTrunk), opts)
+	return mr.mock.ctrl.RecordCallWithMethodType(mr.mock, "CreateTrunk", reflect.TypeOf((*MockNetworkClient)(nil).CreateTrunk), ctx, opts)
 }
 
 // DeleteFloatingIP mocks base method.
-func (m *MockNetworkClient) DeleteFloatingIP(id string) error {
+func (m *MockNetworkClient) DeleteFloatingIP(ctx context.Context, id string) error {
 	m.ctrl.T.Helper()
-	ret := m.ctrl.Call(m, "DeleteFloatingIP", id)
+	ret := m.ctrl.Call(m, "DeleteFloatingIP", ctx, id)
 	ret0, _ := ret[0].(error)
 	return ret0
 }
 
 // DeleteFloatingIP indicates an expected call of DeleteFloatingIP.
-func (mr *MockNetworkClientMockRecorder) DeleteFloatingIP(id any) *gomock.Call {
+func (mr *MockNetworkClientMockRecorder) DeleteFloatingIP(ctx, id any) *gomock.Call {
 	mr.mock.ctrl.T.Helper()
-	return mr.mock.ctrl.RecordCallWithMethodType(mr.mock, "DeleteFloatingIP", reflect.TypeOf((*MockNetworkClient)(nil).DeleteFloatingIP), id)
+	return mr.mock.ctrl.RecordCallWithMethodType(mr.mock, "DeleteFloatingIP", reflect.TypeOf((*MockNetworkClient)(nil).DeleteFloatingIP), ctx, id)
 }
 
 // DeleteNetwork mocks base method.
@@ -301,32 +301,32 @@ func (mr *MockNetworkClientMockRecorder) DeleteSubnet(ctx, id any) *gomock.Call 
 }
 
 // DeleteTrunk mocks base method.
-func (m *MockNetworkClient) DeleteTrunk(id string) error {
+func (m *MockNetworkClient) DeleteTrunk(ctx context.Context, id string) error {
 	m.ctrl.T.Helper()
-	ret := m.ctrl.Call(m, "DeleteTrunk", id)
+	ret := m.ctrl.Call(m, "DeleteTrunk", ctx, id)
 	ret0, _ := ret[0].(error)
 	return ret0
 }
 
 // DeleteTrunk indicates an expected call of DeleteTrunk.
-func (mr *MockNetworkClientMockRecorder) DeleteTrunk(id any) *gomock.Call {
+func (mr *MockNetworkClientMockRecorder) DeleteTrunk(ctx, id any) *gomock.Call {
 	mr.mock.ctrl.T.Helper()
-	return mr.mock.ctrl.RecordCallWithMethodType(mr.mock, "DeleteTrunk", reflect.TypeOf((*MockNetworkClient)(nil).DeleteTrunk), id)
+	return mr.mock.ctrl.RecordCallWithMethodType(mr.mock, "DeleteTrunk", reflect.TypeOf((*MockNetworkClient)(nil).DeleteTrunk), ctx, id)
 }
 
 // GetFloatingIP mocks base method.
-func (m *MockNetworkClient) GetFloatingIP(id string) (*floatingips.FloatingIP, error) {
+func (m *MockNetworkClient) GetFloatingIP(ctx context.Context, id string) (*floatingips.FloatingIP, error) {
 	m.ctrl.T.Helper()
-	ret := m.ctrl.Call(m, "GetFloatingIP", id)
+	ret := m.ctrl.Call(m, "GetFloatingIP", ctx, id)
 	ret0, _ := ret[0].(*floatingips.FloatingIP)
 	ret1, _ := ret[1].(error)
 	return ret0, ret1
 }
 
 // GetFloatingIP indicates an expected call of GetFloatingIP.
-func (mr *MockNetworkClientMockRecorder) GetFloatingIP(id any) *gomock.Call {
+func (mr *MockNetworkClientMockRecorder) GetFloatingIP(ctx, id any) *gomock.Call {
 	mr.mock.ctrl.T.Helper()
-	return mr.mock.ctrl.RecordCallWithMethodType(mr.mock, "GetFloatingIP", reflect.TypeOf((*MockNetworkClient)(nil).GetFloatingIP), id)
+	return mr.mock.ctrl.RecordCallWithMethodType(mr.mock, "GetFloatingIP", reflect.TypeOf((*MockNetworkClient)(nil).GetFloatingIP), ctx, id)
 }
 
 // GetNetwork mocks base method.
@@ -420,33 +420,33 @@ func (mr *MockNetworkClientMockRecorder) GetSubnet(ctx, id any) *gomock.Call {
 }
 
 // ListExtensions mocks base method.
-func (m *MockNetworkClient) ListExtensions() ([]extensions.Extension, error) {
+func (m *MockNetworkClient) ListExtensions(ctx context.Context) ([]extensions.Extension, error) {
 	m.ctrl.T.Helper()
-	ret := m.ctrl.Call(m, "ListExtensions")
+	ret := m.ctrl.Call(m, "ListExtensions", ctx)
 	ret0, _ := ret[0].([]extensions.Extension)
 	ret1, _ := ret[1].(error)
 	return ret0, ret1
 }
 
 // ListExtensions indicates an expected call of ListExtensions.
-func (mr *MockNetworkClientMockRecorder) ListExtensions() *gomock.Call {
+func (mr *MockNetworkClientMockRecorder) ListExtensions(ctx any) *gomock.Call {
 	mr.mock.ctrl.T.Helper()
-	return mr.mock.ctrl.RecordCallWithMethodType(mr.mock, "ListExtensions", reflect.TypeOf((*MockNetworkClient)(nil).ListExtensions))
+	return mr.mock.ctrl.RecordCallWithMethodType(mr.mock, "ListExtensions", reflect.TypeOf((*MockNetworkClient)(nil).ListExtensions), ctx)
 }
 
 // ListFloatingIP mocks base method.
-func (m *MockNetworkClient) ListFloatingIP(opts floatingips.ListOptsBuilder) ([]floatingips.FloatingIP, error) {
+func (m *MockNetworkClient) ListFloatingIP(ctx context.Context, opts floatingips.ListOptsBuilder) ([]floatingips.FloatingIP, error) {
 	m.ctrl.T.Helper()
-	ret := m.ctrl.Call(m, "ListFloatingIP", opts)
+	ret := m.ctrl.Call(m, "ListFloatingIP", ctx, opts)
 	ret0, _ := ret[0].([]floatingips.FloatingIP)
 	ret1, _ := ret[1].(error)
 	return ret0, ret1
 }
 
 // ListFloatingIP indicates an expected call of ListFloatingIP.
-func (mr *MockNetworkClientMockRecorder) ListFloatingIP(opts any) *gomock.Call {
+func (mr *MockNetworkClientMockRecorder) ListFloatingIP(ctx, opts any) *gomock.Call {
 	mr.mock.ctrl.T.Helper()
-	return mr.mock.ctrl.RecordCallWithMethodType(mr.mock, "ListFloatingIP", reflect.TypeOf((*MockNetworkClient)(nil).ListFloatingIP), opts)
+	return mr.mock.ctrl.RecordCallWithMethodType(mr.mock, "ListFloatingIP", reflect.TypeOf((*MockNetworkClient)(nil).ListFloatingIP), ctx, opts)
 }
 
 // ListNetwork mocks base method.
@@ -535,33 +535,33 @@ func (mr *MockNetworkClientMockRecorder) ListSubnet(ctx, opts any) *gomock.Call 
 }
 
 // ListTrunk mocks base method.
-func (m *MockNetworkClient) ListTrunk(opts trunks.ListOptsBuilder) ([]trunks.Trunk, error) {
+func (m *MockNetworkClient) ListTrunk(ctx context.Context, opts trunks.ListOptsBuilder) ([]trunks.Trunk, error) {
 	m.ctrl.T.Helper()
-	ret := m.ctrl.Call(m, "ListTrunk", opts)
+	ret := m.ctrl.Call(m, "ListTrunk", ctx, opts)
 	ret0, _ := ret[0].([]trunks.Trunk)
 	ret1, _ := ret[1].(error)
 	return ret0, ret1
 }
 
 // ListTrunk indicates an expected call of ListTrunk.
-func (mr *MockNetworkClientMockRecorder) ListTrunk(opts any) *gomock.Call {
+func (mr *MockNetworkClientMockRecorder) ListTrunk(ctx, opts any) *gomock.Call {
 	mr.mock.ctrl.T.Helper()
-	return mr.mock.ctrl.RecordCallWithMethodType(mr.mock, "ListTrunk", reflect.TypeOf((*MockNetworkClient)(nil).ListTrunk), opts)
+	return mr.mock.ctrl.RecordCallWithMethodType(mr.mock, "ListTrunk", reflect.TypeOf((*MockNetworkClient)(nil).ListTrunk), ctx, opts)
 }
 
 // ListTrunkSubports mocks base method.
-func (m *MockNetworkClient) ListTrunkSubports(trunkID string) ([]trunks.Subport, error) {
+func (m *MockNetworkClient) ListTrunkSubports(ctx context.Context, trunkID string) ([]trunks.Subport, error) {
 	m.ctrl.T.Helper()
-	ret := m.ctrl.Call(m, "ListTrunkSubports", trunkID)
+	ret := m.ctrl.Call(m, "ListTrunkSubports", ctx, trunkID)
 	ret0, _ := ret[0].([]trunks.Subport)
 	ret1, _ := ret[1].(error)
 	return ret0, ret1
 }
 
 // ListTrunkSubports indicates an expected call of ListTrunkSubports.
-func (mr *MockNetworkClientMockRecorder) ListTrunkSubports(trunkID any) *gomock.Call {
+func (mr *MockNetworkClientMockRecorder) ListTrunkSubports(ctx, trunkID any) *gomock.Call {
 	mr.mock.ctrl.T.Helper()
-	return mr.mock.ctrl.RecordCallWithMethodType(mr.mock, "ListTrunkSubports", reflect.TypeOf((*MockNetworkClient)(nil).ListTrunkSubports), trunkID)
+	return mr.mock.ctrl.RecordCallWithMethodType(mr.mock, "ListTrunkSubports", reflect.TypeOf((*MockNetworkClient)(nil).ListTrunkSubports), ctx, trunkID)
 }
 
 // RemoveRouterInterface mocks base method.
@@ -580,17 +580,17 @@ func (mr *MockNetworkClientMockRecorder) RemoveRouterInterface(ctx, id, opts any
 }
 
 // RemoveSubports mocks base method.
-func (m *MockNetworkClient) RemoveSubports(id string, opts trunks.RemoveSubportsOpts) error {
+func (m *MockNetworkClient) RemoveSubports(ctx context.Context, id string, opts trunks.RemoveSubportsOpts) error {
 	m.ctrl.T.Helper()
-	ret := m.ctrl.Call(m, "RemoveSubports", id, opts)
+	ret := m.ctrl.Call(m, "RemoveSubports", ctx, id, opts)
 	ret0, _ := ret[0].(error)
 	return ret0
 }
 
 // RemoveSubports indicates an expected call of RemoveSubports.
-func (mr *MockNetworkClientMockRecorder) RemoveSubports(id, opts any) *gomock.Call {
+func (mr *MockNetworkClientMockRecorder) RemoveSubports(ctx, id, opts any) *gomock.Call {
 	mr.mock.ctrl.T.Helper()
-	return mr.mock.ctrl.RecordCallWithMethodType(mr.mock, "RemoveSubports", reflect.TypeOf((*MockNetworkClient)(nil).RemoveSubports), id, opts)
+	return mr.mock.ctrl.RecordCallWithMethodType(mr.mock, "RemoveSubports", reflect.TypeOf((*MockNetworkClient)(nil).RemoveSubports), ctx, id, opts)
 }
 
 // ReplaceAllAttributesTags mocks base method.
@@ -609,18 +609,18 @@ func (mr *MockNetworkClientMockRecorder) ReplaceAllAttributesTags(ctx, resourceT
 }
 
 // UpdateFloatingIP mocks base method.
-func (m *MockNetworkClient) UpdateFloatingIP(id string, opts floatingips.UpdateOptsBuilder) (*floatingips.FloatingIP, error) {
+func (m *MockNetworkClient) UpdateFloatingIP(ctx context.Context, id string, opts floatingips.UpdateOptsBuilder) (*floatingips.FloatingIP, error) {
 	m.ctrl.T.Helper()
-	ret := m.ctrl.Call(m, "UpdateFloatingIP", id, opts)
+	ret := m.ctrl.Call(m, "UpdateFloatingIP", ctx, id, opts)
 	ret0, _ := ret[0].(*floatingips.FloatingIP)
 	ret1, _ := ret[1].(error)
 	return ret0, ret1
 }
 
 // UpdateFloatingIP indicates an expected call of UpdateFloatingIP.
-func (mr *MockNetworkClientMockRecorder) UpdateFloatingIP(id, opts any) *gomock.Call {
+func (mr *MockNetworkClientMockRecorder) UpdateFloatingIP(ctx, id, opts any) *gomock.Call {
 	mr.mock.ctrl.T.Helper()
-	return mr.mock.ctrl.RecordCallWithMethodType(mr.mock, "UpdateFloatingIP", reflect.TypeOf((*MockNetworkClient)(nil).UpdateFloatingIP), id, opts)
+	return mr.mock.ctrl.RecordCallWithMethodType(mr.mock, "UpdateFloatingIP", reflect.TypeOf((*MockNetworkClient)(nil).UpdateFloatingIP), ctx, id, opts)
 }
 
 // UpdateNetwork mocks base method.
@@ -639,18 +639,18 @@ func (mr *MockNetworkClientMockRecorder) UpdateNetwork(ctx, id, opts any) *gomoc
 }
 
 // UpdatePort mocks base method.
-func (m *MockNetworkClient) UpdatePort(id string, opts ports.UpdateOptsBuilder) (*ports.Port, error) {
+func (m *MockNetworkClient) UpdatePort(ctx context.Context, id string, opts ports.UpdateOptsBuilder) (*ports.Port, error) {
 	m.ctrl.T.Helper()
-	ret := m.ctrl.Call(m, "UpdatePort", id, opts)
+	ret := m.ctrl.Call(m, "UpdatePort", ctx, id, opts)
 	ret0, _ := ret[0].(*ports.Port)
 	ret1, _ := ret[1].(error)
 	return ret0, ret1
 }
 
 // UpdatePort indicates an expected call of UpdatePort.
-func (mr *MockNetworkClientMockRecorder) UpdatePort(id, opts any) *gomock.Call {
+func (mr *MockNetworkClientMockRecorder) UpdatePort(ctx, id, opts any) *gomock.Call {
 	mr.mock.ctrl.T.Helper()
-	return mr.mock.ctrl.RecordCallWithMethodType(mr.mock, "UpdatePort", reflect.TypeOf((*MockNetworkClient)(nil).UpdatePort), id, opts)
+	return mr.mock.ctrl.RecordCallWithMethodType(mr.mock, "UpdatePort", reflect.TypeOf((*MockNetworkClient)(nil).UpdatePort), ctx, id, opts)
 }
 
 // UpdateRouter mocks base method.

--- a/internal/osclients/mock/volume.go
+++ b/internal/osclients/mock/volume.go
@@ -25,6 +25,7 @@ limitations under the License.
 package mock
 
 import (
+	context "context"
 	reflect "reflect"
 
 	volumes "github.com/gophercloud/gophercloud/v2/openstack/blockstorage/v3/volumes"
@@ -56,60 +57,60 @@ func (m *MockVolumeClient) EXPECT() *MockVolumeClientMockRecorder {
 }
 
 // CreateVolume mocks base method.
-func (m *MockVolumeClient) CreateVolume(opts volumes.CreateOptsBuilder) (*volumes.Volume, error) {
+func (m *MockVolumeClient) CreateVolume(ctx context.Context, opts volumes.CreateOptsBuilder) (*volumes.Volume, error) {
 	m.ctrl.T.Helper()
-	ret := m.ctrl.Call(m, "CreateVolume", opts)
+	ret := m.ctrl.Call(m, "CreateVolume", ctx, opts)
 	ret0, _ := ret[0].(*volumes.Volume)
 	ret1, _ := ret[1].(error)
 	return ret0, ret1
 }
 
 // CreateVolume indicates an expected call of CreateVolume.
-func (mr *MockVolumeClientMockRecorder) CreateVolume(opts any) *gomock.Call {
+func (mr *MockVolumeClientMockRecorder) CreateVolume(ctx, opts any) *gomock.Call {
 	mr.mock.ctrl.T.Helper()
-	return mr.mock.ctrl.RecordCallWithMethodType(mr.mock, "CreateVolume", reflect.TypeOf((*MockVolumeClient)(nil).CreateVolume), opts)
+	return mr.mock.ctrl.RecordCallWithMethodType(mr.mock, "CreateVolume", reflect.TypeOf((*MockVolumeClient)(nil).CreateVolume), ctx, opts)
 }
 
 // DeleteVolume mocks base method.
-func (m *MockVolumeClient) DeleteVolume(volumeID string, opts volumes.DeleteOptsBuilder) error {
+func (m *MockVolumeClient) DeleteVolume(ctx context.Context, volumeID string, opts volumes.DeleteOptsBuilder) error {
 	m.ctrl.T.Helper()
-	ret := m.ctrl.Call(m, "DeleteVolume", volumeID, opts)
+	ret := m.ctrl.Call(m, "DeleteVolume", ctx, volumeID, opts)
 	ret0, _ := ret[0].(error)
 	return ret0
 }
 
 // DeleteVolume indicates an expected call of DeleteVolume.
-func (mr *MockVolumeClientMockRecorder) DeleteVolume(volumeID, opts any) *gomock.Call {
+func (mr *MockVolumeClientMockRecorder) DeleteVolume(ctx, volumeID, opts any) *gomock.Call {
 	mr.mock.ctrl.T.Helper()
-	return mr.mock.ctrl.RecordCallWithMethodType(mr.mock, "DeleteVolume", reflect.TypeOf((*MockVolumeClient)(nil).DeleteVolume), volumeID, opts)
+	return mr.mock.ctrl.RecordCallWithMethodType(mr.mock, "DeleteVolume", reflect.TypeOf((*MockVolumeClient)(nil).DeleteVolume), ctx, volumeID, opts)
 }
 
 // GetVolume mocks base method.
-func (m *MockVolumeClient) GetVolume(volumeID string) (*volumes.Volume, error) {
+func (m *MockVolumeClient) GetVolume(ctx context.Context, volumeID string) (*volumes.Volume, error) {
 	m.ctrl.T.Helper()
-	ret := m.ctrl.Call(m, "GetVolume", volumeID)
+	ret := m.ctrl.Call(m, "GetVolume", ctx, volumeID)
 	ret0, _ := ret[0].(*volumes.Volume)
 	ret1, _ := ret[1].(error)
 	return ret0, ret1
 }
 
 // GetVolume indicates an expected call of GetVolume.
-func (mr *MockVolumeClientMockRecorder) GetVolume(volumeID any) *gomock.Call {
+func (mr *MockVolumeClientMockRecorder) GetVolume(ctx, volumeID any) *gomock.Call {
 	mr.mock.ctrl.T.Helper()
-	return mr.mock.ctrl.RecordCallWithMethodType(mr.mock, "GetVolume", reflect.TypeOf((*MockVolumeClient)(nil).GetVolume), volumeID)
+	return mr.mock.ctrl.RecordCallWithMethodType(mr.mock, "GetVolume", reflect.TypeOf((*MockVolumeClient)(nil).GetVolume), ctx, volumeID)
 }
 
 // ListVolumes mocks base method.
-func (m *MockVolumeClient) ListVolumes(opts volumes.ListOptsBuilder) ([]volumes.Volume, error) {
+func (m *MockVolumeClient) ListVolumes(ctx context.Context, opts volumes.ListOptsBuilder) ([]volumes.Volume, error) {
 	m.ctrl.T.Helper()
-	ret := m.ctrl.Call(m, "ListVolumes", opts)
+	ret := m.ctrl.Call(m, "ListVolumes", ctx, opts)
 	ret0, _ := ret[0].([]volumes.Volume)
 	ret1, _ := ret[1].(error)
 	return ret0, ret1
 }
 
 // ListVolumes indicates an expected call of ListVolumes.
-func (mr *MockVolumeClientMockRecorder) ListVolumes(opts any) *gomock.Call {
+func (mr *MockVolumeClientMockRecorder) ListVolumes(ctx, opts any) *gomock.Call {
 	mr.mock.ctrl.T.Helper()
-	return mr.mock.ctrl.RecordCallWithMethodType(mr.mock, "ListVolumes", reflect.TypeOf((*MockVolumeClient)(nil).ListVolumes), opts)
+	return mr.mock.ctrl.RecordCallWithMethodType(mr.mock, "ListVolumes", reflect.TypeOf((*MockVolumeClient)(nil).ListVolumes), ctx, opts)
 }

--- a/internal/osclients/networking.go
+++ b/internal/osclients/networking.go
@@ -52,24 +52,24 @@ type NetworkExt struct {
 }
 
 type NetworkClient interface {
-	ListFloatingIP(opts floatingips.ListOptsBuilder) ([]floatingips.FloatingIP, error)
-	CreateFloatingIP(opts floatingips.CreateOptsBuilder) (*floatingips.FloatingIP, error)
-	DeleteFloatingIP(id string) error
-	GetFloatingIP(id string) (*floatingips.FloatingIP, error)
-	UpdateFloatingIP(id string, opts floatingips.UpdateOptsBuilder) (*floatingips.FloatingIP, error)
+	ListFloatingIP(ctx context.Context, opts floatingips.ListOptsBuilder) ([]floatingips.FloatingIP, error)
+	CreateFloatingIP(ctx context.Context, opts floatingips.CreateOptsBuilder) (*floatingips.FloatingIP, error)
+	DeleteFloatingIP(ctx context.Context, id string) error
+	GetFloatingIP(ctx context.Context, id string) (*floatingips.FloatingIP, error)
+	UpdateFloatingIP(ctx context.Context, id string, opts floatingips.UpdateOptsBuilder) (*floatingips.FloatingIP, error)
 
 	ListPort(ctx context.Context, opts ports.ListOptsBuilder) iter.Seq2[*ports.Port, error]
 	CreatePort(ctx context.Context, opts ports.CreateOptsBuilder) (*ports.Port, error)
 	DeletePort(ctx context.Context, id string) error
 	GetPort(ctx context.Context, id string) (*ports.Port, error)
-	UpdatePort(id string, opts ports.UpdateOptsBuilder) (*ports.Port, error)
+	UpdatePort(ctx context.Context, id string, opts ports.UpdateOptsBuilder) (*ports.Port, error)
 
-	ListTrunk(opts trunks.ListOptsBuilder) ([]trunks.Trunk, error)
-	CreateTrunk(opts trunks.CreateOptsBuilder) (*trunks.Trunk, error)
-	DeleteTrunk(id string) error
+	ListTrunk(ctx context.Context, opts trunks.ListOptsBuilder) ([]trunks.Trunk, error)
+	CreateTrunk(ctx context.Context, opts trunks.CreateOptsBuilder) (*trunks.Trunk, error)
+	DeleteTrunk(ctx context.Context, id string) error
 
-	ListTrunkSubports(trunkID string) ([]trunks.Subport, error)
-	RemoveSubports(id string, opts trunks.RemoveSubportsOpts) error
+	ListTrunkSubports(ctx context.Context, trunkID string) ([]trunks.Subport, error)
+	RemoveSubports(ctx context.Context, id string, opts trunks.RemoveSubportsOpts) error
 
 	ListRouter(ctx context.Context, opts routers.ListOpts) iter.Seq2[*routers.Router, error]
 	CreateRouter(ctx context.Context, opts routers.CreateOptsBuilder) (*routers.Router, error)
@@ -102,7 +102,7 @@ type NetworkClient interface {
 	GetSubnet(ctx context.Context, id string) (*subnets.Subnet, error)
 	UpdateSubnet(ctx context.Context, id string, opts subnets.UpdateOptsBuilder) (*subnets.Subnet, error)
 
-	ListExtensions() ([]extensions.Extension, error)
+	ListExtensions(ctx context.Context) ([]extensions.Extension, error)
 
 	ReplaceAllAttributesTags(ctx context.Context, resourceType string, resourceID string, opts attributestags.ReplaceAllOptsBuilder) ([]string, error)
 }
@@ -145,32 +145,32 @@ func (c networkClient) ListRouter(ctx context.Context, opts routers.ListOpts) it
 	}
 }
 
-func (c networkClient) ListFloatingIP(opts floatingips.ListOptsBuilder) ([]floatingips.FloatingIP, error) {
-	allPages, err := floatingips.List(c.serviceClient, opts).AllPages(context.TODO())
+func (c networkClient) ListFloatingIP(ctx context.Context, opts floatingips.ListOptsBuilder) ([]floatingips.FloatingIP, error) {
+	allPages, err := floatingips.List(c.serviceClient, opts).AllPages(ctx)
 	if err != nil {
 		return nil, err
 	}
 	return floatingips.ExtractFloatingIPs(allPages)
 }
 
-func (c networkClient) CreateFloatingIP(opts floatingips.CreateOptsBuilder) (*floatingips.FloatingIP, error) {
-	fip, err := floatingips.Create(context.TODO(), c.serviceClient, opts).Extract()
+func (c networkClient) CreateFloatingIP(ctx context.Context, opts floatingips.CreateOptsBuilder) (*floatingips.FloatingIP, error) {
+	fip, err := floatingips.Create(ctx, c.serviceClient, opts).Extract()
 	if err != nil {
 		return nil, err
 	}
 	return fip, nil
 }
 
-func (c networkClient) DeleteFloatingIP(id string) error {
-	return floatingips.Delete(context.TODO(), c.serviceClient, id).ExtractErr()
+func (c networkClient) DeleteFloatingIP(ctx context.Context, id string) error {
+	return floatingips.Delete(ctx, c.serviceClient, id).ExtractErr()
 }
 
-func (c networkClient) GetFloatingIP(id string) (*floatingips.FloatingIP, error) {
-	return floatingips.Get(context.TODO(), c.serviceClient, id).Extract()
+func (c networkClient) GetFloatingIP(ctx context.Context, id string) (*floatingips.FloatingIP, error) {
+	return floatingips.Get(ctx, c.serviceClient, id).Extract()
 }
 
-func (c networkClient) UpdateFloatingIP(id string, opts floatingips.UpdateOptsBuilder) (*floatingips.FloatingIP, error) {
-	return floatingips.Update(context.TODO(), c.serviceClient, id, opts).Extract()
+func (c networkClient) UpdateFloatingIP(ctx context.Context, id string, opts floatingips.UpdateOptsBuilder) (*floatingips.FloatingIP, error) {
+	return floatingips.Update(ctx, c.serviceClient, id, opts).Extract()
 }
 
 func (c networkClient) ListPort(ctx context.Context, opts ports.ListOptsBuilder) iter.Seq2[*ports.Port, error] {
@@ -192,29 +192,29 @@ func (c networkClient) GetPort(ctx context.Context, id string) (*ports.Port, err
 	return ports.Get(ctx, c.serviceClient, id).Extract()
 }
 
-func (c networkClient) UpdatePort(id string, opts ports.UpdateOptsBuilder) (*ports.Port, error) {
-	return ports.Update(context.TODO(), c.serviceClient, id, opts).Extract()
+func (c networkClient) UpdatePort(ctx context.Context, id string, opts ports.UpdateOptsBuilder) (*ports.Port, error) {
+	return ports.Update(ctx, c.serviceClient, id, opts).Extract()
 }
 
-func (c networkClient) CreateTrunk(opts trunks.CreateOptsBuilder) (*trunks.Trunk, error) {
-	return trunks.Create(context.TODO(), c.serviceClient, opts).Extract()
+func (c networkClient) CreateTrunk(ctx context.Context, opts trunks.CreateOptsBuilder) (*trunks.Trunk, error) {
+	return trunks.Create(ctx, c.serviceClient, opts).Extract()
 }
 
-func (c networkClient) DeleteTrunk(id string) error {
-	return trunks.Delete(context.TODO(), c.serviceClient, id).ExtractErr()
+func (c networkClient) DeleteTrunk(ctx context.Context, id string) error {
+	return trunks.Delete(ctx, c.serviceClient, id).ExtractErr()
 }
 
-func (c networkClient) ListTrunkSubports(trunkID string) ([]trunks.Subport, error) {
-	return trunks.GetSubports(context.TODO(), c.serviceClient, trunkID).Extract()
+func (c networkClient) ListTrunkSubports(ctx context.Context, trunkID string) ([]trunks.Subport, error) {
+	return trunks.GetSubports(ctx, c.serviceClient, trunkID).Extract()
 }
 
-func (c networkClient) RemoveSubports(id string, opts trunks.RemoveSubportsOpts) error {
-	_, err := trunks.RemoveSubports(context.TODO(), c.serviceClient, id, opts).Extract()
+func (c networkClient) RemoveSubports(ctx context.Context, id string, opts trunks.RemoveSubportsOpts) error {
+	_, err := trunks.RemoveSubports(ctx, c.serviceClient, id, opts).Extract()
 	return err
 }
 
-func (c networkClient) ListTrunk(opts trunks.ListOptsBuilder) ([]trunks.Trunk, error) {
-	allPages, err := trunks.List(c.serviceClient, opts).AllPages(context.TODO())
+func (c networkClient) ListTrunk(ctx context.Context, opts trunks.ListOptsBuilder) ([]trunks.Trunk, error) {
+	allPages, err := trunks.List(c.serviceClient, opts).AllPages(ctx)
 	if err != nil {
 		return nil, err
 	}
@@ -234,7 +234,7 @@ func (c networkClient) GetRouter(ctx context.Context, id string) (*routers.Route
 }
 
 func (c networkClient) UpdateRouter(ctx context.Context, id string, opts routers.UpdateOptsBuilder) (*routers.Router, error) {
-	return routers.Update(context.TODO(), c.serviceClient, id, opts).Extract()
+	return routers.Update(ctx, c.serviceClient, id, opts).Extract()
 }
 
 func (c networkClient) ListSecGroup(ctx context.Context, opts groups.ListOpts) iter.Seq2[*groups.SecGroup, error] {
@@ -347,8 +347,8 @@ func (c networkClient) UpdateSubnet(ctx context.Context, id string, opts subnets
 	return subnets.Update(ctx, c.serviceClient, id, opts).Extract()
 }
 
-func (c networkClient) ListExtensions() ([]extensions.Extension, error) {
-	allPages, err := extensions.List(c.serviceClient).AllPages(context.TODO())
+func (c networkClient) ListExtensions(ctx context.Context) ([]extensions.Extension, error) {
+	allPages, err := extensions.List(c.serviceClient).AllPages(ctx)
 	if err != nil {
 		return nil, err
 	}

--- a/internal/osclients/volume.go
+++ b/internal/osclients/volume.go
@@ -27,10 +27,10 @@ import (
 )
 
 type VolumeClient interface {
-	ListVolumes(opts volumes.ListOptsBuilder) ([]volumes.Volume, error)
-	CreateVolume(opts volumes.CreateOptsBuilder) (*volumes.Volume, error)
-	DeleteVolume(volumeID string, opts volumes.DeleteOptsBuilder) error
-	GetVolume(volumeID string) (*volumes.Volume, error)
+	ListVolumes(ctx context.Context, opts volumes.ListOptsBuilder) ([]volumes.Volume, error)
+	CreateVolume(ctx context.Context, opts volumes.CreateOptsBuilder) (*volumes.Volume, error)
+	DeleteVolume(ctx context.Context, volumeID string, opts volumes.DeleteOptsBuilder) error
+	GetVolume(ctx context.Context, volumeID string) (*volumes.Volume, error)
 }
 
 type volumeClient struct{ client *gophercloud.ServiceClient }
@@ -48,24 +48,24 @@ func NewVolumeClient(providerClient *gophercloud.ProviderClient, providerClientO
 	return &volumeClient{volume}, nil
 }
 
-func (c volumeClient) ListVolumes(opts volumes.ListOptsBuilder) ([]volumes.Volume, error) {
-	pages, err := volumes.List(c.client, opts).AllPages(context.TODO())
+func (c volumeClient) ListVolumes(ctx context.Context, opts volumes.ListOptsBuilder) ([]volumes.Volume, error) {
+	pages, err := volumes.List(c.client, opts).AllPages(ctx)
 	if err != nil {
 		return nil, err
 	}
 	return volumes.ExtractVolumes(pages)
 }
 
-func (c volumeClient) CreateVolume(opts volumes.CreateOptsBuilder) (*volumes.Volume, error) {
-	return volumes.Create(context.TODO(), c.client, opts, nil).Extract()
+func (c volumeClient) CreateVolume(ctx context.Context, opts volumes.CreateOptsBuilder) (*volumes.Volume, error) {
+	return volumes.Create(ctx, c.client, opts, nil).Extract()
 }
 
-func (c volumeClient) DeleteVolume(volumeID string, opts volumes.DeleteOptsBuilder) error {
-	return volumes.Delete(context.TODO(), c.client, volumeID, opts).ExtractErr()
+func (c volumeClient) DeleteVolume(ctx context.Context, volumeID string, opts volumes.DeleteOptsBuilder) error {
+	return volumes.Delete(ctx, c.client, volumeID, opts).ExtractErr()
 }
 
-func (c volumeClient) GetVolume(volumeID string) (*volumes.Volume, error) {
-	return volumes.Get(context.TODO(), c.client, volumeID).Extract()
+func (c volumeClient) GetVolume(ctx context.Context, volumeID string) (*volumes.Volume, error) {
+	return volumes.Get(ctx, c.client, volumeID).Extract()
 }
 
 type volumeErrorClient struct{ error }
@@ -75,18 +75,18 @@ func NewVolumeErrorClient(e error) VolumeClient {
 	return volumeErrorClient{e}
 }
 
-func (e volumeErrorClient) ListVolumes(_ volumes.ListOptsBuilder) ([]volumes.Volume, error) {
+func (e volumeErrorClient) ListVolumes(_ context.Context, _ volumes.ListOptsBuilder) ([]volumes.Volume, error) {
 	return nil, e.error
 }
 
-func (e volumeErrorClient) CreateVolume(_ volumes.CreateOptsBuilder) (*volumes.Volume, error) {
+func (e volumeErrorClient) CreateVolume(_ context.Context, _ volumes.CreateOptsBuilder) (*volumes.Volume, error) {
 	return nil, e.error
 }
 
-func (e volumeErrorClient) DeleteVolume(_ string, _ volumes.DeleteOptsBuilder) error {
+func (e volumeErrorClient) DeleteVolume(_ context.Context, _ string, _ volumes.DeleteOptsBuilder) error {
 	return e.error
 }
 
-func (e volumeErrorClient) GetVolume(_ string) (*volumes.Volume, error) {
+func (e volumeErrorClient) GetVolume(_ context.Context, _ string) (*volumes.Volume, error) {
 	return nil, e.error
 }

--- a/internal/scope/client.go
+++ b/internal/scope/client.go
@@ -1,0 +1,25 @@
+package scope
+
+import (
+	"net/http"
+
+	"sigs.k8s.io/controller-runtime/pkg/controller"
+)
+
+// RoundTripper satisfies the http.RoundTripper interface and is used to
+// customize the default http client RoundTripper
+type RoundTripper struct {
+	// Default http.RoundTripper
+	http.RoundTripper
+}
+
+// RoundTrip performs a round-trip HTTP request, injecting the OpenStack
+// Request ID header when appropriate
+func (rt *RoundTripper) RoundTrip(request *http.Request) (*http.Response, error) {
+	reconcileID := controller.ReconcileIDFromContext(request.Context())
+	if reconcileID != "" {
+		request.Header.Set("X-OpenStack-Request-ID", "req-"+string(reconcileID))
+	}
+
+	return rt.RoundTripper.RoundTrip(request)
+}

--- a/internal/scope/provider.go
+++ b/internal/scope/provider.go
@@ -215,7 +215,9 @@ func NewProviderClient(cloud clientconfig.Cloud, caCert []byte, logger logr.Logg
 		}
 	}
 
-	provider.HTTPClient.Transport = &http.Transport{Proxy: http.ProxyFromEnvironment, TLSClientConfig: config}
+	provider.HTTPClient.Transport = &RoundTripper{
+		RoundTripper: &http.Transport{Proxy: http.ProxyFromEnvironment, TLSClientConfig: config},
+	}
 	if klog.V(6).Enabled() {
 		provider.HTTPClient.Transport = &osclient.RoundTripper{
 			Rt:     provider.HTTPClient.Transport,


### PR DESCRIPTION
Use a client capable of sending the reconcile ID as the request ID for
all OpenStack API calls. This makes it possible to correlate ORC and
OpenStack logs.

For https://github.com/k-orc/openstack-resource-controller/issues/218.