### PR TITLE
Subnet: add mutability for a fields that support it

### DIFF
--- a/api/v1alpha1/subnet_types.go
+++ b/api/v1alpha1/subnet_types.go
@@ -62,7 +62,6 @@ type SubnetFilter struct {
 	FilterByNeutronTags `json:",inline"`
 }
 
-// +kubebuilder:validation:XValidation:rule="self == oldSelf",message="SubnetResourceSpec is immutable"
 type SubnetResourceSpec struct {
 	// name is a human-readable name of the subnet. If not set, the object's name will be used.
 	// +optional
@@ -74,6 +73,7 @@ type SubnetResourceSpec struct {
 
 	// networkRef is a reference to the ORC Network which this subnet is associated with.
 	// +required
+	// +kubebuilder:validation:XValidation:rule="self == oldSelf",message="networkRef is immutable"
 	NetworkRef KubernetesNameRef `json:"networkRef"`
 
 	// tags is a list of tags which will be applied to the subnet.
@@ -84,10 +84,12 @@ type SubnetResourceSpec struct {
 
 	// ipVersion is the IP version for the subnet.
 	// +required
+	// +kubebuilder:validation:XValidation:rule="self == oldSelf",message="ipVersion is immutable"
 	IPVersion IPVersion `json:"ipVersion"`
 
 	// cidr is the address CIDR of the subnet. It must match the IP version specified in IPVersion.
 	// +required
+	// +kubebuilder:validation:XValidation:rule="self == oldSelf",message="cidr is immutable"
 	CIDR CIDR `json:"cidr"`
 
 	// allocationPools are IP Address pools that will be available for DHCP. IP
@@ -116,6 +118,7 @@ type SubnetResourceSpec struct {
 	// dnsPublishFixedIP will either enable or disable the publication of
 	// fixed IPs to the DNS. Defaults to false.
 	// +optional
+	// +kubebuilder:validation:XValidation:rule="self == oldSelf",message="dnsPublishFixedIP is immutable"
 	DNSPublishFixedIP *bool `json:"dnsPublishFixedIP,omitempty"`
 
 	// hostRoutes are any static host routes to be set via DHCP.
@@ -126,15 +129,18 @@ type SubnetResourceSpec struct {
 
 	// ipv6 contains IPv6-specific options. It may only be set if IPVersion is 6.
 	// +optional
+	// +kubebuilder:validation:XValidation:rule="self == oldSelf",message="ipv6 is immutable"
 	IPv6 *IPv6Options `json:"ipv6,omitempty"`
 
 	// routerRef specifies a router to attach the subnet to
 	// +optional
+	// +kubebuilder:validation:XValidation:rule="self == oldSelf",message="routerRef is immutable"
 	RouterRef *KubernetesNameRef `json:"routerRef,omitempty"`
 
 	// projectRef is a reference to the ORC Project this resource is associated with.
 	// Typically, only used by admin.
 	// +optional
+	// +kubebuilder:validation:XValidation:rule="self == oldSelf",message="projectRef is immutable"
 	ProjectRef *KubernetesNameRef `json:"projectRef,omitempty"`
 
 	// TODO: Support service types

--- a/config/crd/bases/openstack.k-orc.cloud_subnets.yaml
+++ b/config/crd/bases/openstack.k-orc.cloud_subnets.yaml
@@ -292,6 +292,9 @@ spec:
                     maxLength: 49
                     minLength: 1
                     type: string
+                    x-kubernetes-validations:
+                    - message: cidr is immutable
+                      rule: self == oldSelf
                   description:
                     description: description is a human-readable description for the
                       resource.
@@ -313,6 +316,9 @@ spec:
                       dnsPublishFixedIP will either enable or disable the publication of
                       fixed IPs to the DNS. Defaults to false.
                     type: boolean
+                    x-kubernetes-validations:
+                    - message: dnsPublishFixedIP is immutable
+                      rule: self == oldSelf
                   enableDHCP:
                     description: enableDHCP will either enable to disable the DHCP
                       service.
@@ -377,6 +383,9 @@ spec:
                     - 6
                     format: int32
                     type: integer
+                    x-kubernetes-validations:
+                    - message: ipVersion is immutable
+                      rule: self == oldSelf
                   ipv6:
                     description: ipv6 contains IPv6-specific options. It may only
                       be set if IPVersion is 6.
@@ -400,6 +409,9 @@ spec:
                         - dhcpv6-stateless
                         type: string
                     type: object
+                    x-kubernetes-validations:
+                    - message: ipv6 is immutable
+                      rule: self == oldSelf
                   name:
                     description: name is a human-readable name of the subnet. If not
                       set, the object's name will be used.
@@ -413,6 +425,9 @@ spec:
                     maxLength: 253
                     minLength: 1
                     type: string
+                    x-kubernetes-validations:
+                    - message: networkRef is immutable
+                      rule: self == oldSelf
                   projectRef:
                     description: |-
                       projectRef is a reference to the ORC Project this resource is associated with.
@@ -420,12 +435,18 @@ spec:
                     maxLength: 253
                     minLength: 1
                     type: string
+                    x-kubernetes-validations:
+                    - message: projectRef is immutable
+                      rule: self == oldSelf
                   routerRef:
                     description: routerRef specifies a router to attach the subnet
                       to
                     maxLength: 253
                     minLength: 1
                     type: string
+                    x-kubernetes-validations:
+                    - message: routerRef is immutable
+                      rule: self == oldSelf
                   tags:
                     description: tags is a list of tags which will be applied to the
                       subnet.
@@ -444,9 +465,6 @@ spec:
                 - ipVersion
                 - networkRef
                 type: object
-                x-kubernetes-validations:
-                - message: SubnetResourceSpec is immutable
-                  rule: self == oldSelf
             required:
             - cloudCredentialsRef
             type: object

--- a/internal/controllers/generic/reconciler/controller.go
+++ b/internal/controllers/generic/reconciler/controller.go
@@ -217,7 +217,7 @@ func (c *Controller[
 
 	if objAdapter.GetManagementPolicy() == orcv1alpha1.ManagementPolicyManaged {
 		if reconciler, ok := actuator.(interfaces.ReconcileResourceActuator[orcObjectPT, osResourceT]); ok {
-			// We deliberately execute all reconcilers returned by GetResourceUpdates, even if it returns an error.
+			// We deliberately execute all reconcilers returned by GetResourceReconcilers, even if it returns an error.
 			reconcilers, getReconcilersRS := reconciler.GetResourceReconcilers(ctx, objAdapter.GetObject(), osResource, c)
 			reconcileStatus = getReconcilersRS.WithReconcileStatus(reconcileStatus)
 

--- a/internal/controllers/subnet/actuator_test.go
+++ b/internal/controllers/subnet/actuator_test.go
@@ -1,0 +1,429 @@
+package subnet
+
+import (
+	"reflect"
+	"testing"
+
+	"github.com/gophercloud/gophercloud/v2/openstack/networking/v2/subnets"
+	orcv1alpha1 "github.com/k-orc/openstack-resource-controller/v2/api/v1alpha1"
+	"k8s.io/utils/ptr"
+)
+
+func TestHandleNameUpdate(t *testing.T) {
+	ptrToName := ptr.To[orcv1alpha1.OpenStackName]
+	testCases := []struct {
+		name          string
+		newValue      *orcv1alpha1.OpenStackName
+		existingValue string
+		expectChange  bool
+	}{
+		{name: "Identical", newValue: ptrToName("name"), existingValue: "name", expectChange: false},
+		{name: "Different", newValue: ptrToName("new-name"), existingValue: "name", expectChange: true},
+		{name: "No value provided, existing is identical to object name", newValue: nil, existingValue: "object-name", expectChange: false},
+		{name: "No value provided, existing is different from object name", newValue: nil, existingValue: "different-from-object-name", expectChange: true},
+	}
+
+	for _, tt := range testCases {
+		t.Run(tt.name, func(t *testing.T) {
+			resource := &orcv1alpha1.Subnet{}
+			resource.Name = "object-name"
+			resource.Spec = orcv1alpha1.SubnetSpec{
+				Resource: &orcv1alpha1.SubnetResourceSpec{Name: tt.newValue},
+			}
+			osResource := &subnets.Subnet{Name: tt.existingValue}
+
+			updateOpts := subnets.UpdateOpts{}
+			handleNameUpdate(&updateOpts, resource, osResource)
+
+			got := !reflect.ValueOf(updateOpts).IsZero()
+			if got != tt.expectChange {
+				t.Errorf("Expected change: %v, got %v", tt.expectChange, got)
+			}
+		})
+
+	}
+}
+
+func TestHandleDescriptionUpdate(t *testing.T) {
+	ptrToDescription := ptr.To[orcv1alpha1.NeutronDescription]
+	testCases := []struct {
+		name          string
+		newValue      *orcv1alpha1.NeutronDescription
+		existingValue string
+		expectChange  bool
+	}{
+		{name: "Identical", newValue: ptrToDescription("desc"), existingValue: "desc", expectChange: false},
+		{name: "Different", newValue: ptrToDescription("new-desc"), existingValue: "desc", expectChange: true},
+		{name: "No value provided, existing is set", newValue: nil, existingValue: "desc", expectChange: true},
+		{name: "No value provided, existing is empty", newValue: nil, existingValue: "", expectChange: false},
+	}
+
+	for _, tt := range testCases {
+		t.Run(tt.name, func(t *testing.T) {
+			resource := &orcv1alpha1.SubnetResourceSpec{Description: tt.newValue}
+			osResource := &subnets.Subnet{Description: tt.existingValue}
+
+			updateOpts := subnets.UpdateOpts{}
+			handleDescriptionUpdate(&updateOpts, resource, osResource)
+
+			got := !reflect.ValueOf(updateOpts).IsZero()
+			if got != tt.expectChange {
+				t.Errorf("Expected change: %v, got %v", tt.expectChange, got)
+			}
+		})
+
+	}
+}
+
+func TestHandleAllocationPoolsUpdate(t *testing.T) {
+	testCases := []struct {
+		name          string
+		newValue      []orcv1alpha1.AllocationPool
+		existingValue []subnets.AllocationPool
+		expectChange  bool
+	}{
+		{
+			name: "Identical",
+			newValue: []orcv1alpha1.AllocationPool{
+				{Start: orcv1alpha1.IPvAny("192.168.1.1"), End: orcv1alpha1.IPvAny("192.168.1.10")},
+				{Start: orcv1alpha1.IPvAny("192.168.2.1"), End: orcv1alpha1.IPvAny("192.168.2.10")},
+			},
+			existingValue: []subnets.AllocationPool{
+				{Start: "192.168.1.1", End: "192.168.1.10"},
+				{Start: "192.168.2.1", End: "192.168.2.10"},
+			},
+			expectChange: false,
+		},
+		{
+			name: "Different entry",
+			newValue: []orcv1alpha1.AllocationPool{
+				{Start: orcv1alpha1.IPvAny("192.168.1.1"), End: orcv1alpha1.IPvAny("192.168.1.10")},
+				{Start: orcv1alpha1.IPvAny("192.168.5.1"), End: orcv1alpha1.IPvAny("192.168.5.10")},
+			},
+			existingValue: []subnets.AllocationPool{
+				{Start: "192.168.1.1", End: "192.168.1.10"},
+				{Start: "192.168.2.1", End: "192.168.2.10"},
+			},
+			expectChange: true,
+		},
+		{
+			name: "Identical, out of order",
+			newValue: []orcv1alpha1.AllocationPool{
+				{Start: orcv1alpha1.IPvAny("192.168.2.1"), End: orcv1alpha1.IPvAny("192.168.2.10")},
+				{Start: orcv1alpha1.IPvAny("192.168.1.1"), End: orcv1alpha1.IPvAny("192.168.1.10")},
+			},
+			existingValue: []subnets.AllocationPool{
+				{Start: "192.168.1.1", End: "192.168.1.10"},
+				{Start: "192.168.2.1", End: "192.168.2.10"},
+			},
+			expectChange: false,
+		},
+		{
+			name: "Identical, with duplicate",
+			newValue: []orcv1alpha1.AllocationPool{
+				{Start: orcv1alpha1.IPvAny("192.168.1.1"), End: orcv1alpha1.IPvAny("192.168.1.10")},
+				{Start: orcv1alpha1.IPvAny("192.168.2.1"), End: orcv1alpha1.IPvAny("192.168.2.10")},
+				{Start: orcv1alpha1.IPvAny("192.168.2.1"), End: orcv1alpha1.IPvAny("192.168.2.10")},
+			},
+			existingValue: []subnets.AllocationPool{
+				{Start: "192.168.1.1", End: "192.168.1.10"},
+				{Start: "192.168.2.1", End: "192.168.2.10"},
+			},
+			expectChange: false,
+		},
+		{
+			name: "Removing an entry",
+			newValue: []orcv1alpha1.AllocationPool{
+				{Start: orcv1alpha1.IPvAny("192.168.1.1"), End: orcv1alpha1.IPvAny("192.168.1.10")},
+			},
+			existingValue: []subnets.AllocationPool{
+				{Start: "192.168.1.1", End: "192.168.1.10"},
+				{Start: "192.168.2.1", End: "192.168.2.10"},
+			},
+			expectChange: true,
+		},
+		{
+			name: "Adding an entry",
+			newValue: []orcv1alpha1.AllocationPool{
+				{Start: orcv1alpha1.IPvAny("192.168.1.1"), End: orcv1alpha1.IPvAny("192.168.1.10")},
+				{Start: orcv1alpha1.IPvAny("192.168.2.1"), End: orcv1alpha1.IPvAny("192.168.2.10")},
+			},
+			existingValue: []subnets.AllocationPool{
+				{Start: "192.168.1.1", End: "192.168.1.10"},
+			},
+			expectChange: true,
+		},
+		{
+			name:     "Default allocation pool",
+			newValue: []orcv1alpha1.AllocationPool{},
+			existingValue: []subnets.AllocationPool{
+				{Start: "192.168.1.1", End: "192.168.1.10"},
+			},
+			expectChange: false,
+		},
+	}
+
+	for _, tt := range testCases {
+		t.Run(tt.name, func(t *testing.T) {
+			resource := &orcv1alpha1.SubnetResourceSpec{AllocationPools: tt.newValue}
+			osResource := &subnets.Subnet{AllocationPools: tt.existingValue}
+
+			updateOpts := subnets.UpdateOpts{}
+			handleAllocationPoolsUpdate(&updateOpts, resource, osResource)
+
+			got := !reflect.ValueOf(updateOpts).IsZero()
+			if got != tt.expectChange {
+				t.Errorf("Expected change: %v, got %v", tt.expectChange, got)
+			}
+		})
+
+	}
+}
+
+func TestHandleHostRoutesUpdate(t *testing.T) {
+	testCases := []struct {
+		name          string
+		newValue      []orcv1alpha1.HostRoute
+		existingValue []subnets.HostRoute
+		expectChange  bool
+	}{
+		{
+			name: "Identical",
+			newValue: []orcv1alpha1.HostRoute{
+				{Destination: orcv1alpha1.CIDR("192.168.1.0/24"), NextHop: orcv1alpha1.IPvAny("192.168.100.1")},
+				{Destination: orcv1alpha1.CIDR("192.168.2.0/24"), NextHop: orcv1alpha1.IPvAny("192.168.200.1")},
+			},
+			existingValue: []subnets.HostRoute{
+				{DestinationCIDR: "192.168.1.0/24", NextHop: "192.168.100.1"},
+				{DestinationCIDR: "192.168.2.0/24", NextHop: "192.168.200.1"},
+			},
+			expectChange: false,
+		},
+		{
+			name: "Different entry",
+			newValue: []orcv1alpha1.HostRoute{
+				{Destination: orcv1alpha1.CIDR("192.168.1.0/24"), NextHop: orcv1alpha1.IPvAny("192.168.100.1")},
+				{Destination: orcv1alpha1.CIDR("192.168.5.0/24"), NextHop: orcv1alpha1.IPvAny("192.168.500.1")},
+			},
+			existingValue: []subnets.HostRoute{
+				{DestinationCIDR: "192.168.1.0/24", NextHop: "192.168.100.1"},
+				{DestinationCIDR: "192.168.2.0/24", NextHop: "192.168.200.1"},
+			},
+			expectChange: true,
+		},
+		{
+			name: "Identical, out of order",
+			newValue: []orcv1alpha1.HostRoute{
+				{Destination: orcv1alpha1.CIDR("192.168.2.0/24"), NextHop: orcv1alpha1.IPvAny("192.168.200.1")},
+				{Destination: orcv1alpha1.CIDR("192.168.1.0/24"), NextHop: orcv1alpha1.IPvAny("192.168.100.1")},
+			},
+			existingValue: []subnets.HostRoute{
+				{DestinationCIDR: "192.168.1.0/24", NextHop: "192.168.100.1"},
+				{DestinationCIDR: "192.168.2.0/24", NextHop: "192.168.200.1"},
+			},
+			expectChange: false,
+		},
+		{
+			name: "Identical, with duplicates",
+			newValue: []orcv1alpha1.HostRoute{
+				{Destination: orcv1alpha1.CIDR("192.168.1.0/24"), NextHop: orcv1alpha1.IPvAny("192.168.100.1")},
+				{Destination: orcv1alpha1.CIDR("192.168.2.0/24"), NextHop: orcv1alpha1.IPvAny("192.168.200.1")},
+				{Destination: orcv1alpha1.CIDR("192.168.2.0/24"), NextHop: orcv1alpha1.IPvAny("192.168.200.1")},
+			},
+			existingValue: []subnets.HostRoute{
+				{DestinationCIDR: "192.168.1.0/24", NextHop: "192.168.100.1"},
+				{DestinationCIDR: "192.168.2.0/24", NextHop: "192.168.200.1"},
+			},
+			expectChange: false,
+		},
+		{
+			name: "Removing an entry",
+			newValue: []orcv1alpha1.HostRoute{
+				{Destination: orcv1alpha1.CIDR("192.168.1.0/24"), NextHop: orcv1alpha1.IPvAny("192.168.100.1")},
+			},
+			existingValue: []subnets.HostRoute{
+				{DestinationCIDR: "192.168.1.0/24", NextHop: "192.168.100.1"},
+				{DestinationCIDR: "192.168.2.0/24", NextHop: "192.168.200.1"},
+			},
+			expectChange: true,
+		},
+		{
+			name: "Adding an entry",
+			newValue: []orcv1alpha1.HostRoute{
+				{Destination: orcv1alpha1.CIDR("192.168.1.0/24"), NextHop: orcv1alpha1.IPvAny("192.168.100.1")},
+				{Destination: orcv1alpha1.CIDR("192.168.2.0/24"), NextHop: orcv1alpha1.IPvAny("192.168.200.1")},
+			},
+			existingValue: []subnets.HostRoute{
+				{DestinationCIDR: "192.168.1.0/24", NextHop: "192.168.100.1"},
+			},
+			expectChange: true,
+		},
+	}
+
+	for _, tt := range testCases {
+		t.Run(tt.name, func(t *testing.T) {
+			resource := &orcv1alpha1.SubnetResourceSpec{HostRoutes: tt.newValue}
+			osResource := &subnets.Subnet{HostRoutes: tt.existingValue}
+
+			updateOpts := subnets.UpdateOpts{}
+			handleHostRoutesUpdate(&updateOpts, resource, osResource)
+
+			got := !reflect.ValueOf(updateOpts).IsZero()
+			if got != tt.expectChange {
+				t.Errorf("Expected change: %v, got %v", tt.expectChange, got)
+			}
+		})
+
+	}
+}
+
+func TestHandleDNSNameserversUpdate(t *testing.T) {
+	testCases := []struct {
+		name          string
+		newValue      []orcv1alpha1.IPvAny
+		existingValue []string
+		expectChange  bool
+	}{
+		{
+			name:          "Identical",
+			newValue:      []orcv1alpha1.IPvAny{"192.168.1.1", "192.168.1.2"},
+			existingValue: []string{"192.168.1.1", "192.168.1.2"},
+			expectChange:  false,
+		},
+		{
+			name:          "Change order",
+			newValue:      []orcv1alpha1.IPvAny{"192.168.1.2", "192.168.1.1"},
+			existingValue: []string{"192.168.1.1", "192.168.1.2"},
+			expectChange:  true,
+		},
+		{
+			name:          "Duplicate entry, with update",
+			newValue:      []orcv1alpha1.IPvAny{"192.168.1.1", "192.168.1.1", "192.168.1.2"},
+			existingValue: []string{"192.168.1.1", "192.168.1.2", "192.168.1.3"},
+			expectChange:  true,
+		},
+	}
+
+	for _, tt := range testCases {
+		t.Run(tt.name, func(t *testing.T) {
+			resource := &orcv1alpha1.SubnetResourceSpec{DNSNameservers: tt.newValue}
+			osResource := &subnets.Subnet{DNSNameservers: tt.existingValue}
+
+			updateOpts := subnets.UpdateOpts{}
+			handleDNSNameserversUpdate(&updateOpts, resource, osResource)
+
+			got := !reflect.ValueOf(updateOpts).IsZero()
+			if got != tt.expectChange {
+				t.Errorf("Expected change: %v, got %v", tt.expectChange, got)
+			}
+		})
+
+	}
+}
+
+func TestHandleEnableDHCPUpdate(t *testing.T) {
+	ptrToBool := ptr.To[bool]
+	testCases := []struct {
+		name          string
+		newValue      *bool
+		existingValue bool
+		expectChange  bool
+	}{
+		{name: "Identical", newValue: ptrToBool(true), existingValue: true, expectChange: false},
+		{name: "Different", newValue: ptrToBool(true), existingValue: false, expectChange: true},
+		{name: "No value provided, existing is set", newValue: nil, existingValue: false, expectChange: true},
+		{name: "No value provided, existing is default", newValue: nil, existingValue: true, expectChange: false},
+	}
+
+	for _, tt := range testCases {
+		t.Run(tt.name, func(t *testing.T) {
+			resource := &orcv1alpha1.SubnetResourceSpec{EnableDHCP: tt.newValue}
+			osResource := &subnets.Subnet{EnableDHCP: tt.existingValue}
+
+			updateOpts := subnets.UpdateOpts{}
+			handleEnableDHCPUpdate(&updateOpts, resource, osResource)
+
+			got := !reflect.ValueOf(updateOpts).IsZero()
+			if got != tt.expectChange {
+				t.Errorf("Expected change: %v, got %v", tt.expectChange, got)
+			}
+		})
+
+	}
+}
+
+func TestHandleGatewayUpdate(t *testing.T) {
+	ptrToGateway := ptr.To[orcv1alpha1.SubnetGateway]
+	ptrToIP := ptr.To[orcv1alpha1.IPvAny]
+	testCases := []struct {
+		name          string
+		newValue      *orcv1alpha1.SubnetGateway
+		existingValue string
+		expectChange  bool
+	}{
+		{
+			name: "Identical",
+			newValue: ptrToGateway(orcv1alpha1.SubnetGateway{
+				Type: orcv1alpha1.SubnetGatewayTypeIP,
+				IP:   ptrToIP("192.168.1.1"),
+			}),
+			existingValue: "192.168.1.1",
+			expectChange:  false,
+		},
+		{
+			name: "To different IP",
+			newValue: ptrToGateway(orcv1alpha1.SubnetGateway{
+				Type: orcv1alpha1.SubnetGatewayTypeIP,
+				IP:   ptrToIP("192.168.1.2"),
+			}),
+			existingValue: "192.168.1.1",
+			expectChange:  true,
+		},
+		{
+			name: "Disable gateway",
+			newValue: ptrToGateway(orcv1alpha1.SubnetGateway{
+				Type: orcv1alpha1.SubnetGatewayTypeNone,
+			}),
+			existingValue: "192.168.1.1",
+			expectChange:  true,
+		},
+		{
+			name: "Disabled gateway",
+			newValue: ptrToGateway(orcv1alpha1.SubnetGateway{
+				Type: orcv1alpha1.SubnetGatewayTypeNone,
+			}),
+			existingValue: "",
+			expectChange:  false,
+		},
+		{
+			name: "Not updating when automatic",
+			newValue: ptrToGateway(orcv1alpha1.SubnetGateway{
+				Type: orcv1alpha1.SubnetGatewayTypeAutomatic,
+			}),
+			existingValue: "192.168.1.1",
+			expectChange:  false,
+		},
+		{
+			name:          "Not updating when no value provided",
+			newValue:      nil,
+			existingValue: "192.168.1.1",
+			expectChange:  false,
+		},
+	}
+
+	for _, tt := range testCases {
+		t.Run(tt.name, func(t *testing.T) {
+			resource := &orcv1alpha1.SubnetResourceSpec{Gateway: tt.newValue}
+			osResource := &subnets.Subnet{GatewayIP: tt.existingValue}
+
+			updateOpts := subnets.UpdateOpts{}
+			handleGatewayUpdate(&updateOpts, resource, osResource)
+
+			got := !reflect.ValueOf(updateOpts).IsZero()
+			if got != tt.expectChange {
+				t.Errorf("Expected change: %v, got %v", tt.expectChange, got)
+			}
+		})
+
+	}
+}

--- a/internal/controllers/subnet/tests/subnet-create-full-v4/00-assert.yaml
+++ b/internal/controllers/subnet/tests/subnet-create-full-v4/00-assert.yaml
@@ -40,7 +40,6 @@ status:
     allocationPools:
       - start: 192.168.1.10
         end: 192.168.1.15
-    enableDHCP: false
     gatewayIP: 192.168.1.2
     enableDHCP: false
     dnsNameservers:

--- a/internal/controllers/subnet/tests/subnet-update/00-assert.yaml
+++ b/internal/controllers/subnet/tests/subnet-update/00-assert.yaml
@@ -1,0 +1,43 @@
+---
+apiVersion: kuttl.dev/v1beta1
+kind: TestAssert
+resourceRefs:
+    - apiVersion: openstack.k-orc.cloud/v1alpha1
+      kind: Subnet
+      name: subnet-update
+      ref: subnet
+    - apiVersion: openstack.k-orc.cloud/v1alpha1
+      kind: Network
+      name: subnet-update
+      ref: network
+assertAll:
+    - celExpr: "subnet.status.resource.networkID == network.status.id"
+    - celExpr: "!has(subnet.status.resource.description)"
+    - celExpr: "!has(subnet.status.resource.tags)"
+    - celExpr: "!has(subnet.status.resource.hostRoutes)"
+    - celExpr: "!has(subnet.status.resource.dnsNameservers)"
+---
+apiVersion: openstack.k-orc.cloud/v1alpha1
+kind: Subnet
+metadata:
+  name: subnet-update
+status:
+  resource:
+    name: subnet-update
+    allocationPools:
+      - start: 192.168.0.2
+        end: 192.168.0.254
+    cidr: 192.168.0.0/24
+    dnsPublishFixedIP: false
+    enableDHCP: true
+    gatewayIP: 192.168.0.1
+    ipVersion: 4
+  conditions:
+    - type: Available
+      message: OpenStack resource is available
+      status: "True"
+      reason: Success
+    - type: Progressing
+      message: OpenStack resource is up to date
+      status: "False"
+      reason: Success

--- a/internal/controllers/subnet/tests/subnet-update/00-minimal-resource.yaml
+++ b/internal/controllers/subnet/tests/subnet-update/00-minimal-resource.yaml
@@ -1,0 +1,13 @@
+apiVersion: openstack.k-orc.cloud/v1alpha1
+kind: Subnet
+metadata:
+  name: subnet-update
+spec:
+  cloudCredentialsRef:
+    cloudName: openstack
+    secretName: openstack-clouds
+  managementPolicy: managed
+  resource:
+    networkRef: subnet-update
+    ipVersion: 4
+    cidr: 192.168.0.0/24

--- a/internal/controllers/subnet/tests/subnet-update/00-prerequisites.yaml
+++ b/internal/controllers/subnet/tests/subnet-update/00-prerequisites.yaml
@@ -1,0 +1,16 @@
+apiVersion: openstack.k-orc.cloud/v1alpha1
+kind: Network
+metadata:
+  name: subnet-update
+spec:
+  cloudCredentialsRef:
+    cloudName: openstack
+    secretName: openstack-clouds
+  managementPolicy: managed
+  resource: {}
+---
+apiVersion: kuttl.dev/v1beta1
+kind: TestStep
+commands:
+  - command: kubectl create secret generic openstack-clouds --from-file=clouds.yaml=${E2E_KUTTL_OSCLOUDS} ${E2E_KUTTL_CACERT_OPT}
+    namespaced: true

--- a/internal/controllers/subnet/tests/subnet-update/01-assert.yaml
+++ b/internal/controllers/subnet/tests/subnet-update/01-assert.yaml
@@ -1,0 +1,42 @@
+---
+apiVersion: kuttl.dev/v1beta1
+kind: TestAssert
+resourceRefs:
+    - apiVersion: openstack.k-orc.cloud/v1alpha1
+      kind: Subnet
+      name: subnet-update
+      ref: subnet
+    - apiVersion: openstack.k-orc.cloud/v1alpha1
+      kind: Network
+      name: subnet-update
+      ref: network
+assertAll:
+    - celExpr: "subnet.status.resource.networkID == network.status.id"
+---
+apiVersion: openstack.k-orc.cloud/v1alpha1
+kind: Subnet
+metadata:
+  name: subnet-update
+status:
+  resource:
+    name: subnet-update-updated
+    description: subnet-update-updated
+    allocationPools:
+      - start: 192.168.0.5
+        end: 192.168.0.200
+    cidr: 192.168.0.0/24
+    dnsPublishFixedIP: false
+    enableDHCP: false
+    gatewayIP: 192.168.0.2
+    ipVersion: 4
+    tags:
+      - tag1
+      - tag2
+    hostRoutes:
+      - destination: 192.168.3.0/24
+        nextHop: 192.168.4.1
+      - destination: 192.168.5.0/24
+        nextHop: 192.168.6.1
+    dnsNameservers:
+      - 1.1.1.1
+      - 8.8.8.8

--- a/internal/controllers/subnet/tests/subnet-update/01-updated-resource.yaml
+++ b/internal/controllers/subnet/tests/subnet-update/01-updated-resource.yaml
@@ -1,0 +1,32 @@
+---
+apiVersion: openstack.k-orc.cloud/v1alpha1
+kind: Subnet
+metadata:
+  name: subnet-update
+spec:
+  cloudCredentialsRef:
+    cloudName: openstack
+    secretName: openstack-clouds
+  managementPolicy: managed
+  resource:
+    # kuttl does a merge patch, we only need to change the things we want changed
+    name: subnet-update-updated
+    description: subnet-update-updated
+    tags:
+      - tag1
+      - tag2
+    allocationPools:
+      - start: 192.168.0.5
+        end: 192.168.0.200
+    enableDHCP: false
+    hostRoutes:
+      - destination: 192.168.3.0/24
+        nextHop: 192.168.4.1
+      - destination: 192.168.5.0/24
+        nextHop: 192.168.6.1
+    dnsNameservers:
+      - 1.1.1.1
+      - 8.8.8.8
+    gateway:
+      type: IP
+      ip: 192.168.0.2

--- a/internal/controllers/subnet/tests/subnet-update/02-assert.yaml
+++ b/internal/controllers/subnet/tests/subnet-update/02-assert.yaml
@@ -1,0 +1,38 @@
+---
+apiVersion: kuttl.dev/v1beta1
+kind: TestAssert
+resourceRefs:
+    - apiVersion: openstack.k-orc.cloud/v1alpha1
+      kind: Subnet
+      name: subnet-update
+      ref: subnet
+    - apiVersion: openstack.k-orc.cloud/v1alpha1
+      kind: Network
+      name: subnet-update
+      ref: network
+assertAll:
+    - celExpr: "subnet.status.resource.networkID == network.status.id"
+    - celExpr: "!has(subnet.status.resource.description)"
+    - celExpr: "!has(subnet.status.resource.tags)"
+    - celExpr: "!has(subnet.status.resource.hostRoutes)"
+    - celExpr: "!has(subnet.status.resource.dnsNameservers)"
+---
+apiVersion: openstack.k-orc.cloud/v1alpha1
+kind: Subnet
+metadata:
+  name: subnet-update
+status:
+  resource:
+    name: subnet-update
+    allocationPools:
+      - start: 192.168.0.2
+        end: 192.168.0.254
+    cidr: 192.168.0.0/24
+    dnsPublishFixedIP: false
+    enableDHCP: true
+    ipVersion: 4
+    # The following values aren't reset because the original spec had no value
+    allocationPools:
+      - start: 192.168.0.5
+        end: 192.168.0.200
+    gatewayIP: 192.168.0.2

--- a/internal/controllers/subnet/tests/subnet-update/02-reverted-resource.yaml
+++ b/internal/controllers/subnet/tests/subnet-update/02-reverted-resource.yaml
@@ -1,0 +1,7 @@
+# NOTE: kuttl only does patch updates, which means we can't delete a field.
+# We have to use a kubectl apply command instead.
+apiVersion: kuttl.dev/v1beta1
+kind: TestStep
+commands:
+  - command: kubectl replace -f 00-minimal-resource.yaml
+    namespaced: true


### PR DESCRIPTION
Allow mutability for all the fields available in gophercloud's subnet UpdateOpts stucture, except for `dnsPublishFixedIP` that we have explicitly left immutable to avoid potential endless reconciliation.

Fixes https://github.com/k-orc/openstack-resource-controller/issues/275