### PR TITLE
CI: enable project e2e tests

### DIFF
--- a/kuttl-test.yaml
+++ b/kuttl-test.yaml
@@ -5,6 +5,7 @@ testDirs:
 - ./internal/controllers/image/tests/
 - ./internal/controllers/network/tests/
 - ./internal/controllers/port/tests/
+- ./internal/controllers/project/tests/
 - ./internal/controllers/router/tests/
 - ./internal/controllers/routerinterface/tests/
 - ./internal/controllers/securitygroup/tests/


### PR DESCRIPTION
This was missing from https://github.com/k-orc/openstack-resource-controller/pull/370.