### PR TITLE
Change return of getResourceName to string

### DIFF
--- a/cmd/resource-generator/data/adapter.template
+++ b/cmd/resource-generator/data/adapter.template
@@ -79,9 +79,9 @@ func (f adapterT) GetImportFilter() *filterT {
 // getResourceName returns the name of the OpenStack resource we should use.
 // This method is not implemented as part of APIObjectAdapter as it is intended
 // to be used by resource actuators, which don't use the adapter.
-func getResourceName(orcObject orcObjectPT) orcv1alpha1.OpenStackName {
+func getResourceName(orcObject orcObjectPT) string {
 	if orcObject.Spec.Resource.Name != nil {
-		return *orcObject.Spec.Resource.Name
+		return string(*orcObject.Spec.Resource.Name)
 	}
-	return orcv1alpha1.OpenStackName(orcObject.Name)
+	return orcObject.Name
 }

--- a/internal/controllers/flavor/actuator.go
+++ b/internal/controllers/flavor/actuator.go
@@ -80,7 +80,7 @@ func (actuator flavorActuator) ListOSResourcesForAdoption(ctx context.Context, o
 		func(f *flavors.Flavor) bool {
 			name := getResourceName(orcObject)
 			// Compare non-pointer values
-			return f.Name == string(name) &&
+			return f.Name == name &&
 				f.RAM == int(resourceSpec.RAM) &&
 				f.VCPUs == int(resourceSpec.Vcpus) &&
 				f.Disk == int(resourceSpec.Disk) &&
@@ -144,7 +144,7 @@ func (actuator flavorActuator) CreateResource(ctx context.Context, obj orcObject
 	}
 
 	createOpts := flavors.CreateOpts{
-		Name:        string(getResourceName(obj)),
+		Name:        getResourceName(obj),
 		RAM:         int(resource.RAM),
 		VCPUs:       int(resource.Vcpus),
 		Disk:        ptr.To(int(resource.Disk)),

--- a/internal/controllers/flavor/zz_generated.adapter.go
+++ b/internal/controllers/flavor/zz_generated.adapter.go
@@ -80,9 +80,9 @@ func (f adapterT) GetImportFilter() *filterT {
 // getResourceName returns the name of the OpenStack resource we should use.
 // This method is not implemented as part of APIObjectAdapter as it is intended
 // to be used by resource actuators, which don't use the adapter.
-func getResourceName(orcObject orcObjectPT) orcv1alpha1.OpenStackName {
+func getResourceName(orcObject orcObjectPT) string {
 	if orcObject.Spec.Resource.Name != nil {
-		return *orcObject.Spec.Resource.Name
+		return string(*orcObject.Spec.Resource.Name)
 	}
-	return orcv1alpha1.OpenStackName(orcObject.Name)
+	return orcObject.Name
 }

--- a/internal/controllers/image/actuator.go
+++ b/internal/controllers/image/actuator.go
@@ -75,7 +75,7 @@ func (actuator imageActuator) ListOSResourcesForAdoption(ctx context.Context, ob
 	}
 
 	listOpts := images.ListOpts{
-		Name: string(getResourceName(obj)),
+		Name: getResourceName(obj),
 	}
 
 	if len(obj.Spec.Resource.Tags) > 0 {
@@ -145,7 +145,7 @@ func (actuator imageActuator) CreateResource(ctx context.Context, obj *orcv1alph
 	}
 
 	image, err := actuator.osClient.CreateImage(ctx, &images.CreateOpts{
-		Name:            string(getResourceName(obj)),
+		Name:            getResourceName(obj),
 		Visibility:      visibility,
 		Tags:            tags,
 		ContainerFormat: string(resource.Content.ContainerFormat),

--- a/internal/controllers/image/zz_generated.adapter.go
+++ b/internal/controllers/image/zz_generated.adapter.go
@@ -80,9 +80,9 @@ func (f adapterT) GetImportFilter() *filterT {
 // getResourceName returns the name of the OpenStack resource we should use.
 // This method is not implemented as part of APIObjectAdapter as it is intended
 // to be used by resource actuators, which don't use the adapter.
-func getResourceName(orcObject orcObjectPT) orcv1alpha1.OpenStackName {
+func getResourceName(orcObject orcObjectPT) string {
 	if orcObject.Spec.Resource.Name != nil {
-		return *orcObject.Spec.Resource.Name
+		return string(*orcObject.Spec.Resource.Name)
 	}
-	return orcv1alpha1.OpenStackName(orcObject.Name)
+	return orcObject.Name
 }

--- a/internal/controllers/network/actuator.go
+++ b/internal/controllers/network/actuator.go
@@ -72,7 +72,7 @@ func (actuator networkActuator) ListOSResourcesForAdoption(ctx context.Context, 
 		return nil, false
 	}
 
-	listOpts := networks.ListOpts{Name: string(getResourceName(obj))}
+	listOpts := networks.ListOpts{Name: getResourceName(obj)}
 	return actuator.osClient.ListNetwork(ctx, listOpts), true
 }
 
@@ -99,7 +99,7 @@ func (actuator networkActuator) CreateResource(ctx context.Context, obj orcObjec
 	var createOpts networks.CreateOptsBuilder
 	{
 		createOptsBase := networks.CreateOpts{
-			Name:         string(getResourceName(obj)),
+			Name:         getResourceName(obj),
 			Description:  string(ptr.Deref(resource.Description, "")),
 			AdminStateUp: resource.AdminStateUp,
 			Shared:       resource.Shared,

--- a/internal/controllers/network/zz_generated.adapter.go
+++ b/internal/controllers/network/zz_generated.adapter.go
@@ -80,9 +80,9 @@ func (f adapterT) GetImportFilter() *filterT {
 // getResourceName returns the name of the OpenStack resource we should use.
 // This method is not implemented as part of APIObjectAdapter as it is intended
 // to be used by resource actuators, which don't use the adapter.
-func getResourceName(orcObject orcObjectPT) orcv1alpha1.OpenStackName {
+func getResourceName(orcObject orcObjectPT) string {
 	if orcObject.Spec.Resource.Name != nil {
-		return *orcObject.Spec.Resource.Name
+		return string(*orcObject.Spec.Resource.Name)
 	}
-	return orcv1alpha1.OpenStackName(orcObject.Name)
+	return orcObject.Name
 }

--- a/internal/controllers/port/actuator.go
+++ b/internal/controllers/port/actuator.go
@@ -74,7 +74,7 @@ func (actuator portActuator) ListOSResourcesForAdoption(ctx context.Context, obj
 		return nil, false
 	}
 
-	listOpts := ports.ListOpts{Name: string(getResourceName(obj))}
+	listOpts := ports.ListOpts{Name: getResourceName(obj)}
 	return actuator.osClient.ListPort(ctx, listOpts), true
 }
 
@@ -146,7 +146,7 @@ func (actuator portActuator) CreateResource(ctx context.Context, obj *orcv1alpha
 
 	createOpts := ports.CreateOpts{
 		NetworkID:   *network.Status.ID,
-		Name:        string(getResourceName(obj)),
+		Name:        getResourceName(obj),
 		Description: string(ptr.Deref(resource.Description, "")),
 	}
 

--- a/internal/controllers/port/zz_generated.adapter.go
+++ b/internal/controllers/port/zz_generated.adapter.go
@@ -80,9 +80,9 @@ func (f adapterT) GetImportFilter() *filterT {
 // getResourceName returns the name of the OpenStack resource we should use.
 // This method is not implemented as part of APIObjectAdapter as it is intended
 // to be used by resource actuators, which don't use the adapter.
-func getResourceName(orcObject orcObjectPT) orcv1alpha1.OpenStackName {
+func getResourceName(orcObject orcObjectPT) string {
 	if orcObject.Spec.Resource.Name != nil {
-		return *orcObject.Spec.Resource.Name
+		return string(*orcObject.Spec.Resource.Name)
 	}
-	return orcv1alpha1.OpenStackName(orcObject.Name)
+	return orcObject.Name
 }

--- a/internal/controllers/router/actuator.go
+++ b/internal/controllers/router/actuator.go
@@ -74,7 +74,7 @@ func (actuator routerActuator) ListOSResourcesForAdoption(ctx context.Context, o
 		return nil, false
 	}
 
-	listOpts := routers.ListOpts{Name: string(getResourceName(obj))}
+	listOpts := routers.ListOpts{Name: getResourceName(obj)}
 	return actuator.osClient.ListRouter(ctx, listOpts), true
 }
 
@@ -114,7 +114,7 @@ func (actuator routerCreateActuator) CreateResource(ctx context.Context, obj *or
 	}
 
 	createOpts := routers.CreateOpts{
-		Name:         string(getResourceName(obj)),
+		Name:         getResourceName(obj),
 		Description:  string(ptr.Deref(resource.Description, "")),
 		AdminStateUp: resource.AdminStateUp,
 		Distributed:  resource.Distributed,

--- a/internal/controllers/router/zz_generated.adapter.go
+++ b/internal/controllers/router/zz_generated.adapter.go
@@ -80,9 +80,9 @@ func (f adapterT) GetImportFilter() *filterT {
 // getResourceName returns the name of the OpenStack resource we should use.
 // This method is not implemented as part of APIObjectAdapter as it is intended
 // to be used by resource actuators, which don't use the adapter.
-func getResourceName(orcObject orcObjectPT) orcv1alpha1.OpenStackName {
+func getResourceName(orcObject orcObjectPT) string {
 	if orcObject.Spec.Resource.Name != nil {
-		return *orcObject.Spec.Resource.Name
+		return string(*orcObject.Spec.Resource.Name)
 	}
-	return orcv1alpha1.OpenStackName(orcObject.Name)
+	return orcObject.Name
 }

--- a/internal/controllers/securitygroup/actuator.go
+++ b/internal/controllers/securitygroup/actuator.go
@@ -71,7 +71,7 @@ func (actuator securityGroupActuator) ListOSResourcesForAdoption(ctx context.Con
 		return nil, false
 	}
 
-	listOpts := groups.ListOpts{Name: string(getResourceName(obj))}
+	listOpts := groups.ListOpts{Name: getResourceName(obj)}
 	return actuator.osClient.ListSecGroup(ctx, listOpts), true
 }
 
@@ -97,7 +97,7 @@ func (actuator securityGroupActuator) CreateResource(ctx context.Context, obj *o
 	}
 
 	createOpts := groups.CreateOpts{
-		Name:        string(getResourceName(obj)),
+		Name:        getResourceName(obj),
 		Description: string(ptr.Deref(resource.Description, "")),
 		Stateful:    resource.Stateful,
 	}

--- a/internal/controllers/securitygroup/zz_generated.adapter.go
+++ b/internal/controllers/securitygroup/zz_generated.adapter.go
@@ -80,9 +80,9 @@ func (f adapterT) GetImportFilter() *filterT {
 // getResourceName returns the name of the OpenStack resource we should use.
 // This method is not implemented as part of APIObjectAdapter as it is intended
 // to be used by resource actuators, which don't use the adapter.
-func getResourceName(orcObject orcObjectPT) orcv1alpha1.OpenStackName {
+func getResourceName(orcObject orcObjectPT) string {
 	if orcObject.Spec.Resource.Name != nil {
-		return *orcObject.Spec.Resource.Name
+		return string(*orcObject.Spec.Resource.Name)
 	}
-	return orcv1alpha1.OpenStackName(orcObject.Name)
+	return orcObject.Name
 }

--- a/internal/controllers/server/actuator.go
+++ b/internal/controllers/server/actuator.go
@@ -80,7 +80,7 @@ func (actuator serverActuator) ListOSResourcesForAdoption(ctx context.Context, o
 	}
 
 	listOpts := servers.ListOpts{
-		Name: fmt.Sprintf("^%s$", string(getResourceName(obj))),
+		Name: fmt.Sprintf("^%s$", getResourceName(obj)),
 		Tags: neutrontags.Join(obj.Spec.Resource.Tags),
 	}
 
@@ -196,7 +196,7 @@ func (actuator serverActuator) CreateResource(ctx context.Context, obj *orcv1alp
 	slices.Sort(tags)
 
 	createOpts := servers.CreateOpts{
-		Name:      string(getResourceName(obj)),
+		Name:      getResourceName(obj),
 		ImageRef:  *image.Status.ID,
 		FlavorRef: *flavor.Status.ID,
 		Networks:  portList,

--- a/internal/controllers/server/zz_generated.adapter.go
+++ b/internal/controllers/server/zz_generated.adapter.go
@@ -80,9 +80,9 @@ func (f adapterT) GetImportFilter() *filterT {
 // getResourceName returns the name of the OpenStack resource we should use.
 // This method is not implemented as part of APIObjectAdapter as it is intended
 // to be used by resource actuators, which don't use the adapter.
-func getResourceName(orcObject orcObjectPT) orcv1alpha1.OpenStackName {
+func getResourceName(orcObject orcObjectPT) string {
 	if orcObject.Spec.Resource.Name != nil {
-		return *orcObject.Spec.Resource.Name
+		return string(*orcObject.Spec.Resource.Name)
 	}
-	return orcv1alpha1.OpenStackName(orcObject.Name)
+	return orcObject.Name
 }

--- a/internal/controllers/subnet/actuator.go
+++ b/internal/controllers/subnet/actuator.go
@@ -77,7 +77,7 @@ func (actuator subnetActuator) ListOSResourcesForAdoption(ctx context.Context, o
 	if obj.Spec.Resource == nil {
 		return nil, false
 	}
-	listOpts := subnets.ListOpts{Name: string(getResourceName(obj))}
+	listOpts := subnets.ListOpts{Name: getResourceName(obj)}
 	return actuator.osClient.ListSubnet(ctx, listOpts), true
 }
 
@@ -143,7 +143,7 @@ func (actuator subnetActuator) CreateResource(ctx context.Context, obj orcObject
 	createOpts := subnets.CreateOpts{
 		NetworkID:         *network.Status.ID,
 		CIDR:              string(resource.CIDR),
-		Name:              string(getResourceName(obj)),
+		Name:              getResourceName(obj),
 		Description:       string(ptr.Deref(resource.Description, "")),
 		IPVersion:         gophercloud.IPVersion(resource.IPVersion),
 		EnableDHCP:        resource.EnableDHCP,

--- a/internal/controllers/subnet/zz_generated.adapter.go
+++ b/internal/controllers/subnet/zz_generated.adapter.go
@@ -80,9 +80,9 @@ func (f adapterT) GetImportFilter() *filterT {
 // getResourceName returns the name of the OpenStack resource we should use.
 // This method is not implemented as part of APIObjectAdapter as it is intended
 // to be used by resource actuators, which don't use the adapter.
-func getResourceName(orcObject orcObjectPT) orcv1alpha1.OpenStackName {
+func getResourceName(orcObject orcObjectPT) string {
 	if orcObject.Spec.Resource.Name != nil {
-		return *orcObject.Spec.Resource.Name
+		return string(*orcObject.Spec.Resource.Name)
 	}
-	return orcv1alpha1.OpenStackName(orcObject.Name)
+	return orcObject.Name
 }


### PR DESCRIPTION
This created inflexibility for any API with different name constraints
to those specified on OpenStackName.

Additionally, every caller of it was already casting the result to
string.
