### PR TITLE
Subnet: Add dependency on router

### DIFF
--- a/internal/controllers/subnet/actuator.go
+++ b/internal/controllers/subnet/actuator.go
@@ -161,6 +161,15 @@ func (actuator subnetActuator) CreateResource(ctx context.Context, obj orcObject
 		},
 	)
 
+	if resource.RouterRef != nil {
+		_, routerDepRS := routerDependency.GetDependency(
+			ctx, actuator.k8sClient, obj, func(dep *orcv1alpha1.Router) bool {
+				return orcv1alpha1.IsAvailable(dep) && dep.Status.ID != nil
+			},
+		)
+		reconcileStatus = reconcileStatus.WithReconcileStatus(routerDepRS)
+	}
+
 	var projectID string
 	if resource.ProjectRef != "" {
 		project, projectDepRS := projectDependency.GetDependency(

--- a/internal/controllers/subnet/tests/subnet-dependency/00-assert.yaml
+++ b/internal/controllers/subnet/tests/subnet-dependency/00-assert.yaml
@@ -33,18 +33,16 @@ apiVersion: openstack.k-orc.cloud/v1alpha1
 kind: Subnet
 metadata:
   name: subnet-dependency-no-router
-# FIXME We're missing a dependency on router
-# https://github.com/k-orc/openstack-resource-controller/issues/316
-# status:
-#   conditions:
-#     - type: Available
-#       message: Waiting for Router/subnet-dependency-pending to be created
-#       status: "False"
-#       reason: Progressing
-#     - type: Progressing
-#       message: Waiting for Router/subnet-dependency-pending to be created
-#       status: "True"
-#       reason: Progressing
+status:
+  conditions:
+    - type: Available
+      message: Waiting for Router/subnet-dependency-pending to be created
+      status: "False"
+      reason: Progressing
+    - type: Progressing
+      message: Waiting for Router/subnet-dependency-pending to be created
+      status: "True"
+      reason: Progressing
 ---
 apiVersion: openstack.k-orc.cloud/v1alpha1
 kind: Subnet

--- a/internal/controllers/subnet/tests/subnet-dependency/02-assert.yaml
+++ b/internal/controllers/subnet/tests/subnet-dependency/02-assert.yaml
@@ -6,12 +6,10 @@ resourceRefs:
       kind: Network
       name: subnet-dependency
       ref: network
-    # FIXME We're missing a dependency on router
-    # https://github.com/k-orc/openstack-resource-controller/issues/316
-    # - apiVersion: openstack.k-orc.cloud/v1alpha1
-    #   kind: Router
-    #   name: subnet-dependency
-    #   ref: router
+    - apiVersion: openstack.k-orc.cloud/v1alpha1
+      kind: Router
+      name: subnet-dependency
+      ref: router
     - apiVersion: openstack.k-orc.cloud/v1alpha1
       kind: Project
       name: subnet-dependency
@@ -23,8 +21,8 @@ resourceRefs:
 assertAll:
     - celExpr: "network.metadata.deletionTimestamp != 0"
     - celExpr: "'openstack.k-orc.cloud/subnet' in network.metadata.finalizers"
-    # - celExpr: "router.metadata.deletionTimestamp != 0"
-    # - celExpr: "'openstack.k-orc.cloud/subnet' in router.metadata.finalizers"
+    - celExpr: "router.metadata.deletionTimestamp != 0"
+    - celExpr: "'openstack.k-orc.cloud/subnet' in router.metadata.finalizers"
     - celExpr: "project.metadata.deletionTimestamp != 0"
     - celExpr: "'openstack.k-orc.cloud/subnet' in project.metadata.finalizers"
     - celExpr: "secret.metadata.deletionTimestamp != 0"


### PR DESCRIPTION
Whenever the subnet has a routerRef, it needs to be able to wait for the resource to be available.

Fixes https://github.com/k-orc/openstack-resource-controller/issues/316.