### PR TITLE
Prepare for enabling merge-queues

### DIFF
--- a/.github/workflows/check-pr-labels.yaml
+++ b/.github/workflows/check-pr-labels.yaml
@@ -1,5 +1,6 @@
 name: Ready
 on:
+  merge_group:
   pull_request_target:
     types:
       - labeled

--- a/.github/workflows/e2e.yaml
+++ b/.github/workflows/e2e.yaml
@@ -1,6 +1,7 @@
 name: e2e
 
 on:
+  merge_group:
   pull_request:
 
 permissions:

--- a/.github/workflows/generate.yaml
+++ b/.github/workflows/generate.yaml
@@ -2,6 +2,7 @@ on:
   push:
     branches:
     - main
+  merge_group:
   pull_request:
 name: generate
 permissions:

--- a/.github/workflows/go-lint.yaml
+++ b/.github/workflows/go-lint.yaml
@@ -2,6 +2,7 @@ on:
   push:
     branches:
     - main
+  merge_group:
   pull_request:
 name: go lint
 permissions:

--- a/.github/workflows/unit.yml
+++ b/.github/workflows/unit.yml
@@ -2,6 +2,7 @@ on:
   push:
     branches:
     - main
+  merge_group:
   pull_request:
 name: go test
 permissions:


### PR DESCRIPTION
In preparation for enabling merge queues in this repository, we need to update the required workflows to be triggered on `merge_group` events.

https://docs.github.com/en/repositories/configuring-branches-and-merges-in-your-repository/configuring-pull-request-merges/managing-a-merge-queue

Related to #220