### PR TITLE
Bump go to 1.23.10

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -3,7 +3,7 @@ IMG ?= controller:latest
 # ENVTEST_K8S_VERSION refers to the version of kubebuilder assets to be downloaded by envtest binary.
 ENVTEST_K8S_VERSION = 1.30.0
 TRIVY_VERSION = 0.49.1
-GO_VERSION ?= 1.23.9
+GO_VERSION ?= 1.23.10
 
 # Get the currently used golang install path (in GOPATH/bin, unless GOBIN is set)
 ifeq (,$(shell go env GOBIN))


### PR DESCRIPTION
This addresses three vulnerabilities in the standard library:
- GO-2025-3751
- GO-2025-3750
- GO-2025-3749