### PR TITLE
CI: Bump devstack-action

### DIFF
--- a/.github/workflows/e2e.yaml
+++ b/.github/workflows/e2e.yaml
@@ -28,7 +28,7 @@ jobs:
     - uses: actions/checkout@v4
 
     - name: Deploy devstack
-      uses: gophercloud/devstack-action@264ea76100c468f10c5d2e62bb81c6dc26fd5a3b
+      uses: gophercloud/devstack-action@60ca1042045c0c9e3e001c64575d381654ffcba1
       with:
         enable_workaround_docker_io: 'false'
         branch: ${{ matrix.openstack_version }}


### PR DESCRIPTION
Fixes the following error while deploying devstack:

    E: Failed to fetch mirror+file:/etc/apt/apt-mirrors.txt/pool/main/libv/libvpx/libvpx7_1.11.0-2ubuntu2.3_amd64.deb  404  Not Found [IP: 52.147.219.192 80]