### PR TITLE
Add security scan using govulncheck and trivy

### DIFF
--- a/.github/workflows/e2e.yaml
+++ b/.github/workflows/e2e.yaml
@@ -40,7 +40,7 @@ jobs:
 
     - name: Build and push a container image to Kind
       run: |
-        docker build -t ${{ env.image_tag }} .
+        make docker-build IMG=${{ env.image_tag }}
         kind load docker-image ${{ env.image_tag }} ${{ env.image_tag }} --name orc
 
     - name: Deploy orc

--- a/.gitignore
+++ b/.gitignore
@@ -22,6 +22,7 @@ Dockerfile.cross
 *.swp
 *.swo
 *~
+.devcontainer
 
 # website dynamic assets
 /venv

--- a/Dockerfile
+++ b/Dockerfile
@@ -1,5 +1,6 @@
 # Build the manager binary
-FROM golang:1.23 AS builder
+ARG GO_VERSION="1.23"
+FROM golang:${GO_VERSION} AS builder
 ARG TARGETOS
 ARG TARGETARCH
 

--- a/hack/ensure-trivy.sh
+++ b/hack/ensure-trivy.sh
@@ -1,0 +1,57 @@
+#!/bin/bash
+
+# Copyright 2023 The Kubernetes Authors.
+#
+# Licensed under the Apache License, Version 2.0 (the "License");
+# you may not use this file except in compliance with the License.
+# You may obtain a copy of the License at
+#
+# 	http://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing, software
+# distributed under the License is distributed on an "AS IS" BASIS,
+# WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+# See the License for the specific language governing permissions and
+# limitations under the License.
+
+set -o errexit
+set -o nounset
+set -o pipefail
+
+if [[ "${TRACE-0}" == "1" ]]; then
+    set -o xtrace
+fi
+
+VERSION=${1}
+
+GO_OS="$(go env GOOS)"
+if [[ "${GO_OS}" == "linux" ]]; then
+  TRIVY_OS="Linux"
+elif [[ "${GO_OS}" == "darwin"* ]]; then
+  TRIVY_OS="macOS"
+fi
+
+GO_ARCH="$(go env GOARCH)"
+if [[ "${GO_ARCH}" == "amd" ]]; then
+  TRIVY_ARCH="32bit"
+elif [[ "${GO_ARCH}" == "amd64"* ]]; then
+  TRIVY_ARCH="64bit"
+elif [[ "${GO_ARCH}" == "arm" ]]; then
+  TRIVY_ARCH="ARM"
+elif [[ "${GO_ARCH}" == "arm64" ]]; then
+  TRIVY_ARCH="ARM64"
+fi
+
+TOOL_BIN=bin
+mkdir -p ${TOOL_BIN}
+
+TRIVY="${TOOL_BIN}/trivy/${VERSION}/trivy"
+
+# Downloads trivy scanner
+if [ ! -f "$TRIVY" ]; then
+  curl -L -o ${TOOL_BIN}/trivy.tar.gz "https://github.com/aquasecurity/trivy/releases/download/v${VERSION}/trivy_${VERSION}_${TRIVY_OS}-${TRIVY_ARCH}.tar.gz"
+  mkdir -p "${TOOL_BIN}/trivy/${VERSION}"
+  tar -xf "${TOOL_BIN}/trivy.tar.gz" -C "${TOOL_BIN}/trivy/${VERSION}" trivy
+  chmod +x "${TOOL_BIN}/trivy/${VERSION}/trivy"
+  rm "${TOOL_BIN}/trivy.tar.gz"
+fi

--- a/hack/verify-container-images.sh
+++ b/hack/verify-container-images.sh
@@ -1,0 +1,51 @@
+#!/bin/bash
+
+# Copyright 2022 The Kubernetes Authors.
+#
+# Licensed under the Apache License, Version 2.0 (the "License");
+# you may not use this file except in compliance with the License.
+# You may obtain a copy of the License at
+#
+# 	http://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing, software
+# distributed under the License is distributed on an "AS IS" BASIS,
+# WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+# See the License for the specific language governing permissions and
+# limitations under the License.
+
+set -o errexit
+set -o nounset
+set -o pipefail
+
+if [[ "${TRACE-0}" == "1" ]]; then
+    set -o xtrace
+fi
+
+VERSION=${1}
+GO_ARCH="$(go env GOARCH)"
+DB_MIRROR="public.ecr.aws/aquasecurity/trivy-db"
+
+REPO_ROOT=$(git rev-parse --show-toplevel)
+"${REPO_ROOT}/hack/ensure-trivy.sh" "${VERSION}"
+
+TRIVY="${REPO_ROOT}/bin/trivy/${VERSION}/trivy"
+
+# Build the container image to be scanned
+make IMG=quay.io/orc/openstack-resource-controller-${GO_ARCH}:dev docker-build
+
+# Scan the images
+"${TRIVY}" image --db-repository="${DB_MIRROR}" -q --exit-code 1 --ignore-unfixed --severity MEDIUM,HIGH,CRITICAL quay.io/orc/openstack-resource-controller-"${GO_ARCH}":dev && R1=$? || R1=$?
+
+echo ""
+BRed='\033[1;31m'
+BGreen='\033[1;32m'
+NC='\033[0m' # No
+
+if [ "$R1" -ne "0" ]
+then
+  echo -e "${BRed}Check container images failed! There are vulnerabilities to be fixed${NC}"
+  exit 1
+fi
+
+echo -e "${BGreen}Check container images passed! No vulnerability found${NC}"


### PR DESCRIPTION
This is essentially a manual backport of https://github.com/k-orc/openstack-resource-controller/pull/396 and https://github.com/k-orc/openstack-resource-controller/pull/405, minus the actual github workflow, since that is anyway only run on main.

This adds a new make target "verify-security" that runs govulncheck agains the code base and also builds the contaier image and scans it with trivy. I tried keeping things similar to how they are done elsewhere in the code. This is all based on how they do it in Cluster API (hence the copyright text in the scripts).

Probably the most controversial thing here is that I added the GO_VERSION variable. The idea is to make sure we know what exact version is used.