### PR TITLE
Format Go code

### DIFF
--- a/.github/workflows/go-lint.yaml
+++ b/.github/workflows/go-lint.yaml
@@ -20,3 +20,4 @@ jobs:
 
       - run: |
           make lint 
+          make verify-fmt

--- a/Makefile
+++ b/Makefile
@@ -86,6 +86,16 @@ verify-generated: generate
 fmt: ## Run go fmt against code.
 	go fmt ./...
 
+.PHONY: verify-fmt
+verify-fmt: SRC := $(shell find . -path './.git' -prune -o -type f -name '*.go' -print)
+verify-fmt: ## Errors if the code is not go-fmt'd.
+	@UNFORMATTED="$$(gofmt -s -l $(SRC))"; \
+	if [ -n "$$UNFORMATTED" ]; then \
+		echo "Run go fmt ./... to fix these files:"; \
+		echo "$$UNFORMATTED"; \
+		exit 1; \
+	fi
+
 .PHONY: vet
 vet: ## Run go vet against code.
 	go vet ./...

--- a/api/v1alpha1/zz_generated.flavor-resource.go
+++ b/api/v1alpha1/zz_generated.flavor-resource.go
@@ -128,7 +128,7 @@ func (i *Flavor) GetConditions() []metav1.Condition {
 
 // Flavor is the Schema for an ORC resource.
 type Flavor struct {
-	metav1.TypeMeta   `json:",inline"`
+	metav1.TypeMeta `json:",inline"`
 
 	// metadata contains the object metadata
 	// +optional
@@ -136,7 +136,7 @@ type Flavor struct {
 
 	// spec specifies the desired state of the resource.
 	// +optional
-	Spec   FlavorSpec   `json:"spec,omitempty"`
+	Spec FlavorSpec `json:"spec,omitempty"`
 
 	// status defines the observed state of the resource.
 	// +optional
@@ -155,7 +155,7 @@ type FlavorList struct {
 
 	// items contains a list of Flavor.
 	// +required
-	Items           []Flavor `json:"items"`
+	Items []Flavor `json:"items"`
 }
 
 func (l *FlavorList) GetItems() []Flavor {

--- a/api/v1alpha1/zz_generated.image-resource.go
+++ b/api/v1alpha1/zz_generated.image-resource.go
@@ -131,7 +131,7 @@ func (i *Image) GetConditions() []metav1.Condition {
 
 // Image is the Schema for an ORC resource.
 type Image struct {
-	metav1.TypeMeta   `json:",inline"`
+	metav1.TypeMeta `json:",inline"`
 
 	// metadata contains the object metadata
 	// +optional
@@ -139,7 +139,7 @@ type Image struct {
 
 	// spec specifies the desired state of the resource.
 	// +optional
-	Spec   ImageSpec   `json:"spec,omitempty"`
+	Spec ImageSpec `json:"spec,omitempty"`
 
 	// status defines the observed state of the resource.
 	// +optional
@@ -158,7 +158,7 @@ type ImageList struct {
 
 	// items contains a list of Image.
 	// +required
-	Items           []Image `json:"items"`
+	Items []Image `json:"items"`
 }
 
 func (l *ImageList) GetItems() []Image {

--- a/api/v1alpha1/zz_generated.network-resource.go
+++ b/api/v1alpha1/zz_generated.network-resource.go
@@ -128,7 +128,7 @@ func (i *Network) GetConditions() []metav1.Condition {
 
 // Network is the Schema for an ORC resource.
 type Network struct {
-	metav1.TypeMeta   `json:",inline"`
+	metav1.TypeMeta `json:",inline"`
 
 	// metadata contains the object metadata
 	// +optional
@@ -136,7 +136,7 @@ type Network struct {
 
 	// spec specifies the desired state of the resource.
 	// +optional
-	Spec   NetworkSpec   `json:"spec,omitempty"`
+	Spec NetworkSpec `json:"spec,omitempty"`
 
 	// status defines the observed state of the resource.
 	// +optional
@@ -155,7 +155,7 @@ type NetworkList struct {
 
 	// items contains a list of Network.
 	// +required
-	Items           []Network `json:"items"`
+	Items []Network `json:"items"`
 }
 
 func (l *NetworkList) GetItems() []Network {

--- a/api/v1alpha1/zz_generated.port-resource.go
+++ b/api/v1alpha1/zz_generated.port-resource.go
@@ -129,7 +129,7 @@ func (i *Port) GetConditions() []metav1.Condition {
 
 // Port is the Schema for an ORC resource.
 type Port struct {
-	metav1.TypeMeta   `json:",inline"`
+	metav1.TypeMeta `json:",inline"`
 
 	// metadata contains the object metadata
 	// +optional
@@ -137,7 +137,7 @@ type Port struct {
 
 	// spec specifies the desired state of the resource.
 	// +optional
-	Spec   PortSpec   `json:"spec,omitempty"`
+	Spec PortSpec `json:"spec,omitempty"`
 
 	// status defines the observed state of the resource.
 	// +optional
@@ -156,7 +156,7 @@ type PortList struct {
 
 	// items contains a list of Port.
 	// +required
-	Items           []Port `json:"items"`
+	Items []Port `json:"items"`
 }
 
 func (l *PortList) GetItems() []Port {

--- a/api/v1alpha1/zz_generated.router-resource.go
+++ b/api/v1alpha1/zz_generated.router-resource.go
@@ -128,7 +128,7 @@ func (i *Router) GetConditions() []metav1.Condition {
 
 // Router is the Schema for an ORC resource.
 type Router struct {
-	metav1.TypeMeta   `json:",inline"`
+	metav1.TypeMeta `json:",inline"`
 
 	// metadata contains the object metadata
 	// +optional
@@ -136,7 +136,7 @@ type Router struct {
 
 	// spec specifies the desired state of the resource.
 	// +optional
-	Spec   RouterSpec   `json:"spec,omitempty"`
+	Spec RouterSpec `json:"spec,omitempty"`
 
 	// status defines the observed state of the resource.
 	// +optional
@@ -155,7 +155,7 @@ type RouterList struct {
 
 	// items contains a list of Router.
 	// +required
-	Items           []Router `json:"items"`
+	Items []Router `json:"items"`
 }
 
 func (l *RouterList) GetItems() []Router {

--- a/api/v1alpha1/zz_generated.securitygroup-resource.go
+++ b/api/v1alpha1/zz_generated.securitygroup-resource.go
@@ -128,7 +128,7 @@ func (i *SecurityGroup) GetConditions() []metav1.Condition {
 
 // SecurityGroup is the Schema for an ORC resource.
 type SecurityGroup struct {
-	metav1.TypeMeta   `json:",inline"`
+	metav1.TypeMeta `json:",inline"`
 
 	// metadata contains the object metadata
 	// +optional
@@ -136,7 +136,7 @@ type SecurityGroup struct {
 
 	// spec specifies the desired state of the resource.
 	// +optional
-	Spec   SecurityGroupSpec   `json:"spec,omitempty"`
+	Spec SecurityGroupSpec `json:"spec,omitempty"`
 
 	// status defines the observed state of the resource.
 	// +optional
@@ -155,7 +155,7 @@ type SecurityGroupList struct {
 
 	// items contains a list of SecurityGroup.
 	// +required
-	Items           []SecurityGroup `json:"items"`
+	Items []SecurityGroup `json:"items"`
 }
 
 func (l *SecurityGroupList) GetItems() []SecurityGroup {

--- a/api/v1alpha1/zz_generated.server-resource.go
+++ b/api/v1alpha1/zz_generated.server-resource.go
@@ -128,7 +128,7 @@ func (i *Server) GetConditions() []metav1.Condition {
 
 // Server is the Schema for an ORC resource.
 type Server struct {
-	metav1.TypeMeta   `json:",inline"`
+	metav1.TypeMeta `json:",inline"`
 
 	// metadata contains the object metadata
 	// +optional
@@ -136,7 +136,7 @@ type Server struct {
 
 	// spec specifies the desired state of the resource.
 	// +optional
-	Spec   ServerSpec   `json:"spec,omitempty"`
+	Spec ServerSpec `json:"spec,omitempty"`
 
 	// status defines the observed state of the resource.
 	// +optional
@@ -155,7 +155,7 @@ type ServerList struct {
 
 	// items contains a list of Server.
 	// +required
-	Items           []Server `json:"items"`
+	Items []Server `json:"items"`
 }
 
 func (l *ServerList) GetItems() []Server {

--- a/api/v1alpha1/zz_generated.subnet-resource.go
+++ b/api/v1alpha1/zz_generated.subnet-resource.go
@@ -128,7 +128,7 @@ func (i *Subnet) GetConditions() []metav1.Condition {
 
 // Subnet is the Schema for an ORC resource.
 type Subnet struct {
-	metav1.TypeMeta   `json:",inline"`
+	metav1.TypeMeta `json:",inline"`
 
 	// metadata contains the object metadata
 	// +optional
@@ -136,7 +136,7 @@ type Subnet struct {
 
 	// spec specifies the desired state of the resource.
 	// +optional
-	Spec   SubnetSpec   `json:"spec,omitempty"`
+	Spec SubnetSpec `json:"spec,omitempty"`
 
 	// status defines the observed state of the resource.
 	// +optional
@@ -155,7 +155,7 @@ type SubnetList struct {
 
 	// items contains a list of Subnet.
 	// +required
-	Items           []Subnet `json:"items"`
+	Items []Subnet `json:"items"`
 }
 
 func (l *SubnetList) GetItems() []Subnet {

--- a/cmd/resource-generator/data/adapter.template
+++ b/cmd/resource-generator/data/adapter.template
@@ -31,9 +31,9 @@ type (
 
 // Derived types
 type (
-	orcObjectPT    = *orcObjectT
-	adapterI       = interfaces.APIObjectAdapter[orcObjectPT, resourceSpecT, filterT]
-	adapterT       = {{ .NameLower }}Adapter
+	orcObjectPT = *orcObjectT
+	adapterI    = interfaces.APIObjectAdapter[orcObjectPT, resourceSpecT, filterT]
+	adapterT    = {{ .NameLower }}Adapter
 )
 
 type {{ .NameLower }}Adapter struct {

--- a/cmd/resource-generator/data/api.template
+++ b/cmd/resource-generator/data/api.template
@@ -140,7 +140,7 @@ func (i *{{ .Name }}) GetConditions() []metav1.Condition {
 
 // {{ .Name }} is the Schema for an ORC resource.
 type {{ .Name }} struct {
-	metav1.TypeMeta   `json:",inline"`
+	metav1.TypeMeta `json:",inline"`
 
 	// metadata contains the object metadata
 	// +optional
@@ -148,7 +148,7 @@ type {{ .Name }} struct {
 
 	// spec specifies the desired state of the resource.
 	// +optional
-	Spec   {{ .Name }}Spec   `json:"spec,omitempty"`
+	Spec {{ .Name }}Spec `json:"spec,omitempty"`
 
 	// status defines the observed state of the resource.
 	// +optional
@@ -167,7 +167,7 @@ type {{ .Name }}List struct {
 
 	// items contains a list of {{ .Name }}.
 	// +required
-	Items           []{{ .Name }} `json:"items"`
+	Items []{{ .Name }} `json:"items"`
 }
 
 func (l *{{ .Name }}List) GetItems() []{{ .Name }} {

--- a/cmd/resource-generator/data/controller.template
+++ b/cmd/resource-generator/data/controller.template
@@ -19,15 +19,15 @@ package {{ .NameLower }}
 import (
 	corev1 "k8s.io/api/core/v1"
 
-        orcstrings "github.com/k-orc/openstack-resource-controller/v2/internal/util/strings"
 	"github.com/k-orc/openstack-resource-controller/v2/internal/util/dependency"
+	orcstrings "github.com/k-orc/openstack-resource-controller/v2/internal/util/strings"
 )
 
 var (
 	// NOTE: controllerName must be defined in any controller using this template
 
 	// finalizer is the string this controller adds to an object's Finalizers
-	finalizer  = orcstrings.GetFinalizerName(controllerName)
+	finalizer = orcstrings.GetFinalizerName(controllerName)
 
 	// externalObjectFieldOwner is the field owner we use when using
 	// server-side-apply on objects we don't control

--- a/internal/controllers/flavor/zz_generated.adapter.go
+++ b/internal/controllers/flavor/zz_generated.adapter.go
@@ -32,9 +32,9 @@ type (
 
 // Derived types
 type (
-	orcObjectPT    = *orcObjectT
-	adapterI       = interfaces.APIObjectAdapter[orcObjectPT, resourceSpecT, filterT]
-	adapterT       = flavorAdapter
+	orcObjectPT = *orcObjectT
+	adapterI    = interfaces.APIObjectAdapter[orcObjectPT, resourceSpecT, filterT]
+	adapterT    = flavorAdapter
 )
 
 type flavorAdapter struct {

--- a/internal/controllers/flavor/zz_generated.controller.go
+++ b/internal/controllers/flavor/zz_generated.controller.go
@@ -20,15 +20,15 @@ package flavor
 import (
 	corev1 "k8s.io/api/core/v1"
 
-        orcstrings "github.com/k-orc/openstack-resource-controller/v2/internal/util/strings"
 	"github.com/k-orc/openstack-resource-controller/v2/internal/util/dependency"
+	orcstrings "github.com/k-orc/openstack-resource-controller/v2/internal/util/strings"
 )
 
 var (
 	// NOTE: controllerName must be defined in any controller using this template
 
 	// finalizer is the string this controller adds to an object's Finalizers
-	finalizer  = orcstrings.GetFinalizerName(controllerName)
+	finalizer = orcstrings.GetFinalizerName(controllerName)
 
 	// externalObjectFieldOwner is the field owner we use when using
 	// server-side-apply on objects we don't control

--- a/internal/controllers/image/zz_generated.adapter.go
+++ b/internal/controllers/image/zz_generated.adapter.go
@@ -32,9 +32,9 @@ type (
 
 // Derived types
 type (
-	orcObjectPT    = *orcObjectT
-	adapterI       = interfaces.APIObjectAdapter[orcObjectPT, resourceSpecT, filterT]
-	adapterT       = imageAdapter
+	orcObjectPT = *orcObjectT
+	adapterI    = interfaces.APIObjectAdapter[orcObjectPT, resourceSpecT, filterT]
+	adapterT    = imageAdapter
 )
 
 type imageAdapter struct {

--- a/internal/controllers/image/zz_generated.controller.go
+++ b/internal/controllers/image/zz_generated.controller.go
@@ -20,15 +20,15 @@ package image
 import (
 	corev1 "k8s.io/api/core/v1"
 
-        orcstrings "github.com/k-orc/openstack-resource-controller/v2/internal/util/strings"
 	"github.com/k-orc/openstack-resource-controller/v2/internal/util/dependency"
+	orcstrings "github.com/k-orc/openstack-resource-controller/v2/internal/util/strings"
 )
 
 var (
 	// NOTE: controllerName must be defined in any controller using this template
 
 	// finalizer is the string this controller adds to an object's Finalizers
-	finalizer  = orcstrings.GetFinalizerName(controllerName)
+	finalizer = orcstrings.GetFinalizerName(controllerName)
 
 	// externalObjectFieldOwner is the field owner we use when using
 	// server-side-apply on objects we don't control

--- a/internal/controllers/network/zz_generated.adapter.go
+++ b/internal/controllers/network/zz_generated.adapter.go
@@ -32,9 +32,9 @@ type (
 
 // Derived types
 type (
-	orcObjectPT    = *orcObjectT
-	adapterI       = interfaces.APIObjectAdapter[orcObjectPT, resourceSpecT, filterT]
-	adapterT       = networkAdapter
+	orcObjectPT = *orcObjectT
+	adapterI    = interfaces.APIObjectAdapter[orcObjectPT, resourceSpecT, filterT]
+	adapterT    = networkAdapter
 )
 
 type networkAdapter struct {

--- a/internal/controllers/network/zz_generated.controller.go
+++ b/internal/controllers/network/zz_generated.controller.go
@@ -20,15 +20,15 @@ package network
 import (
 	corev1 "k8s.io/api/core/v1"
 
-        orcstrings "github.com/k-orc/openstack-resource-controller/v2/internal/util/strings"
 	"github.com/k-orc/openstack-resource-controller/v2/internal/util/dependency"
+	orcstrings "github.com/k-orc/openstack-resource-controller/v2/internal/util/strings"
 )
 
 var (
 	// NOTE: controllerName must be defined in any controller using this template
 
 	// finalizer is the string this controller adds to an object's Finalizers
-	finalizer  = orcstrings.GetFinalizerName(controllerName)
+	finalizer = orcstrings.GetFinalizerName(controllerName)
 
 	// externalObjectFieldOwner is the field owner we use when using
 	// server-side-apply on objects we don't control

--- a/internal/controllers/port/zz_generated.adapter.go
+++ b/internal/controllers/port/zz_generated.adapter.go
@@ -32,9 +32,9 @@ type (
 
 // Derived types
 type (
-	orcObjectPT    = *orcObjectT
-	adapterI       = interfaces.APIObjectAdapter[orcObjectPT, resourceSpecT, filterT]
-	adapterT       = portAdapter
+	orcObjectPT = *orcObjectT
+	adapterI    = interfaces.APIObjectAdapter[orcObjectPT, resourceSpecT, filterT]
+	adapterT    = portAdapter
 )
 
 type portAdapter struct {

--- a/internal/controllers/port/zz_generated.controller.go
+++ b/internal/controllers/port/zz_generated.controller.go
@@ -20,15 +20,15 @@ package port
 import (
 	corev1 "k8s.io/api/core/v1"
 
-        orcstrings "github.com/k-orc/openstack-resource-controller/v2/internal/util/strings"
 	"github.com/k-orc/openstack-resource-controller/v2/internal/util/dependency"
+	orcstrings "github.com/k-orc/openstack-resource-controller/v2/internal/util/strings"
 )
 
 var (
 	// NOTE: controllerName must be defined in any controller using this template
 
 	// finalizer is the string this controller adds to an object's Finalizers
-	finalizer  = orcstrings.GetFinalizerName(controllerName)
+	finalizer = orcstrings.GetFinalizerName(controllerName)
 
 	// externalObjectFieldOwner is the field owner we use when using
 	// server-side-apply on objects we don't control

--- a/internal/controllers/router/zz_generated.adapter.go
+++ b/internal/controllers/router/zz_generated.adapter.go
@@ -32,9 +32,9 @@ type (
 
 // Derived types
 type (
-	orcObjectPT    = *orcObjectT
-	adapterI       = interfaces.APIObjectAdapter[orcObjectPT, resourceSpecT, filterT]
-	adapterT       = routerAdapter
+	orcObjectPT = *orcObjectT
+	adapterI    = interfaces.APIObjectAdapter[orcObjectPT, resourceSpecT, filterT]
+	adapterT    = routerAdapter
 )
 
 type routerAdapter struct {

--- a/internal/controllers/router/zz_generated.controller.go
+++ b/internal/controllers/router/zz_generated.controller.go
@@ -20,15 +20,15 @@ package router
 import (
 	corev1 "k8s.io/api/core/v1"
 
-        orcstrings "github.com/k-orc/openstack-resource-controller/v2/internal/util/strings"
 	"github.com/k-orc/openstack-resource-controller/v2/internal/util/dependency"
+	orcstrings "github.com/k-orc/openstack-resource-controller/v2/internal/util/strings"
 )
 
 var (
 	// NOTE: controllerName must be defined in any controller using this template
 
 	// finalizer is the string this controller adds to an object's Finalizers
-	finalizer  = orcstrings.GetFinalizerName(controllerName)
+	finalizer = orcstrings.GetFinalizerName(controllerName)
 
 	// externalObjectFieldOwner is the field owner we use when using
 	// server-side-apply on objects we don't control

--- a/internal/controllers/securitygroup/zz_generated.adapter.go
+++ b/internal/controllers/securitygroup/zz_generated.adapter.go
@@ -32,9 +32,9 @@ type (
 
 // Derived types
 type (
-	orcObjectPT    = *orcObjectT
-	adapterI       = interfaces.APIObjectAdapter[orcObjectPT, resourceSpecT, filterT]
-	adapterT       = securitygroupAdapter
+	orcObjectPT = *orcObjectT
+	adapterI    = interfaces.APIObjectAdapter[orcObjectPT, resourceSpecT, filterT]
+	adapterT    = securitygroupAdapter
 )
 
 type securitygroupAdapter struct {

--- a/internal/controllers/securitygroup/zz_generated.controller.go
+++ b/internal/controllers/securitygroup/zz_generated.controller.go
@@ -20,15 +20,15 @@ package securitygroup
 import (
 	corev1 "k8s.io/api/core/v1"
 
-        orcstrings "github.com/k-orc/openstack-resource-controller/v2/internal/util/strings"
 	"github.com/k-orc/openstack-resource-controller/v2/internal/util/dependency"
+	orcstrings "github.com/k-orc/openstack-resource-controller/v2/internal/util/strings"
 )
 
 var (
 	// NOTE: controllerName must be defined in any controller using this template
 
 	// finalizer is the string this controller adds to an object's Finalizers
-	finalizer  = orcstrings.GetFinalizerName(controllerName)
+	finalizer = orcstrings.GetFinalizerName(controllerName)
 
 	// externalObjectFieldOwner is the field owner we use when using
 	// server-side-apply on objects we don't control

--- a/internal/controllers/server/zz_generated.adapter.go
+++ b/internal/controllers/server/zz_generated.adapter.go
@@ -32,9 +32,9 @@ type (
 
 // Derived types
 type (
-	orcObjectPT    = *orcObjectT
-	adapterI       = interfaces.APIObjectAdapter[orcObjectPT, resourceSpecT, filterT]
-	adapterT       = serverAdapter
+	orcObjectPT = *orcObjectT
+	adapterI    = interfaces.APIObjectAdapter[orcObjectPT, resourceSpecT, filterT]
+	adapterT    = serverAdapter
 )
 
 type serverAdapter struct {

--- a/internal/controllers/server/zz_generated.controller.go
+++ b/internal/controllers/server/zz_generated.controller.go
@@ -20,15 +20,15 @@ package server
 import (
 	corev1 "k8s.io/api/core/v1"
 
-        orcstrings "github.com/k-orc/openstack-resource-controller/v2/internal/util/strings"
 	"github.com/k-orc/openstack-resource-controller/v2/internal/util/dependency"
+	orcstrings "github.com/k-orc/openstack-resource-controller/v2/internal/util/strings"
 )
 
 var (
 	// NOTE: controllerName must be defined in any controller using this template
 
 	// finalizer is the string this controller adds to an object's Finalizers
-	finalizer  = orcstrings.GetFinalizerName(controllerName)
+	finalizer = orcstrings.GetFinalizerName(controllerName)
 
 	// externalObjectFieldOwner is the field owner we use when using
 	// server-side-apply on objects we don't control

--- a/internal/controllers/subnet/zz_generated.adapter.go
+++ b/internal/controllers/subnet/zz_generated.adapter.go
@@ -32,9 +32,9 @@ type (
 
 // Derived types
 type (
-	orcObjectPT    = *orcObjectT
-	adapterI       = interfaces.APIObjectAdapter[orcObjectPT, resourceSpecT, filterT]
-	adapterT       = subnetAdapter
+	orcObjectPT = *orcObjectT
+	adapterI    = interfaces.APIObjectAdapter[orcObjectPT, resourceSpecT, filterT]
+	adapterT    = subnetAdapter
 )
 
 type subnetAdapter struct {

--- a/internal/controllers/subnet/zz_generated.controller.go
+++ b/internal/controllers/subnet/zz_generated.controller.go
@@ -20,15 +20,15 @@ package subnet
 import (
 	corev1 "k8s.io/api/core/v1"
 
-        orcstrings "github.com/k-orc/openstack-resource-controller/v2/internal/util/strings"
 	"github.com/k-orc/openstack-resource-controller/v2/internal/util/dependency"
+	orcstrings "github.com/k-orc/openstack-resource-controller/v2/internal/util/strings"
 )
 
 var (
 	// NOTE: controllerName must be defined in any controller using this template
 
 	// finalizer is the string this controller adds to an object's Finalizers
-	finalizer  = orcstrings.GetFinalizerName(controllerName)
+	finalizer = orcstrings.GetFinalizerName(controllerName)
 
 	// externalObjectFieldOwner is the field owner we use when using
 	// server-side-apply on objects we don't control


### PR DESCRIPTION
This patch:

* Fixes the templates for resource generation, so that they output formatted code;
* Re-generates the resources
* Adds a gofmt check to the `go-lint` test