### PR TITLE
Bump kube-api-linter

### DIFF
--- a/.golangci.yml
+++ b/.golangci.yml
@@ -12,7 +12,7 @@ linters:
     - gocyclo
     - govet
     - ineffassign
-    - kal
+    - kubeapilinter
     - lll
     - misspell
     - nolintlint
@@ -28,9 +28,9 @@ linters:
       rules:
         - name: comment-spacings
     custom:
-      kal:
+      kubeapilinter:
         type: module
-        description: KAL is the Kube-API-Linter and lints Kube like APIs based on API conventions and best practices.
+        description: Kube API Linter lints Kube like APIs based on API conventions and best practices.
         settings:
           linters:
             enable:
@@ -63,7 +63,7 @@ linters:
           - lll
         path: internal/*
       - linters:
-          - kal
+          - kubeapilinter
         path-except: api/*
     paths:
       - third_party$

--- a/.golangci.yml
+++ b/.golangci.yml
@@ -41,8 +41,9 @@ linters:
               - maxlength
               # NOTE: we have a number of boolean fields. Should we convert them to
               # string?
-              # - "nobools"
+              # - nobools
               - nofloats
+              - nomaps
               - nophase
               - optionalorrequired
               - requiredfields

--- a/Makefile
+++ b/Makefile
@@ -266,7 +266,7 @@ KUSTOMIZE ?= $(LOCALBIN)/kustomize
 CONTROLLER_GEN ?= $(LOCALBIN)/controller-gen
 ENVTEST ?= $(LOCALBIN)/setup-envtest
 GOLANGCI_LINT = $(LOCALBIN)/golangci-lint
-GOLANGCI_KAL = $(LOCALBIN)/golangci-kal
+GOLANGCI_KAL = $(LOCALBIN)/golangci-kube-api-linter
 MOCKGEN = $(LOCALBIN)/mockgen
 KUTTL = $(LOCALBIN)/kubectl-kuttl
 
@@ -275,7 +275,7 @@ KUSTOMIZE_VERSION ?= v5.6.0
 CONTROLLER_TOOLS_VERSION ?= v0.17.1
 ENVTEST_VERSION ?= release-0.19
 GOLANGCI_LINT_VERSION ?= v2.0.1
-KAL_VERSION ?= v0.0.0-20250226170450-3245ed227194
+KAL_VERSION ?= v0.0.0-20250501211755-2c83ed303cde
 MOCKGEN_VERSION ?= v0.5.0
 KUTTL_VERSION ?= v0.22.0
 
@@ -301,10 +301,10 @@ $(GOLANGCI_LINT): $(LOCALBIN)
 
 define custom-gcl
 version:  $(GOLANGCI_LINT_VERSION)
-name: golangci-kal
+name: golangci-kube-api-linter
 destination: $(LOCALBIN)
 plugins:
-- module: 'github.com/JoelSpeed/kal'
+- module: 'sigs.k8s.io/kube-api-linter'
   version: $(KAL_VERSION)
 endef
 export custom-gcl

--- a/api/v1alpha1/image_types.go
+++ b/api/v1alpha1/image_types.go
@@ -267,7 +267,7 @@ type ImageContent struct {
 	// download describes how to obtain image data by downloading it from a URL.
 	// Must be set when creating a managed image.
 	// +required
-	//nolint:kal
+	//nolint:kubeapilinter
 	Download *ImageContentSourceDownload `json:"download"`
 }
 

--- a/api/v1alpha1/securitygroup_types.go
+++ b/api/v1alpha1/securitygroup_types.go
@@ -49,7 +49,6 @@ const (
 )
 
 // +kubebuilder:validation:Enum:=IPv4;IPv6
-// +required
 type Ethertype string
 
 const (


### PR DESCRIPTION
The project moved to sigs.k8s.io and changed name to kube-api-linter.

Fixes one new offense (not changing our public API), and enable the new `nomaps` linter.