### PR TITLE
Fix verify-govulncheck

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -265,7 +265,7 @@ verify-container-images: ## Verify container images
 	TRACE=$(TRACE) ./hack/verify-container-images.sh $(TRIVY_VERSION)
 
 .PHONY: verify-govulncheck
-verify-govulncheck: $(GOVULNCHECK) ## Verify code for vulnerabilities
+verify-govulncheck: govulncheck ## Verify code for vulnerabilities
 	$(GOVULNCHECK) ./... && R1=$$? || R1=$$?; \
 	if [ "$$R1" -ne "0" ]; then \
 		exit 1; \


### PR DESCRIPTION
As you can see, I got the "prerequisite" wrong for the verify-govulncheck target in the Makefile.
https://github.com/k-orc/openstack-resource-controller/actions/runs/15108667183/job/42462914639#step:5:192

I had govulncheck already installed when I tried it locally, so of course I didn't catch it...