### PR TITLE
CloudCredential secret: export constants in api

### DIFF
--- a/api/v1alpha1/credentials_ref.go
+++ b/api/v1alpha1/credentials_ref.go
@@ -16,6 +16,13 @@ limitations under the License.
 
 package v1alpha1
 
+const (
+	// CloudCredentialsConfigSecretKey is the key for the clouds configuration in the cloud credentials secret.
+	CloudCredentialsConfigSecretKey = "clouds.yaml"
+	// CloudCredencialsCASecretKey is the key for the CA certificate in the cloud credentials secret.
+	CloudCredencialsCASecretKey = "cacert"
+)
+
 // CloudCredentialsReference is a reference to a secret containing OpenStack credentials.
 type CloudCredentialsReference struct {
 	// secretName is the name of a secret in the same namespace as the resource being provisioned.

--- a/internal/scope/provider.go
+++ b/internal/scope/provider.go
@@ -42,11 +42,6 @@ import (
 	"github.com/k-orc/openstack-resource-controller/v2/internal/version"
 )
 
-const (
-	CloudsSecretKey = "clouds.yaml"
-	CASecretKey     = "cacert"
-)
-
 type providerScopeFactory struct {
 	clientCache   *cache.LRUExpireCache
 	defaultCACert []byte
@@ -258,10 +253,10 @@ func getCloudFromSecret(ctx context.Context, ctrlClient client.Client, secretNam
 		return emptyCloud, nil, err
 	}
 
-	content, ok := secret.Data[CloudsSecretKey]
+	content, ok := secret.Data[orcv1alpha1.CloudCredentialsConfigSecretKey]
 	if !ok {
 		return emptyCloud, nil, fmt.Errorf("OpenStack credentials secret %v did not contain key %v",
-			secretName, CloudsSecretKey)
+			secretName, orcv1alpha1.CloudCredentialsConfigSecretKey)
 	}
 	var clouds clientconfig.Clouds
 	if err = yaml.Unmarshal(content, &clouds); err != nil {
@@ -269,7 +264,7 @@ func getCloudFromSecret(ctx context.Context, ctrlClient client.Client, secretNam
 	}
 
 	// get caCert
-	caCert, ok := secret.Data[CASecretKey]
+	caCert, ok := secret.Data[orcv1alpha1.CloudCredencialsCASecretKey]
 	if !ok {
 		return clouds.Clouds[cloudName], nil, nil
 	}


### PR DESCRIPTION
Move constants for CloudCredentials secret keys to the api package so they can be imported from external repositories.
Closes #413 