### PR TITLE
Use annotation to add expiration for images in quay

### DIFF
--- a/.github/workflows/container_image.yaml
+++ b/.github/workflows/container_image.yaml
@@ -31,4 +31,4 @@ jobs:
         # Ensure we source identical build arguments for both builds
         source hack/version.sh && version::get_git_vars && version::get_build_date && \
           make docker-buildx IMG=${{ env.image_tag_branch }} && \
-          make docker-buildx IMG=${{ env.image_tag_commit }} DOCKER_BUILD_ARGS="--label quay.expires-after=4w"
+          make docker-buildx IMG=${{ env.image_tag_commit }} DOCKER_BUILD_ARGS="--annotation quay.expires-after=4w"


### PR DESCRIPTION
Using a label only works for image manifests, while using an annotation works for both image manifests and image indexes. For multi-arch builds, we need to use an annotation to set an expiration date.

Fixes #433