### PR TITLE
Router interface: reconcile interfaces for routers pending deletion

### DIFF
--- a/internal/controllers/routerinterface/controller.go
+++ b/internal/controllers/routerinterface/controller.go
@@ -110,7 +110,7 @@ func (c routerInterfaceReconcilerConstructor) SetupWithManager(ctx context.Conte
 	}
 	return ctrl.NewControllerManagedBy(mgr).
 		For(&orcv1alpha1.Router{}, builder.WithPredicates(predicates.NewBecameAvailable(log, &orcv1alpha1.Router{}))).
-		Named("router_interface").
+		Named(controllerName).
 		Watches(&orcv1alpha1.RouterInterface{},
 			handler.EnqueueRequestsFromMapFunc(func(ctx context.Context, obj client.Object) []reconcile.Request {
 				log := ctrl.LoggerFrom(ctx).WithValues("watch", "RouterInterface", "name", obj.GetName(), "namespace", obj.GetNamespace())

--- a/internal/controllers/routerinterface/reconcile.go
+++ b/internal/controllers/routerinterface/reconcile.go
@@ -53,7 +53,9 @@ func (r *orcRouterInterfaceReconciler) Reconcile(ctx context.Context, req ctrl.R
 		return ctrl.Result{}, err
 	}
 
-	if !orcv1alpha1.IsAvailable(router) || router.Status.ID == nil {
+	// We still want to reconcile router interface for routers that are scheduled for deletion
+	// so that we can clear the finalizer
+	if router.Status.ID == nil || (!orcv1alpha1.IsAvailable(router) && router.GetDeletionTimestamp().IsZero()) {
 		log.V(logging.Verbose).Info("Not reconciling interfaces for not-Available router")
 		return ctrl.Result{}, nil
 	}

--- a/internal/controllers/routerinterface/tests/routerinterface-create-minimal/00-create-resource.yaml
+++ b/internal/controllers/routerinterface/tests/routerinterface-create-minimal/00-create-resource.yaml
@@ -13,7 +13,7 @@ spec:
 apiVersion: openstack.k-orc.cloud/v1alpha1
 kind: Subnet
 metadata:
-  name: routerinterface-create-minimal
+  name: routerinterface-create-minimal-external
 spec:
   cloudCredentialsRef:
     cloudName: openstack
@@ -27,7 +27,7 @@ spec:
 apiVersion: openstack.k-orc.cloud/v1alpha1
 kind: Router
 metadata:
-  name: routerinterface-router-create-minimal
+  name: routerinterface-create-minimal-external
 spec:
   cloudCredentialsRef:
     cloudName: openstack
@@ -35,13 +35,11 @@ spec:
   managementPolicy: managed
   resource:
     description: Router from "routerinterface-create-minimal" test
-    tags:
-      - tag1
 ---
 apiVersion: openstack.k-orc.cloud/v1alpha1
 kind: Router
 metadata:
-  name: routerinterface-router-import
+  name: routerinterface-create-minimal
 spec:
   cloudCredentialsRef:
     cloudName: openstack
@@ -49,13 +47,12 @@ spec:
   managementPolicy: unmanaged
   import:
     filter:
-      name: routerinterface-router-create-minimal
-      description: Router from "routerinterface-create-minimal" test
+      name: routerinterface-create-minimal-external
 ---
 apiVersion: openstack.k-orc.cloud/v1alpha1
 kind: Subnet
 metadata:
-  name: routerinterface-subnet-import
+  name: routerinterface-create-minimal
 spec:
   cloudCredentialsRef:
     cloudName: openstack
@@ -63,8 +60,7 @@ spec:
   managementPolicy: unmanaged
   import:
     filter:
-      networkRef: routerinterface-create-minimal
-      name: routerinterface-create-minimal
+      name: routerinterface-create-minimal-external
 ---
 apiVersion: openstack.k-orc.cloud/v1alpha1
 kind: RouterInterface
@@ -72,5 +68,5 @@ metadata:
   name: routerinterface-create-minimal
 spec:
   type: Subnet
-  routerRef: routerinterface-router-import
-  subnetRef: routerinterface-subnet-import
+  routerRef: routerinterface-create-minimal
+  subnetRef: routerinterface-create-minimal


### PR DESCRIPTION
This hopefully fixes a deadlock situation where an unmanaged router is not
available due to the backing router being deleted in OpenStack, causing
the router interface to not reconcile, and preventing the router
deletion due to pending finalizer.

While I was looking at router interface, I also made the object names more consistent with other tests in the `routerinterface-create-minimal` test, and used a consistent name for logging, as it appeared as `routerinterface` or `router_interface` in the logs, depending on the event generating the log.

Fixes https://github.com/k-orc/openstack-resource-controller/issues/378.