### PR TITLE
Use pinned go version for CI

### DIFF
--- a/.github/workflows/go-lint.yaml
+++ b/.github/workflows/go-lint.yaml
@@ -14,9 +14,14 @@ jobs:
     steps:
       - uses: actions/checkout@v4
 
-      - uses: actions/setup-go@v5
+      - name: Calculate go version
+        id: vars
+        run: echo "go_version=$(make go-version)" >> $GITHUB_OUTPUT
+
+      - name: Set up Go
+        uses: actions/setup-go@0aaccfd150d50ccaeb58ebd88d36e91967a5f35b # tag=v5.4.0
         with:
-          go-version: '1'
+          go-version: ${{ steps.vars.outputs.go_version }}
 
       - run: |
           make lint 

--- a/.github/workflows/label-pr.yaml
+++ b/.github/workflows/label-pr.yaml
@@ -27,9 +27,14 @@ jobs:
       env:
         GIT_SEQUENCE_EDITOR: '/usr/bin/true'
 
-    - uses: actions/setup-go@v5
+    - name: Calculate go version
+      id: vars
+      run: echo "go_version=$(make go-version)" >> $GITHUB_OUTPUT
+
+    - name: Set up Go
+      uses: actions/setup-go@0aaccfd150d50ccaeb58ebd88d36e91967a5f35b # tag=v5.4.0
       with:
-        go-version: '1'
+        go-version: ${{ steps.vars.outputs.go_version }}
 
     - name: Checking Go API Compatibility
       id: go-apidiff

--- a/.github/workflows/unit.yml
+++ b/.github/workflows/unit.yml
@@ -18,9 +18,14 @@ jobs:
     steps:
       - uses: actions/checkout@v4
 
-      - uses: actions/setup-go@v5
+      - name: Calculate go version
+        id: vars
+        run: echo "go_version=$(make go-version)" >> $GITHUB_OUTPUT
+
+      - name: Set up Go
+        uses: actions/setup-go@0aaccfd150d50ccaeb58ebd88d36e91967a5f35b # tag=v5.4.0
         with:
-          go-version: ${{ matrix.go-version }}
+          go-version: ${{ steps.vars.outputs.go_version }}
 
       - run: |
          make test 


### PR DESCRIPTION
This ensures ORC remains compatible with the go version we claim it supports.