### PR TITLE
FloatingIP: set omitempty for resource.floatingIP

### DIFF
--- a/api/v1alpha1/floatingip_types.go
+++ b/api/v1alpha1/floatingip_types.go
@@ -68,7 +68,7 @@ type FloatingIPResourceSpec struct {
 	// floatingIP is the IP that will be assigned to the floatingip. If not set, it will
 	// be assigned automatically.
 	// +optional
-	FloatingIP *IPvAny `json:"floatingIP"`
+	FloatingIP *IPvAny `json:"floatingIP,omitempty"`
 
 	// portRef is a reference to the ORC Port which this resource is associated with.
 	// +optional


### PR DESCRIPTION
New FloatingIP type has an optional field in resource.spec called `FloatingIP` but it's currently missing `omitempty` json tag, which causes issues when trying to create a new instance using server side apply with this field in null