### PR TITLE
image: Poll until image is ready

### DIFF
--- a/internal/controllers/image/status.go
+++ b/internal/controllers/image/status.go
@@ -69,7 +69,7 @@ func (imageStatusWriter) ResourceAvailableStatus(orcObject orcObjectPT, osResour
 	if osResource.Status == images.ImageStatusActive {
 		return metav1.ConditionTrue, nil
 	}
-	return metav1.ConditionFalse, nil
+	return metav1.ConditionFalse, progress.WaitingOnOpenStack(progress.WaitingOnReady, externalUpdatePollingPeriod)
 }
 
 func (imageStatusWriter) ApplyResourceStatus(log logr.Logger, osResource *osResourceT, statusApply statusApplyPT) {


### PR DESCRIPTION
This fixes the import of image, where the status may not reflect the real status of the resource. This is essentially the same fix as for [1], but for images.

We didn't see failures in our CI, presumably because we're using very small images, however this was seen in CAPO, when bumping to ORC 2.1.0 [2].

[1] https://github.com/k-orc/openstack-resource-controller/issues/280
[2] https://github.com/kubernetes-sigs/cluster-api-provider-openstack/pull/2552