### PR TITLE
Use consistent credentials in subnet gateway test

### DIFF
--- a/internal/controllers/subnet/tests/subnet-create-full-v4/00-subnet.yaml
+++ b/internal/controllers/subnet/tests/subnet-create-full-v4/00-subnet.yaml
@@ -28,7 +28,7 @@ metadata:
   name: subnet-create-full-v4-gateway
 spec:
   cloudCredentialsRef:
-    cloudName: openstack
+    cloudName: openstack-admin
     secretName: openstack-clouds
   managementPolicy: managed
   resource:


### PR DESCRIPTION
Creating a network as admin and subnet as tenant fails in many
deployments. Create both as admin.
