### PR TITLE
floating IP: Add support for projectRef

### DIFF
--- a/api/v1alpha1/floatingip_types.go
+++ b/api/v1alpha1/floatingip_types.go
@@ -35,6 +35,11 @@ type FloatingIPFilter struct {
 	// +optional
 	PortRef *KubernetesNameRef `json:"portRef,omitempty"`
 
+	// projectRef is a reference to the ORC Project this resource is associated with.
+	// Typically, only used by admin.
+	// +optional
+	ProjectRef *KubernetesNameRef `json:"projectRef,omitempty"`
+
 	// status is the status of the floatingip.
 	// +kubebuilder:validation:MaxLength=1024
 	// +optional
@@ -77,6 +82,11 @@ type FloatingIPResourceSpec struct {
 	// fixedIP is the IP address of the port to which the floatingip is associated.
 	// +optional
 	FixedIP *IPvAny `json:"fixedIP,omitempty"`
+
+	// projectRef is a reference to the ORC Project this resource is associated with.
+	// Typically, only used by admin.
+	// +optional
+	ProjectRef *KubernetesNameRef `json:"projectRef,omitempty"`
 }
 
 type FloatingIPResourceStatus struct {

--- a/api/v1alpha1/zz_generated.deepcopy.go
+++ b/api/v1alpha1/zz_generated.deepcopy.go
@@ -582,6 +582,11 @@ func (in *FloatingIPFilter) DeepCopyInto(out *FloatingIPFilter) {
 		*out = new(KubernetesNameRef)
 		**out = **in
 	}
+	if in.ProjectRef != nil {
+		in, out := &in.ProjectRef, &out.ProjectRef
+		*out = new(KubernetesNameRef)
+		**out = **in
+	}
 	in.FilterByNeutronTags.DeepCopyInto(&out.FilterByNeutronTags)
 }
 
@@ -688,6 +693,11 @@ func (in *FloatingIPResourceSpec) DeepCopyInto(out *FloatingIPResourceSpec) {
 	if in.FixedIP != nil {
 		in, out := &in.FixedIP, &out.FixedIP
 		*out = new(IPvAny)
+		**out = **in
+	}
+	if in.ProjectRef != nil {
+		in, out := &in.ProjectRef, &out.ProjectRef
+		*out = new(KubernetesNameRef)
 		**out = **in
 	}
 }

--- a/cmd/models-schema/zz_generated.openapi.go
+++ b/cmd/models-schema/zz_generated.openapi.go
@@ -1437,6 +1437,13 @@ func schema_openstack_resource_controller_v2_api_v1alpha1_FloatingIPFilter(ref c
 							Format:      "",
 						},
 					},
+					"projectRef": {
+						SchemaProps: spec.SchemaProps{
+							Description: "projectRef is a reference to the ORC Project this resource is associated with. Typically, only used by admin.",
+							Type:        []string{"string"},
+							Format:      "",
+						},
+					},
 					"status": {
 						SchemaProps: spec.SchemaProps{
 							Description: "status is the status of the floatingip.",
@@ -1674,6 +1681,13 @@ func schema_openstack_resource_controller_v2_api_v1alpha1_FloatingIPResourceSpec
 					"fixedIP": {
 						SchemaProps: spec.SchemaProps{
 							Description: "fixedIP is the IP address of the port to which the floatingip is associated.",
+							Type:        []string{"string"},
+							Format:      "",
+						},
+					},
+					"projectRef": {
+						SchemaProps: spec.SchemaProps{
+							Description: "projectRef is a reference to the ORC Project this resource is associated with. Typically, only used by admin.",
 							Type:        []string{"string"},
 							Format:      "",
 						},

--- a/config/crd/bases/openstack.k-orc.cloud_floatingips.yaml
+++ b/config/crd/bases/openstack.k-orc.cloud_floatingips.yaml
@@ -145,6 +145,13 @@ spec:
                         maxLength: 253
                         minLength: 1
                         type: string
+                      projectRef:
+                        description: |-
+                          projectRef is a reference to the ORC Project this resource is associated with.
+                          Typically, only used by admin.
+                        maxLength: 253
+                        minLength: 1
+                        type: string
                       status:
                         description: status is the status of the floatingip.
                         maxLength: 1024
@@ -259,6 +266,13 @@ spec:
                   portRef:
                     description: portRef is a reference to the ORC Port which this
                       resource is associated with.
+                    maxLength: 253
+                    minLength: 1
+                    type: string
+                  projectRef:
+                    description: |-
+                      projectRef is a reference to the ORC Project this resource is associated with.
+                      Typically, only used by admin.
                     maxLength: 253
                     minLength: 1
                     type: string

--- a/internal/controllers/floatingip/tests/floatingip-create-full/00-assert.yaml
+++ b/internal/controllers/floatingip/tests/floatingip-create-full/00-assert.yaml
@@ -18,10 +18,15 @@ resourceRefs:
       kind: Port
       name: floatingip-create-full
       ref: port
+    - apiVersion: openstack.k-orc.cloud/v1alpha1
+      kind: project
+      name: floatingip-create-full
+      ref: project
 assertAll:
     - celExpr: "floatingIP.status.resource.floatingNetworkID == network.status.id"
     - celExpr: "floatingIP.status.resource.portID == port.status.id"
     - celExpr: "floatingIP.status.resource.routerID == router.status.id"
+    - celExpr: "floatingIP.status.resource.projectID == project.status.id"
 ---
 apiVersion: openstack.k-orc.cloud/v1alpha1
 kind: FloatingIP

--- a/internal/controllers/floatingip/tests/floatingip-create-full/00-floating-ip.yaml
+++ b/internal/controllers/floatingip/tests/floatingip-create-full/00-floating-ip.yaml
@@ -107,3 +107,4 @@ spec:
     floatingIP: 192.168.155.5
     tags:
       - tag1
+    projectRef: floatingip-create-full

--- a/internal/controllers/floatingip/tests/floatingip-create-full/00-floating-ip.yaml
+++ b/internal/controllers/floatingip/tests/floatingip-create-full/00-floating-ip.yaml
@@ -20,7 +20,6 @@ spec:
     secretName: openstack-clouds
   managementPolicy: managed
   resource:
-    name: floatingip-create-full-external
     external: true
 ---
 apiVersion: openstack.k-orc.cloud/v1alpha1
@@ -38,7 +37,7 @@ spec:
     cidr: 192.168.155.0/24
 ---
 apiVersion: openstack.k-orc.cloud/v1alpha1
-kind: Network
+kind: Router
 metadata:
   name: floatingip-create-full
 spec:
@@ -47,7 +46,19 @@ spec:
     secretName: openstack-clouds
   managementPolicy: managed
   resource:
-    name: floatingip-create-full
+    externalGateways:
+      - networkRef: floatingip-create-full-external
+---
+apiVersion: openstack.k-orc.cloud/v1alpha1
+kind: Network
+metadata:
+  name: floatingip-create-full
+spec:
+  cloudCredentialsRef:
+    cloudName: openstack-admin
+    secretName: openstack-clouds
+  managementPolicy: managed
+  resource: {}
 ---
 apiVersion: openstack.k-orc.cloud/v1alpha1
 kind: Subnet
@@ -60,6 +71,7 @@ spec:
   managementPolicy: managed
   resource:
     networkRef: floatingip-create-full
+    routerRef: floatingip-create-full
     ipVersion: 4
     cidr: 10.0.0.0/24
 ---
@@ -77,30 +89,6 @@ spec:
     addresses:
       - subnetRef: floatingip-create-full
         ip: 10.0.0.10
----
-apiVersion: openstack.k-orc.cloud/v1alpha1
-kind: Router
-metadata:
-  name: floatingip-create-full
-spec:
-  cloudCredentialsRef:
-    cloudName: openstack-admin
-    secretName: openstack-clouds
-  managementPolicy: managed
-  resource:
-    name: floatingip-create-full
-    adminStateUp: false
-    externalGateways:
-      - networkRef: floatingip-create-full-external
----
-apiVersion: openstack.k-orc.cloud/v1alpha1
-kind: RouterInterface
-metadata:
-  name: floatingip-create-full
-spec:
-  type: Subnet
-  routerRef: floatingip-create-full
-  subnetRef: floatingip-create-full
 ---
 apiVersion: openstack.k-orc.cloud/v1alpha1
 kind: FloatingIP

--- a/internal/controllers/floatingip/tests/floatingip-create-minimal/00-floating-ip.yaml
+++ b/internal/controllers/floatingip/tests/floatingip-create-minimal/00-floating-ip.yaml
@@ -1,16 +1,5 @@
 ---
 apiVersion: openstack.k-orc.cloud/v1alpha1
-kind: Project
-metadata:
-  name: floatingip-create-minimal
-spec:
-  cloudCredentialsRef:
-    cloudName: openstack-admin
-    secretName: openstack-clouds
-  managementPolicy: managed
-  resource: {}
----
-apiVersion: openstack.k-orc.cloud/v1alpha1
 kind: Network
 metadata:
   name: floatingip-create-minimal
@@ -20,7 +9,6 @@ spec:
     secretName: openstack-clouds
   managementPolicy: managed
   resource:
-    name: floatingip-create-minimal
     external: true
 ---
 apiVersion: openstack.k-orc.cloud/v1alpha1

--- a/internal/controllers/floatingip/tests/floatingip-create-subnet-ref/00-floating-ip.yaml
+++ b/internal/controllers/floatingip/tests/floatingip-create-subnet-ref/00-floating-ip.yaml
@@ -20,7 +20,6 @@ spec:
     secretName: openstack-clouds
   managementPolicy: managed
   resource:
-    name: floatingip-create-subnet-ref
     external: true
 ---
 apiVersion: openstack.k-orc.cloud/v1alpha1

--- a/internal/controllers/floatingip/tests/floatingip-dependency/00-assert.yaml
+++ b/internal/controllers/floatingip/tests/floatingip-dependency/00-assert.yaml
@@ -1,0 +1,75 @@
+---
+apiVersion: openstack.k-orc.cloud/v1alpha1
+kind: FloatingIP
+metadata:
+  name: floatingip-dependency-no-secret
+status:
+  conditions:
+    - type: Available
+      message: Waiting for Secret/floatingip-dependency to be created
+      status: "False"
+      reason: Progressing
+    - type: Progressing
+      message: Waiting for Secret/floatingip-dependency to be created
+      status: "True"
+      reason: Progressing
+---
+apiVersion: openstack.k-orc.cloud/v1alpha1
+kind: FloatingIP
+metadata:
+  name: floatingip-dependency-no-network
+status:
+  conditions:
+    - type: Available
+      message: Waiting for Network/floatingip-dependency-external-pending to be created
+      status: "False"
+      reason: Progressing
+    - type: Progressing
+      message: Waiting for Network/floatingip-dependency-external-pending to be created
+      status: "True"
+      reason: Progressing
+---
+apiVersion: openstack.k-orc.cloud/v1alpha1
+kind: FloatingIP
+metadata:
+  name: floatingip-dependency-no-subnet
+status:
+  conditions:
+    - type: Available
+      message: Waiting for Subnet/floatingip-dependency-external-pending to be created
+      status: "False"
+      reason: Progressing
+    - type: Progressing
+      message: Waiting for Subnet/floatingip-dependency-external-pending to be created
+      status: "True"
+      reason: Progressing
+---
+apiVersion: openstack.k-orc.cloud/v1alpha1
+kind: FloatingIP
+metadata:
+  name: floatingip-dependency-no-port
+status:
+  conditions:
+    - type: Available
+      message: Waiting for Port/floatingip-dependency to be created
+      status: "False"
+      reason: Progressing
+    - type: Progressing
+      message: Waiting for Port/floatingip-dependency to be created
+      status: "True"
+      reason: Progressing
+---
+apiVersion: openstack.k-orc.cloud/v1alpha1
+kind: FloatingIP
+metadata:
+  name: floatingip-dependency-no-project
+status:
+  conditions:
+    - type: Available
+      message: Waiting for Project/floatingip-dependency to be created
+      status: "False"
+      reason: Progressing
+    - type: Progressing
+      message: Waiting for Project/floatingip-dependency to be created
+      status: "True"
+      reason: Progressing

--- a/internal/controllers/floatingip/tests/floatingip-dependency/00-create-resources-missing-deps.yaml
+++ b/internal/controllers/floatingip/tests/floatingip-dependency/00-create-resources-missing-deps.yaml
@@ -1,0 +1,127 @@
+---
+apiVersion: openstack.k-orc.cloud/v1alpha1
+kind: Network
+metadata:
+  name: floatingip-dependency-external
+spec:
+  cloudCredentialsRef:
+    cloudName: openstack-admin
+    secretName: openstack-clouds
+  managementPolicy: managed
+  resource:
+    external: true
+---
+apiVersion: openstack.k-orc.cloud/v1alpha1
+kind: Subnet
+metadata:
+  name: floatingip-dependency-external
+spec:
+  cloudCredentialsRef:
+    cloudName: openstack
+    secretName: openstack-clouds
+  managementPolicy: managed
+  resource:
+    networkRef: floatingip-dependency-external
+    ipVersion: 4
+    cidr: 192.168.200.0/24
+---
+apiVersion: openstack.k-orc.cloud/v1alpha1
+kind: Router
+metadata:
+  name: floatingip-dependency
+spec:
+  cloudCredentialsRef:
+    cloudName: openstack
+    secretName: openstack-clouds
+  managementPolicy: managed
+  resource:
+    externalGateways:
+    - networkRef: floatingip-dependency-external
+---
+apiVersion: openstack.k-orc.cloud/v1alpha1
+kind: Network
+metadata:
+  name: floatingip-dependency
+spec:
+  cloudCredentialsRef:
+    cloudName: openstack
+    secretName: openstack-clouds
+  managementPolicy: managed
+  resource: {}
+---
+apiVersion: openstack.k-orc.cloud/v1alpha1
+kind: Subnet
+metadata:
+  name: floatingip-dependency
+spec:
+  cloudCredentialsRef:
+    cloudName: openstack
+    secretName: openstack-clouds
+  managementPolicy: managed
+  resource:
+    networkRef: floatingip-dependency
+    routerRef: floatingip-dependency
+    ipVersion: 4
+    cidr: 10.0.2.0/24
+---
+apiVersion: openstack.k-orc.cloud/v1alpha1
+kind: FloatingIP
+metadata:
+  name: floatingip-dependency-no-secret
+spec:
+  cloudCredentialsRef:
+    cloudName: openstack
+    secretName: floatingip-dependency
+  managementPolicy: managed
+  resource:
+    floatingNetworkRef: floatingip-dependency-external
+---
+apiVersion: openstack.k-orc.cloud/v1alpha1
+kind: FloatingIP
+metadata:
+  name: floatingip-dependency-no-network
+spec:
+  cloudCredentialsRef:
+    cloudName: openstack
+    secretName: openstack-clouds
+  managementPolicy: managed
+  resource:
+    floatingNetworkRef: floatingip-dependency-external-pending
+---
+apiVersion: openstack.k-orc.cloud/v1alpha1
+kind: FloatingIP
+metadata:
+  name: floatingip-dependency-no-subnet
+spec:
+  cloudCredentialsRef:
+    cloudName: openstack
+    secretName: openstack-clouds
+  managementPolicy: managed
+  resource:
+    floatingSubnetRef: floatingip-dependency-external-pending
+---
+apiVersion: openstack.k-orc.cloud/v1alpha1
+kind: FloatingIP
+metadata:
+  name: floatingip-dependency-no-port
+spec:
+  cloudCredentialsRef:
+    cloudName: openstack
+    secretName: openstack-clouds
+  managementPolicy: managed
+  resource:
+    floatingSubnetRef: floatingip-dependency-external
+    portRef: floatingip-dependency
+---
+apiVersion: openstack.k-orc.cloud/v1alpha1
+kind: FloatingIP
+metadata:
+  name: floatingip-dependency-no-project
+spec:
+  cloudCredentialsRef:
+    cloudName: openstack-admin
+    secretName: openstack-clouds
+  managementPolicy: managed
+  resource:
+    floatingNetworkRef: floatingip-dependency-external
+    projectRef: floatingip-dependency

--- a/internal/controllers/floatingip/tests/floatingip-dependency/00-secret.yaml
+++ b/internal/controllers/floatingip/tests/floatingip-dependency/00-secret.yaml
@@ -1,0 +1,5 @@
+apiVersion: kuttl.dev/v1beta1
+kind: TestStep
+commands:
+  - command: kubectl create secret generic openstack-clouds --from-file=clouds.yaml=${E2E_KUTTL_OSCLOUDS} ${E2E_KUTTL_CACERT_OPT}
+    namespaced: true

--- a/internal/controllers/floatingip/tests/floatingip-dependency/01-assert.yaml
+++ b/internal/controllers/floatingip/tests/floatingip-dependency/01-assert.yaml
@@ -1,0 +1,75 @@
+---
+apiVersion: openstack.k-orc.cloud/v1alpha1
+kind: FloatingIP
+metadata:
+  name: floatingip-dependency-no-secret
+status:
+  conditions:
+    - type: Available
+      message: OpenStack resource is available
+      status: "True"
+      reason: Success
+    - type: Progressing
+      message: OpenStack resource is up to date
+      status: "False"
+      reason: Success
+---
+apiVersion: openstack.k-orc.cloud/v1alpha1
+kind: FloatingIP
+metadata:
+  name: floatingip-dependency-no-network
+status:
+  conditions:
+    - type: Available
+      message: OpenStack resource is available
+      status: "True"
+      reason: Success
+    - type: Progressing
+      message: OpenStack resource is up to date
+      status: "False"
+      reason: Success
+---
+apiVersion: openstack.k-orc.cloud/v1alpha1
+kind: FloatingIP
+metadata:
+  name: floatingip-dependency-no-subnet
+status:
+  conditions:
+    - type: Available
+      message: OpenStack resource is available
+      status: "True"
+      reason: Success
+    - type: Progressing
+      message: OpenStack resource is up to date
+      status: "False"
+      reason: Success
+---
+apiVersion: openstack.k-orc.cloud/v1alpha1
+kind: FloatingIP
+metadata:
+  name: floatingip-dependency-no-port
+status:
+  conditions:
+    - type: Available
+      message: OpenStack resource is available
+      status: "True"
+      reason: Success
+    - type: Progressing
+      message: OpenStack resource is up to date
+      status: "False"
+      reason: Success
+---
+apiVersion: openstack.k-orc.cloud/v1alpha1
+kind: FloatingIP
+metadata:
+  name: floatingip-dependency-no-project
+status:
+  conditions:
+    - type: Available
+      message: OpenStack resource is available
+      status: "True"
+      reason: Success
+    - type: Progressing
+      message: OpenStack resource is up to date
+      status: "False"
+      reason: Success

--- a/internal/controllers/floatingip/tests/floatingip-dependency/01-create-dependencies.yaml
+++ b/internal/controllers/floatingip/tests/floatingip-dependency/01-create-dependencies.yaml
@@ -1,0 +1,71 @@
+---
+apiVersion: kuttl.dev/v1beta1
+kind: TestStep
+commands:
+  - command: kubectl create secret generic floatingip-dependency --from-file=clouds.yaml=${E2E_KUTTL_OSCLOUDS} ${E2E_KUTTL_CACERT_OPT}
+    namespaced: true
+---
+apiVersion: openstack.k-orc.cloud/v1alpha1
+kind: Network
+metadata:
+  name: floatingip-dependency-external-pending
+spec:
+  cloudCredentialsRef:
+    cloudName: openstack-admin
+    secretName: openstack-clouds
+  managementPolicy: managed
+  resource:
+    external: true
+---
+apiVersion: openstack.k-orc.cloud/v1alpha1
+kind: Subnet
+metadata:
+  name: floatingip-dependency-external-pending
+spec:
+  cloudCredentialsRef:
+    cloudName: openstack
+    secretName: openstack-clouds
+  managementPolicy: managed
+  resource:
+    networkRef: floatingip-dependency-external-pending
+    ipVersion: 4
+    cidr: 192.168.3.0/24
+---
+apiVersion: openstack.k-orc.cloud/v1alpha1
+kind: Router
+metadata:
+  name: floatingip-dependency-pending
+spec:
+  cloudCredentialsRef:
+    cloudName: openstack
+    secretName: openstack-clouds
+  managementPolicy: managed
+  resource:
+    externalGateways:
+    - networkRef: floatingip-dependency-external-pending
+---
+apiVersion: openstack.k-orc.cloud/v1alpha1
+kind: Port
+metadata:
+  name: floatingip-dependency
+spec:
+  cloudCredentialsRef:
+    cloudName: openstack
+    secretName: openstack-clouds
+  managementPolicy: managed
+  resource:
+    networkRef: floatingip-dependency
+    addresses:
+      - subnetRef: floatingip-dependency
+        ip: 10.0.2.10
+---
+apiVersion: openstack.k-orc.cloud/v1alpha1
+kind: Project
+metadata:
+  name: floatingip-dependency
+spec:
+  cloudCredentialsRef:
+    cloudName: openstack-admin
+    secretName: openstack-clouds
+  managementPolicy: managed
+  resource: {}

--- a/internal/controllers/floatingip/tests/floatingip-dependency/02-assert.yaml
+++ b/internal/controllers/floatingip/tests/floatingip-dependency/02-assert.yaml
@@ -1,0 +1,35 @@
+---
+apiVersion: kuttl.dev/v1beta1
+kind: TestAssert
+resourceRefs:
+    - apiVersion: openstack.k-orc.cloud/v1alpha1
+      kind: Network
+      name: floatingip-dependency-external
+      ref: network
+    - apiVersion: openstack.k-orc.cloud/v1alpha1
+      kind: Subnet
+      name: floatingip-dependency-external
+      ref: subnet
+    - apiVersion: openstack.k-orc.cloud/v1alpha1
+      kind: Port
+      name: floatingip-dependency
+      ref: port
+    - apiVersion: openstack.k-orc.cloud/v1alpha1
+      kind: Project
+      name: floatingip-dependency
+      ref: project
+    - apiVersion: v1
+      kind: Secret
+      name: floatingip-dependency
+      ref: secret
+assertAll:
+    - celExpr: "network.metadata.deletionTimestamp != 0"
+    - celExpr: "'openstack.k-orc.cloud/floatingip' in network.metadata.finalizers"
+    - celExpr: "subnet.metadata.deletionTimestamp != 0"
+    - celExpr: "'openstack.k-orc.cloud/floatingip' in subnet.metadata.finalizers"
+    - celExpr: "port.metadata.deletionTimestamp != 0"
+    - celExpr: "'openstack.k-orc.cloud/floatingip' in port.metadata.finalizers"
+    - celExpr: "project.metadata.deletionTimestamp != 0"
+    - celExpr: "'openstack.k-orc.cloud/floatingip' in project.metadata.finalizers"
+    - celExpr: "secret.metadata.deletionTimestamp != 0"
+    - celExpr: "'openstack.k-orc.cloud/floatingip' in secret.metadata.finalizers"

--- a/internal/controllers/floatingip/tests/floatingip-dependency/02-delete-dependencies.yaml
+++ b/internal/controllers/floatingip/tests/floatingip-dependency/02-delete-dependencies.yaml
@@ -1,0 +1,14 @@
+apiVersion: kuttl.dev/v1beta1
+kind: TestStep
+commands:
+  # We expect the deletion to hang due to the finalizer, so use --wait=false
+  - command: kubectl delete port floatingip-dependency --wait=false
+    namespaced: true
+  - command: kubectl delete subnet floatingip-dependency-external --wait=false
+    namespaced: true
+  - command: kubectl delete network floatingip-dependency-external --wait=false
+    namespaced: true
+  - command: kubectl delete project floatingip-dependency --wait=false
+    namespaced: true
+  - command: kubectl delete secret floatingip-dependency --wait=false
+    namespaced: true

--- a/internal/controllers/floatingip/tests/floatingip-dependency/03-assert.yaml
+++ b/internal/controllers/floatingip/tests/floatingip-dependency/03-assert.yaml
@@ -1,0 +1,14 @@
+apiVersion: kuttl.dev/v1beta1
+kind: TestAssert
+commands:
+# Dependencies that were prevented deletion before should now be gone
+- script: "! kubectl get port floatingip-dependency --namespace $NAMESPACE"
+  skipLogOutput: true
+- script: "! kubectl get subnet floatingip-dependency-external --namespace $NAMESPACE"
+  skipLogOutput: true
+- script: "! kubectl get network floatingip-dependency-external --namespace $NAMESPACE"
+  skipLogOutput: true
+- script: "! kubectl get project floatingip-dependency --namespace $NAMESPACE"
+  skipLogOutput: true
+- script: "! kubectl get secret floatingip-dependency --namespace $NAMESPACE"
+  skipLogOutput: true

--- a/internal/controllers/floatingip/tests/floatingip-dependency/03-delete-resources.yaml
+++ b/internal/controllers/floatingip/tests/floatingip-dependency/03-delete-resources.yaml
@@ -1,0 +1,26 @@
+apiVersion: kuttl.dev/v1beta1
+kind: TestStep
+delete:
+  # We need to delete the router if we want the floatingip-dependency-external subnet gone
+  # Also, need to delete the private subnet on which the router has an interface
+- apiVersion: openstack.k-orc.cloud/v1alpha1
+  kind: Subnet
+  name: floatingip-dependency
+- apiVersion: openstack.k-orc.cloud/v1alpha1
+  kind: Router
+  name: floatingip-dependency
+- apiVersion: openstack.k-orc.cloud/v1alpha1
+  kind: FloatingIP
+  name: floatingip-dependency-no-secret
+- apiVersion: openstack.k-orc.cloud/v1alpha1
+  kind: FloatingIP
+  name: floatingip-dependency-no-network
+- apiVersion: openstack.k-orc.cloud/v1alpha1
+  kind: FloatingIP
+  name: floatingip-dependency-no-subnet
+- apiVersion: openstack.k-orc.cloud/v1alpha1
+  kind: FloatingIP
+  name: floatingip-dependency-no-port
+- apiVersion: openstack.k-orc.cloud/v1alpha1
+  kind: FloatingIP
+  name: floatingip-dependency-no-project

--- a/internal/controllers/floatingip/tests/floatingip-dependency/README.md
+++ b/internal/controllers/floatingip/tests/floatingip-dependency/README.md
@@ -1,0 +1,21 @@
+# Creation and deletion dependencies
+
+## Step 00
+
+Create floating IPs referencing non-existing resources. Each floating IP is dependent on other non-existing resource. Verify that the floating IPs are waiting for the needed resources to be created externally.
+
+## Step 01
+
+Create the missing dependencies and make and verify all the floating IPs are available.
+
+## Step 02
+
+Delete all the dependencies and check that ORC prevents deletion since there is still a resource that depends on them.
+
+## Step 03
+
+Delete the floating IPs and validate that all resources are gone.
+
+## Reference
+
+https://k-orc.cloud/development/writing-tests/#dependency

--- a/internal/controllers/floatingip/tests/floatingip-import-dependency/00-assert.yaml
+++ b/internal/controllers/floatingip/tests/floatingip-import-dependency/00-assert.yaml
@@ -1,0 +1,21 @@
+---
+apiVersion: openstack.k-orc.cloud/v1alpha1
+kind: FloatingIP
+metadata:
+  name: floatingip-import-dependency
+status:
+  conditions:
+    - type: Available
+      message: |-
+        Waiting for Network/floatingip-import-dependency to be ready
+        Waiting for Port/floatingip-import-dependency to be ready
+        Waiting for Project/floatingip-import-dependency to be ready
+      status: "False"
+      reason: Progressing
+    - type: Progressing
+      message: |-
+        Waiting for Network/floatingip-import-dependency to be ready
+        Waiting for Port/floatingip-import-dependency to be ready
+        Waiting for Project/floatingip-import-dependency to be ready
+      status: "True"
+      reason: Progressing

--- a/internal/controllers/floatingip/tests/floatingip-import-dependency/00-import-resource.yaml
+++ b/internal/controllers/floatingip/tests/floatingip-import-dependency/00-import-resource.yaml
@@ -1,0 +1,56 @@
+---
+apiVersion: openstack.k-orc.cloud/v1alpha1
+kind: Project
+metadata:
+  name: floatingip-import-dependency
+spec:
+  cloudCredentialsRef:
+    cloudName: openstack-admin
+    secretName: openstack-clouds
+  managementPolicy: unmanaged
+  import:
+    filter:
+      name: floatingip-import-dependency-external
+---
+apiVersion: openstack.k-orc.cloud/v1alpha1
+kind: Network
+metadata:
+  name: floatingip-import-dependency
+spec:
+  cloudCredentialsRef:
+    cloudName: openstack-admin
+    secretName: openstack-clouds
+  managementPolicy: unmanaged
+  import:
+    filter:
+      name: floatingip-import-dependency-floating-external
+      projectRef: floatingip-import-dependency
+---
+apiVersion: openstack.k-orc.cloud/v1alpha1
+kind: Port
+metadata:
+  name: floatingip-import-dependency
+spec:
+  cloudCredentialsRef:
+    cloudName: openstack-admin
+    secretName: openstack-clouds
+  managementPolicy: unmanaged
+  import:
+    filter:
+      name: floatingip-import-dependency-external
+      projectRef: floatingip-import-dependency
+---
+apiVersion: openstack.k-orc.cloud/v1alpha1
+kind: FloatingIP
+metadata:
+  name: floatingip-import-dependency
+spec:
+  cloudCredentialsRef:
+    cloudName: openstack-admin
+    secretName: openstack-clouds
+  managementPolicy: unmanaged
+  import:
+    filter:
+      floatingNetworkRef: floatingip-import-dependency
+      portRef: floatingip-import-dependency
+      projectRef: floatingip-import-dependency

--- a/internal/controllers/floatingip/tests/floatingip-import-dependency/00-secret.yaml
+++ b/internal/controllers/floatingip/tests/floatingip-import-dependency/00-secret.yaml
@@ -1,0 +1,5 @@
+apiVersion: kuttl.dev/v1beta1
+kind: TestStep
+commands:
+  - command: kubectl create secret generic openstack-clouds --from-file=clouds.yaml=${E2E_KUTTL_OSCLOUDS} ${E2E_KUTTL_CACERT_OPT}
+    namespaced: true

--- a/internal/controllers/floatingip/tests/floatingip-import-dependency/01-assert.yaml
+++ b/internal/controllers/floatingip/tests/floatingip-import-dependency/01-assert.yaml
@@ -1,0 +1,36 @@
+---
+apiVersion: openstack.k-orc.cloud/v1alpha1
+kind: FloatingIP
+metadata:
+  name: floatingip-import-dependency-not-this-one
+status:
+  conditions:
+    - type: Available
+      message: OpenStack resource is available
+      status: "True"
+      reason: Success
+    - type: Progressing
+      message: OpenStack resource is up to date
+      status: "False"
+      reason: Success
+---
+apiVersion: openstack.k-orc.cloud/v1alpha1
+kind: FloatingIP
+metadata:
+  name: floatingip-import-dependency
+status:
+  conditions:
+    - type: Available
+      message: |-
+        Waiting for Network/floatingip-import-dependency to be ready
+        Waiting for Port/floatingip-import-dependency to be ready
+        Waiting for Project/floatingip-import-dependency to be ready
+      status: "False"
+      reason: Progressing
+    - type: Progressing
+      message: |-
+        Waiting for Network/floatingip-import-dependency to be ready
+        Waiting for Port/floatingip-import-dependency to be ready
+        Waiting for Project/floatingip-import-dependency to be ready
+      status: "True"
+      reason: Progressing

--- a/internal/controllers/floatingip/tests/floatingip-import-dependency/01-create-trap-resource.yaml
+++ b/internal/controllers/floatingip/tests/floatingip-import-dependency/01-create-trap-resource.yaml
@@ -1,0 +1,112 @@
+---
+apiVersion: openstack.k-orc.cloud/v1alpha1
+kind: Project
+metadata:
+  name: floatingip-import-dependency-not-this-one
+spec:
+  cloudCredentialsRef:
+    cloudName: openstack-admin
+    secretName: openstack-clouds
+  managementPolicy: managed
+  resource: {}
+---
+apiVersion: openstack.k-orc.cloud/v1alpha1
+kind: Network
+metadata:
+  name: floatingip-import-dependency-floating-not-this-one
+spec:
+  cloudCredentialsRef:
+    cloudName: openstack-admin
+    secretName: openstack-clouds
+  managementPolicy: managed
+  resource:
+    projectRef: floatingip-import-dependency-not-this-one
+    external: true
+---
+apiVersion: openstack.k-orc.cloud/v1alpha1
+kind: Subnet
+metadata:
+  name: floatingip-import-dependency-floating-not-this-one
+spec:
+  cloudCredentialsRef:
+    cloudName: openstack-admin
+    secretName: openstack-clouds
+  managementPolicy: managed
+  resource:
+    networkRef: floatingip-import-dependency-floating-not-this-one
+    projectRef: floatingip-import-dependency-not-this-one
+    ipVersion: 4
+    cidr: 192.168.120.0/24
+---
+apiVersion: openstack.k-orc.cloud/v1alpha1
+kind: Router
+metadata:
+  name: floatingip-import-dependency-not-this-one
+spec:
+  cloudCredentialsRef:
+    cloudName: openstack-admin
+    secretName: openstack-clouds
+  managementPolicy: managed
+  resource:
+    externalGateways:
+      - networkRef: floatingip-import-dependency-floating-not-this-one
+    projectRef: floatingip-import-dependency-not-this-one
+---
+apiVersion: openstack.k-orc.cloud/v1alpha1
+kind: Network
+metadata:
+  name: floatingip-import-dependency-not-this-one
+spec:
+  cloudCredentialsRef:
+    cloudName: openstack-admin
+    secretName: openstack-clouds
+  managementPolicy: managed
+  resource:
+    projectRef: floatingip-import-dependency-not-this-one
+---
+apiVersion: openstack.k-orc.cloud/v1alpha1
+kind: Subnet
+metadata:
+  name: floatingip-import-dependency-not-this-one
+spec:
+  cloudCredentialsRef:
+    cloudName: openstack-admin
+    secretName: openstack-clouds
+  managementPolicy: managed
+  resource:
+    networkRef: floatingip-import-dependency-not-this-one
+    routerRef: floatingip-import-dependency-not-this-one
+    projectRef: floatingip-import-dependency-not-this-one
+    ipVersion: 4
+    cidr: 10.0.0.0/24
+---
+apiVersion: openstack.k-orc.cloud/v1alpha1
+kind: Port
+metadata:
+  name: floatingip-import-dependency-not-this-one
+spec:
+  cloudCredentialsRef:
+    cloudName: openstack-admin
+    secretName: openstack-clouds
+  managementPolicy: managed
+  resource:
+    networkRef: floatingip-import-dependency-not-this-one
+    addresses:
+      - subnetRef: floatingip-import-dependency-not-this-one
+        ip: 10.0.0.10
+    projectRef: floatingip-import-dependency-not-this-one
+---
+# This `floatingip-import-dependency-not-this-one` should not be picked by the import filter
+apiVersion: openstack.k-orc.cloud/v1alpha1
+kind: FloatingIP
+metadata:
+  name: floatingip-import-dependency-not-this-one
+spec:
+  cloudCredentialsRef:
+    cloudName: openstack-admin
+    secretName: openstack-clouds
+  managementPolicy: managed
+  resource:
+    floatingNetworkRef: floatingip-import-dependency-floating-not-this-one
+    portRef: floatingip-import-dependency-not-this-one
+    projectRef: floatingip-import-dependency-not-this-one

--- a/internal/controllers/floatingip/tests/floatingip-import-dependency/02-assert.yaml
+++ b/internal/controllers/floatingip/tests/floatingip-import-dependency/02-assert.yaml
@@ -1,0 +1,44 @@
+---
+apiVersion: kuttl.dev/v1beta1
+kind: TestAssert
+resourceRefs:
+    - apiVersion: openstack.k-orc.cloud/v1alpha1
+      kind: FloatingIP
+      name: floatingip-import-dependency
+      ref: fip1
+    - apiVersion: openstack.k-orc.cloud/v1alpha1
+      kind: FloatingIP
+      name: floatingip-import-dependency-not-this-one
+      ref: fip2
+    - apiVersion: openstack.k-orc.cloud/v1alpha1
+      kind: Network
+      name: floatingip-import-dependency
+      ref: network
+    - apiVersion: openstack.k-orc.cloud/v1alpha1
+      kind: Port
+      name: floatingip-import-dependency
+      ref: port
+    - apiVersion: openstack.k-orc.cloud/v1alpha1
+      kind: Project
+      name: floatingip-import-dependency
+      ref: project
+assertAll:
+    - celExpr: "fip1.status.id != fip2.status.id"
+    - celExpr: "fip1.status.resource.floatingNetworkID == network.status.id"
+    - celExpr: "fip1.status.resource.portID == port.status.id"
+    - celExpr: "fip1.status.resource.projectID == project.status.id"
+---
+apiVersion: openstack.k-orc.cloud/v1alpha1
+kind: FloatingIP
+metadata:
+  name: floatingip-import-dependency
+status:
+  conditions:
+    - type: Available
+      message: OpenStack resource is available
+      status: "True"
+      reason: Success
+    - type: Progressing
+      message: OpenStack resource is up to date
+      status: "False"
+      reason: Success

--- a/internal/controllers/floatingip/tests/floatingip-import-dependency/02-create-resource.yaml
+++ b/internal/controllers/floatingip/tests/floatingip-import-dependency/02-create-resource.yaml
@@ -1,0 +1,111 @@
+---
+apiVersion: openstack.k-orc.cloud/v1alpha1
+kind: Project
+metadata:
+  name: floatingip-import-dependency-external
+spec:
+  cloudCredentialsRef:
+    cloudName: openstack-admin
+    secretName: openstack-clouds
+  managementPolicy: managed
+  resource: {}
+---
+apiVersion: openstack.k-orc.cloud/v1alpha1
+kind: Network
+metadata:
+  name: floatingip-import-dependency-floating-external
+spec:
+  cloudCredentialsRef:
+    cloudName: openstack-admin
+    secretName: openstack-clouds
+  managementPolicy: managed
+  resource:
+    projectRef: floatingip-import-dependency-external
+    external: true
+---
+apiVersion: openstack.k-orc.cloud/v1alpha1
+kind: Subnet
+metadata:
+  name: floatingip-import-dependency-floating-external
+spec:
+  cloudCredentialsRef:
+    cloudName: openstack-admin
+    secretName: openstack-clouds
+  managementPolicy: managed
+  resource:
+    networkRef: floatingip-import-dependency-floating-external
+    projectRef: floatingip-import-dependency-external
+    ipVersion: 4
+    cidr: 192.168.220.0/24
+---
+apiVersion: openstack.k-orc.cloud/v1alpha1
+kind: Router
+metadata:
+  name: floatingip-import-dependency-external
+spec:
+  cloudCredentialsRef:
+    cloudName: openstack-admin
+    secretName: openstack-clouds
+  managementPolicy: managed
+  resource:
+    externalGateways:
+      - networkRef: floatingip-import-dependency-floating-external
+    projectRef: floatingip-import-dependency-external
+---
+apiVersion: openstack.k-orc.cloud/v1alpha1
+kind: Network
+metadata:
+  name: floatingip-import-dependency-external
+spec:
+  cloudCredentialsRef:
+    cloudName: openstack-admin
+    secretName: openstack-clouds
+  managementPolicy: managed
+  resource:
+    projectRef: floatingip-import-dependency-external
+---
+apiVersion: openstack.k-orc.cloud/v1alpha1
+kind: Subnet
+metadata:
+  name: floatingip-import-dependency-external
+spec:
+  cloudCredentialsRef:
+    cloudName: openstack-admin
+    secretName: openstack-clouds
+  managementPolicy: managed
+  resource:
+    networkRef: floatingip-import-dependency-external
+    routerRef: floatingip-import-dependency-external
+    projectRef: floatingip-import-dependency-external
+    ipVersion: 4
+    cidr: 10.0.100.0/24
+---
+apiVersion: openstack.k-orc.cloud/v1alpha1
+kind: Port
+metadata:
+  name: floatingip-import-dependency-external
+spec:
+  cloudCredentialsRef:
+    cloudName: openstack-admin
+    secretName: openstack-clouds
+  managementPolicy: managed
+  resource:
+    networkRef: floatingip-import-dependency-external
+    addresses:
+      - subnetRef: floatingip-import-dependency-external
+        ip: 10.0.100.10
+    projectRef: floatingip-import-dependency-external
+---
+apiVersion: openstack.k-orc.cloud/v1alpha1
+kind: FloatingIP
+metadata:
+  name: floatingip-import-dependency-external
+spec:
+  cloudCredentialsRef:
+    cloudName: openstack-admin
+    secretName: openstack-clouds
+  managementPolicy: managed
+  resource:
+    floatingNetworkRef: floatingip-import-dependency-floating-external
+    portRef: floatingip-import-dependency-external
+    projectRef: floatingip-import-dependency-external

--- a/internal/controllers/floatingip/tests/floatingip-import-dependency/03-assert.yaml
+++ b/internal/controllers/floatingip/tests/floatingip-import-dependency/03-assert.yaml
@@ -1,0 +1,10 @@
+---
+apiVersion: kuttl.dev/v1beta1
+kind: TestAssert
+commands:
+- script: "! kubectl get network floatingip-import-dependency --namespace $NAMESPACE"
+  skipLogOutput: true
+- script: "! kubectl get port floatingip-import-dependency --namespace $NAMESPACE"
+  skipLogOutput: true
+- script: "! kubectl get project floatingip-import-dependency --namespace $NAMESPACE"
+  skipLogOutput: true

--- a/internal/controllers/floatingip/tests/floatingip-import-dependency/03-delete-import-dependencies.yaml
+++ b/internal/controllers/floatingip/tests/floatingip-import-dependency/03-delete-import-dependencies.yaml
@@ -1,0 +1,10 @@
+apiVersion: kuttl.dev/v1beta1
+kind: TestStep
+commands:
+  # We should be able to delete the import dependencies
+  - command: kubectl delete network floatingip-import-dependency
+    namespaced: true
+  - command: kubectl delete port floatingip-import-dependency
+    namespaced: true
+  - command: kubectl delete project floatingip-import-dependency
+    namespaced: true

--- a/internal/controllers/floatingip/tests/floatingip-import-dependency/04-assert.yaml
+++ b/internal/controllers/floatingip/tests/floatingip-import-dependency/04-assert.yaml
@@ -1,0 +1,5 @@
+apiVersion: kuttl.dev/v1beta1
+kind: TestAssert
+commands:
+- script: "! kubectl get floatingip floatingip-import-dependency --namespace $NAMESPACE"
+  skipLogOutput: true

--- a/internal/controllers/floatingip/tests/floatingip-import-dependency/04-delete-resource.yaml
+++ b/internal/controllers/floatingip/tests/floatingip-import-dependency/04-delete-resource.yaml
@@ -1,0 +1,6 @@
+apiVersion: kuttl.dev/v1beta1
+kind: TestStep
+delete:
+  - apiVersion: openstack.k-orc.cloud/v1alpha1
+    kind: FloatingIP
+    name: floatingip-import-dependency

--- a/internal/controllers/floatingip/tests/floatingip-import-dependency/README.md
+++ b/internal/controllers/floatingip/tests/floatingip-import-dependency/README.md
@@ -1,0 +1,29 @@
+# Check dependency handling for imported floating IP
+
+## Step 00
+
+Import a floating IP that references other imported resources. The referenced imported resources has no matching resource yet.
+Verify the floating IP is waiting for the dependency to be ready.
+
+## Step 01
+
+Create a floating IP matching the import filter, except for referenced resources, and verify that it's not being imported.
+
+## Step 02
+
+Create a the referenced resources and a floating IP matching the import filters.
+
+Verify that the observed status on the imported floating IP corresponds to the spec of the created floating IP.
+
+## Step 03
+
+Delete the referenced resources and check that ORC does not prevent deletion. The OpenStack resource still exists because they
+were imported resources and we only deleted the ORC representation of it.
+
+## Step 04
+
+Delete the floating IP and validate that all resources are gone.
+
+## Reference
+
+https://k-orc.cloud/development/writing-tests/#import-dependency

--- a/internal/controllers/floatingip/tests/floatingip-import/00-prerequisites.yaml
+++ b/internal/controllers/floatingip/tests/floatingip-import/00-prerequisites.yaml
@@ -20,7 +20,6 @@ spec:
     secretName: openstack-clouds
   managementPolicy: managed
   resource:
-    name: floatingip-import
     external: true
 ---
 apiVersion: openstack.k-orc.cloud/v1alpha1

--- a/pkg/clients/applyconfiguration/api/v1alpha1/floatingipfilter.go
+++ b/pkg/clients/applyconfiguration/api/v1alpha1/floatingipfilter.go
@@ -29,6 +29,7 @@ type FloatingIPFilterApplyConfiguration struct {
 	Description                           *apiv1alpha1.NeutronDescription `json:"description,omitempty"`
 	FloatingNetworkRef                    *apiv1alpha1.KubernetesNameRef  `json:"floatingNetworkRef,omitempty"`
 	PortRef                               *apiv1alpha1.KubernetesNameRef  `json:"portRef,omitempty"`
+	ProjectRef                            *apiv1alpha1.KubernetesNameRef  `json:"projectRef,omitempty"`
 	Status                                *string                         `json:"status,omitempty"`
 	FilterByNeutronTagsApplyConfiguration `json:",inline"`
 }
@@ -68,6 +69,14 @@ func (b *FloatingIPFilterApplyConfiguration) WithFloatingNetworkRef(value apiv1a
 // If called multiple times, the PortRef field is set to the value of the last call.
 func (b *FloatingIPFilterApplyConfiguration) WithPortRef(value apiv1alpha1.KubernetesNameRef) *FloatingIPFilterApplyConfiguration {
 	b.PortRef = &value
+	return b
+}
+
+// WithProjectRef sets the ProjectRef field in the declarative configuration to the given value
+// and returns the receiver, so that objects can be built by chaining "With" function invocations.
+// If called multiple times, the ProjectRef field is set to the value of the last call.
+func (b *FloatingIPFilterApplyConfiguration) WithProjectRef(value apiv1alpha1.KubernetesNameRef) *FloatingIPFilterApplyConfiguration {
+	b.ProjectRef = &value
 	return b
 }
 

--- a/pkg/clients/applyconfiguration/api/v1alpha1/floatingipresourcespec.go
+++ b/pkg/clients/applyconfiguration/api/v1alpha1/floatingipresourcespec.go
@@ -32,6 +32,7 @@ type FloatingIPResourceSpecApplyConfiguration struct {
 	FloatingIP         *apiv1alpha1.IPvAny             `json:"floatingIP,omitempty"`
 	PortRef            *apiv1alpha1.KubernetesNameRef  `json:"portRef,omitempty"`
 	FixedIP            *apiv1alpha1.IPvAny             `json:"fixedIP,omitempty"`
+	ProjectRef         *apiv1alpha1.KubernetesNameRef  `json:"projectRef,omitempty"`
 }
 
 // FloatingIPResourceSpecApplyConfiguration constructs a declarative configuration of the FloatingIPResourceSpec type for use with
@@ -95,5 +96,13 @@ func (b *FloatingIPResourceSpecApplyConfiguration) WithPortRef(value apiv1alpha1
 // If called multiple times, the FixedIP field is set to the value of the last call.
 func (b *FloatingIPResourceSpecApplyConfiguration) WithFixedIP(value apiv1alpha1.IPvAny) *FloatingIPResourceSpecApplyConfiguration {
 	b.FixedIP = &value
+	return b
+}
+
+// WithProjectRef sets the ProjectRef field in the declarative configuration to the given value
+// and returns the receiver, so that objects can be built by chaining "With" function invocations.
+// If called multiple times, the ProjectRef field is set to the value of the last call.
+func (b *FloatingIPResourceSpecApplyConfiguration) WithProjectRef(value apiv1alpha1.KubernetesNameRef) *FloatingIPResourceSpecApplyConfiguration {
+	b.ProjectRef = &value
 	return b
 }

--- a/pkg/clients/applyconfiguration/internal/internal.go
+++ b/pkg/clients/applyconfiguration/internal/internal.go
@@ -307,6 +307,9 @@ var schemaYAML = typed.YAMLObject(`types:
     - name: portRef
       type:
         scalar: string
+    - name: projectRef
+      type:
+        scalar: string
     - name: status
       type:
         scalar: string
@@ -350,6 +353,9 @@ var schemaYAML = typed.YAMLObject(`types:
       type:
         scalar: string
     - name: portRef
+      type:
+        scalar: string
+    - name: projectRef
       type:
         scalar: string
     - name: tags

--- a/website/docs/crd-reference.md
+++ b/website/docs/crd-reference.md
@@ -528,6 +528,7 @@ _Appears in:_
 | `description` _[NeutronDescription](#neutrondescription)_ | description of the existing resource |  | MaxLength: 255 <br />MinLength: 1 <br /> |
 | `floatingNetworkRef` _[KubernetesNameRef](#kubernetesnameref)_ | floatingNetworkRef is a reference to the ORC Network which this resource is associated with. |  | MaxLength: 253 <br />MinLength: 1 <br /> |
 | `portRef` _[KubernetesNameRef](#kubernetesnameref)_ | portRef is a reference to the ORC Port which this resource is associated with. |  | MaxLength: 253 <br />MinLength: 1 <br /> |
+| `projectRef` _[KubernetesNameRef](#kubernetesnameref)_ | projectRef is a reference to the ORC Project this resource is associated with.<br />Typically, only used by admin. |  | MaxLength: 253 <br />MinLength: 1 <br /> |
 | `status` _string_ | status is the status of the floatingip. |  | MaxLength: 1024 <br /> |
 | `tags` _[NeutronTag](#neutrontag) array_ | tags is a list of tags to filter by. If specified, the resource must<br />have all of the tags specified to be included in the result. |  | MaxItems: 32 <br />MaxLength: 255 <br />MinLength: 1 <br /> |
 | `tagsAny` _[NeutronTag](#neutrontag) array_ | tagsAny is a list of tags to filter by. If specified, the resource<br />must have at least one of the tags specified to be included in the<br />result. |  | MaxItems: 32 <br />MaxLength: 255 <br />MinLength: 1 <br /> |
@@ -593,6 +594,7 @@ _Appears in:_
 | `floatingIP` _[IPvAny](#ipvany)_ | floatingIP is the IP that will be assigned to the floatingip. If not set, it will<br />be assigned automatically. |  | MaxLength: 45 <br />MinLength: 1 <br /> |
 | `portRef` _[KubernetesNameRef](#kubernetesnameref)_ | portRef is a reference to the ORC Port which this resource is associated with. |  | MaxLength: 253 <br />MinLength: 1 <br /> |
 | `fixedIP` _[IPvAny](#ipvany)_ | fixedIP is the IP address of the port to which the floatingip is associated. |  | MaxLength: 45 <br />MinLength: 1 <br /> |
+| `projectRef` _[KubernetesNameRef](#kubernetesnameref)_ | projectRef is a reference to the ORC Project this resource is associated with.<br />Typically, only used by admin. |  | MaxLength: 253 <br />MinLength: 1 <br /> |
 
 
 #### FloatingIPResourceStatus


### PR DESCRIPTION
Similar to what was done in https://github.com/k-orc/openstack-resource-controller/pull/377, this adds support for specifying the project the resource needs to be created on, via the `projectRef` property.

This PR also adds missing `dependency` and `import-dependency` tests, and slightly simplifies the rest of the floatingip tests.