### PR TITLE
Server: add mutability for all fields that support it

### DIFF
--- a/api/v1alpha1/server_types.go
+++ b/api/v1alpha1/server_types.go
@@ -61,7 +61,6 @@ type ServerPortSpec struct {
 }
 
 // ServerResourceSpec contains the desired state of a server
-// +kubebuilder:validation:XValidation:rule="self == oldSelf",message="ServerResourceSpec is immutable"
 type ServerResourceSpec struct {
 	// name will be the name of the created resource. If not specified, the
 	// name of the ORC object will be used.
@@ -71,27 +70,32 @@ type ServerResourceSpec struct {
 	// imageRef references the image to use for the server instance.
 	// NOTE: This is not required in case of boot from volume.
 	// +required
+	// +kubebuilder:validation:XValidation:rule="self == oldSelf",message="imageRef is immutable"
 	ImageRef KubernetesNameRef `json:"imageRef"`
 
 	// flavorRef references the flavor to use for the server instance.
 	// +required
+	// +kubebuilder:validation:XValidation:rule="self == oldSelf",message="flavorRef is immutable"
 	FlavorRef KubernetesNameRef `json:"flavorRef"`
 
 	// userData specifies data which will be made available to the server at
 	// boot time, either via the metadata service or a config drive. It is
 	// typically read by a configuration service such as cloud-init or ignition.
 	// +optional
+	// +kubebuilder:validation:XValidation:rule="self == oldSelf",message="userData is immutable"
 	UserData *UserDataSpec `json:"userData,omitempty"`
 
 	// ports defines a list of ports which will be attached to the server.
 	// +kubebuilder:validation:MaxItems:=32
 	// +listType=atomic
 	// +required
+	// +kubebuilder:validation:XValidation:rule="self == oldSelf",message="ports is immutable"
 	Ports []ServerPortSpec `json:"ports"`
 
 	// serverGroupRef is a reference to a ServerGroup object. The server
 	// will be created in the server group.
 	// +optional
+	// +kubebuilder:validation:XValidation:rule="self == oldSelf",message="serverGroupRef is immutable"
 	ServerGroupRef *KubernetesNameRef `json:"serverGroupRef,omitempty"`
 
 	// tags is a list of tags which will be applied to the server.

--- a/config/crd/bases/openstack.k-orc.cloud_servers.yaml
+++ b/config/crd/bases/openstack.k-orc.cloud_servers.yaml
@@ -195,6 +195,9 @@ spec:
                     maxLength: 253
                     minLength: 1
                     type: string
+                    x-kubernetes-validations:
+                    - message: flavorRef is immutable
+                      rule: self == oldSelf
                   imageRef:
                     description: |-
                       imageRef references the image to use for the server instance.
@@ -202,6 +205,9 @@ spec:
                     maxLength: 253
                     minLength: 1
                     type: string
+                    x-kubernetes-validations:
+                    - message: imageRef is immutable
+                      rule: self == oldSelf
                   name:
                     description: |-
                       name will be the name of the created resource. If not specified, the
@@ -228,6 +234,9 @@ spec:
                     maxItems: 32
                     type: array
                     x-kubernetes-list-type: atomic
+                    x-kubernetes-validations:
+                    - message: ports is immutable
+                      rule: self == oldSelf
                   serverGroupRef:
                     description: |-
                       serverGroupRef is a reference to a ServerGroup object. The server
@@ -235,6 +244,9 @@ spec:
                     maxLength: 253
                     minLength: 1
                     type: string
+                    x-kubernetes-validations:
+                    - message: serverGroupRef is immutable
+                      rule: self == oldSelf
                   tags:
                     description: tags is a list of tags which will be applied to the
                       server.
@@ -260,14 +272,14 @@ spec:
                         minLength: 1
                         type: string
                     type: object
+                    x-kubernetes-validations:
+                    - message: userData is immutable
+                      rule: self == oldSelf
                 required:
                 - flavorRef
                 - imageRef
                 - ports
                 type: object
-                x-kubernetes-validations:
-                - message: ServerResourceSpec is immutable
-                  rule: self == oldSelf
             required:
             - cloudCredentialsRef
             type: object

--- a/internal/controllers/server/actuator_test.go
+++ b/internal/controllers/server/actuator_test.go
@@ -1,0 +1,72 @@
+package server
+
+import (
+	"testing"
+
+	"github.com/gophercloud/gophercloud/v2/openstack/compute/v2/servers"
+	orcv1alpha1 "github.com/k-orc/openstack-resource-controller/v2/api/v1alpha1"
+	"k8s.io/utils/ptr"
+)
+
+func TestNeedsUpdate(t *testing.T) {
+	testCases := []struct {
+		name         string
+		updateOpts   servers.UpdateOptsBuilder
+		expectChange bool
+	}{
+		{
+			name:         "Empty base opts",
+			updateOpts:   servers.UpdateOpts{},
+			expectChange: false,
+		},
+		{
+			name:         "Updated opts",
+			updateOpts:   servers.UpdateOpts{Name: "updated"},
+			expectChange: true,
+		},
+	}
+
+	for _, tt := range testCases {
+		t.Run(tt.name, func(t *testing.T) {
+			got, _ := needsUpdate(tt.updateOpts)
+			if got != tt.expectChange {
+				t.Errorf("Expected change: %v, got: %v", tt.expectChange, got)
+			}
+		})
+	}
+}
+
+func TestHandleNameUpdate(t *testing.T) {
+	ptrToName := ptr.To[orcv1alpha1.OpenStackName]
+	testCases := []struct {
+		name          string
+		newValue      *orcv1alpha1.OpenStackName
+		existingValue string
+		expectChange  bool
+	}{
+		{name: "Identical", newValue: ptrToName("name"), existingValue: "name", expectChange: false},
+		{name: "Different", newValue: ptrToName("new-name"), existingValue: "name", expectChange: true},
+		{name: "No value provided, existing is identical to object name", newValue: nil, existingValue: "object-name", expectChange: false},
+		{name: "No value provided, existing is different from object name", newValue: nil, existingValue: "different-from-object-name", expectChange: true},
+	}
+
+	for _, tt := range testCases {
+		t.Run(tt.name, func(t *testing.T) {
+			resource := &orcv1alpha1.Server{}
+			resource.Name = "object-name"
+			resource.Spec = orcv1alpha1.ServerSpec{
+				Resource: &orcv1alpha1.ServerResourceSpec{Name: tt.newValue},
+			}
+			osResource := &servers.Server{Name: tt.existingValue}
+
+			updateOpts := servers.UpdateOpts{}
+			handleNameUpdate(&updateOpts, resource, osResource)
+
+			got, _ := needsUpdate(updateOpts)
+			if got != tt.expectChange {
+				t.Errorf("Expected change: %v, got: %v", tt.expectChange, got)
+			}
+		})
+
+	}
+}

--- a/internal/controllers/server/tests/server-update/00-assert.yaml
+++ b/internal/controllers/server/tests/server-update/00-assert.yaml
@@ -1,0 +1,41 @@
+---
+apiVersion: kuttl.dev/v1beta1
+kind: TestAssert
+resourceRefs:
+    - apiVersion: openstack.k-orc.cloud/v1alpha1
+      kind: Server
+      name: server-update
+      ref: server
+    - apiVersion: openstack.k-orc.cloud/v1alpha1
+      kind: Image
+      name: server-update
+      ref: image
+    - apiVersion: openstack.k-orc.cloud/v1alpha1
+      kind: Port
+      name: server-update
+      ref: port
+    - apiVersion: openstack.k-orc.cloud/v1alpha1
+      kind: ServerGroup
+      name: server-update
+      ref: sg
+assertAll:
+    - celExpr: "server.status.resource.hostID != ''"
+    - celExpr: "server.status.resource.imageID == image.status.id"
+    - celExpr: "server.status.resource.serverGroups[0] == sg.status.id"
+    - celExpr: "!has(server.status.resource.tags)"
+---
+apiVersion: openstack.k-orc.cloud/v1alpha1
+kind: Server
+metadata:
+  name: server-update
+status:
+  resource:
+    name: server-update
+    status: ACTIVE
+  conditions:
+  - type: Available
+    status: "True"
+    reason: Success
+  - type: Progressing
+    status: "False"
+    reason: Success

--- a/internal/controllers/server/tests/server-update/00-minimal-resource.yaml
+++ b/internal/controllers/server/tests/server-update/00-minimal-resource.yaml
@@ -1,0 +1,16 @@
+---
+apiVersion: openstack.k-orc.cloud/v1alpha1
+kind: Server
+metadata:
+  name: server-update
+spec:
+  cloudCredentialsRef:
+    cloudName: openstack
+    secretName: openstack-clouds
+  managementPolicy: managed
+  resource:
+    imageRef: server-update
+    flavorRef: server-update
+    ports:
+      - portRef: server-update
+    serverGroupRef: server-update

--- a/internal/controllers/server/tests/server-update/00-prerequisites.yaml
+++ b/internal/controllers/server/tests/server-update/00-prerequisites.yaml
@@ -1,0 +1,76 @@
+apiVersion: kuttl.dev/v1beta1
+kind: TestStep
+commands:
+  - command: kubectl create secret generic openstack-clouds --from-file=clouds.yaml=${E2E_KUTTL_OSCLOUDS} ${E2E_KUTTL_CACERT_OPT}
+    namespaced: true
+  - script: |
+      export E2E_KUTTL_CURRENT_TEST=server-update
+      cat ../templates/create-flavor.tmpl | envsubst | kubectl -n ${NAMESPACE} apply -f -
+---
+apiVersion: openstack.k-orc.cloud/v1alpha1
+kind: Image
+metadata:
+  name: server-update
+spec:
+  cloudCredentialsRef:
+    cloudName: openstack-admin
+    secretName: openstack-clouds
+  managementPolicy: managed
+  resource:
+    content:
+      diskFormat: qcow2
+      download:
+        url: https://github.com/k-orc/openstack-resource-controller/raw/2ddc1857f5e22d2f0df6f5ee033353e4fd907121/internal/controllers/image/testdata/cirros-0.6.3-x86_64-disk.img
+    visibility: public
+---
+apiVersion: openstack.k-orc.cloud/v1alpha1
+kind: Network
+metadata:
+  name: server-update
+spec:
+  cloudCredentialsRef:
+    cloudName: openstack
+    secretName: openstack-clouds
+  managementPolicy: managed
+  resource:
+    name: server-update
+---
+apiVersion: openstack.k-orc.cloud/v1alpha1
+kind: Subnet
+metadata:
+  name: server-update
+spec:
+  cloudCredentialsRef:
+    cloudName: openstack
+    secretName: openstack-clouds
+  managementPolicy: managed
+  resource:
+    networkRef: server-update
+    ipVersion: 4
+    cidr: 192.168.200.0/24
+---
+apiVersion: openstack.k-orc.cloud/v1alpha1
+kind: Port
+metadata:
+  name: server-update
+spec:
+  cloudCredentialsRef:
+    cloudName: openstack
+    secretName: openstack-clouds
+  managementPolicy: managed
+  resource:
+    networkRef: server-update
+    addresses:
+      - subnetRef: server-update
+---
+apiVersion: openstack.k-orc.cloud/v1alpha1
+kind: ServerGroup
+metadata:
+  name: server-update
+spec:
+  cloudCredentialsRef:
+    cloudName: openstack
+    secretName: openstack-clouds
+  managementPolicy: managed
+  resource:
+    policy: soft-anti-affinity

--- a/internal/controllers/server/tests/server-update/01-assert.yaml
+++ b/internal/controllers/server/tests/server-update/01-assert.yaml
@@ -1,0 +1,43 @@
+---
+apiVersion: kuttl.dev/v1beta1
+kind: TestAssert
+resourceRefs:
+    - apiVersion: openstack.k-orc.cloud/v1alpha1
+      kind: Server
+      name: server-update
+      ref: server
+    - apiVersion: openstack.k-orc.cloud/v1alpha1
+      kind: Image
+      name: server-update
+      ref: image
+    - apiVersion: openstack.k-orc.cloud/v1alpha1
+      kind: Port
+      name: server-update
+      ref: port
+    - apiVersion: openstack.k-orc.cloud/v1alpha1
+      kind: ServerGroup
+      name: server-update
+      ref: sg
+assertAll:
+    - celExpr: "server.status.resource.hostID != ''"
+    - celExpr: "server.status.resource.imageID == image.status.id"
+    - celExpr: "server.status.resource.serverGroups[0] == sg.status.id"
+---
+apiVersion: openstack.k-orc.cloud/v1alpha1
+kind: Server
+metadata:
+  name: server-update
+status:
+  resource:
+    name: server-update-updated
+    status: ACTIVE
+    # tags:
+    #   - tag1
+    #   - tag2
+  conditions:
+  - type: Available
+    status: "True"
+    reason: Success
+  - type: Progressing
+    status: "False"
+    reason: Success

--- a/internal/controllers/server/tests/server-update/01-updated-resource.yaml
+++ b/internal/controllers/server/tests/server-update/01-updated-resource.yaml
@@ -1,0 +1,16 @@
+---
+apiVersion: openstack.k-orc.cloud/v1alpha1
+kind: Server
+metadata:
+  name: server-update
+spec:
+  cloudCredentialsRef:
+    cloudName: openstack
+    secretName: openstack-clouds
+  managementPolicy: managed
+  resource:
+    name: server-update-updated
+    #FIXME(dkokkino): Issue https://github.com/k-orc/openstack-resource-controller/issues/483
+    # tags:
+    #   - tag1
+    #   - tag2

--- a/internal/controllers/server/tests/server-update/02-assert.yaml
+++ b/internal/controllers/server/tests/server-update/02-assert.yaml
@@ -1,0 +1,41 @@
+---
+apiVersion: kuttl.dev/v1beta1
+kind: TestAssert
+resourceRefs:
+    - apiVersion: openstack.k-orc.cloud/v1alpha1
+      kind: Server
+      name: server-update
+      ref: server
+    - apiVersion: openstack.k-orc.cloud/v1alpha1
+      kind: Image
+      name: server-update
+      ref: image
+    - apiVersion: openstack.k-orc.cloud/v1alpha1
+      kind: Port
+      name: server-update
+      ref: port
+    - apiVersion: openstack.k-orc.cloud/v1alpha1
+      kind: ServerGroup
+      name: server-update
+      ref: sg
+assertAll:
+    - celExpr: "server.status.resource.hostID != ''"
+    - celExpr: "server.status.resource.imageID == image.status.id"
+    - celExpr: "server.status.resource.serverGroups[0] == sg.status.id"
+    - celExpr: "!has(server.status.resource.tags)"
+---
+apiVersion: openstack.k-orc.cloud/v1alpha1
+kind: Server
+metadata:
+  name: server-update
+status:
+  resource:
+    name: server-update
+    status: ACTIVE
+  conditions:
+  - type: Available
+    status: "True"
+    reason: Success
+  - type: Progressing
+    status: "False"
+    reason: Success

--- a/internal/controllers/server/tests/server-update/02-reverted-resource.yaml
+++ b/internal/controllers/server/tests/server-update/02-reverted-resource.yaml
@@ -1,0 +1,7 @@
+# NOTE: kuttl only does patch updates, which means we can't delete a field.
+# We have to use a kubectl apply command instead.
+apiVersion: kuttl.dev/v1beta1
+kind: TestStep
+commands:
+  - command: kubectl replace -f 00-minimal-resource.yaml
+    namespaced: true

--- a/internal/osclients/compute.go
+++ b/internal/osclients/compute.go
@@ -55,6 +55,7 @@ type ComputeClient interface {
 	DeleteServer(ctx context.Context, serverID string) error
 	GetServer(ctx context.Context, serverID string) (*servers.Server, error)
 	ListServers(ctx context.Context, listOpts servers.ListOptsBuilder) iter.Seq2[*servers.Server, error]
+	UpdateServer(ctx context.Context, id string, opts servers.UpdateOptsBuilder) (*servers.Server, error)
 
 	CreateServerGroup(ctx context.Context, createOpts servergroups.CreateOptsBuilder) (*servergroups.ServerGroup, error)
 	DeleteServerGroup(ctx context.Context, serverGroupID string) error
@@ -122,6 +123,10 @@ func (c computeClient) ListServers(ctx context.Context, opts servers.ListOptsBui
 	return func(yield func(*servers.Server, error) bool) {
 		_ = pager.EachPage(ctx, yieldPage(servers.ExtractServers, yield))
 	}
+}
+
+func (c computeClient) UpdateServer(ctx context.Context, id string, opts servers.UpdateOptsBuilder) (*servers.Server, error) {
+	return servers.Update(ctx, c.client, id, opts).Extract()
 }
 
 func (c computeClient) ListAttachedInterfaces(ctx context.Context, serverID string) ([]attachinterfaces.Interface, error) {
@@ -196,6 +201,10 @@ func (e computeErrorClient) ListServers(ctx context.Context, listOpts servers.Li
 	return func(yield func(*servers.Server, error) bool) {
 		yield(nil, e.error)
 	}
+}
+
+func (e computeErrorClient) UpdateServer(_ context.Context, _ string, _ servers.UpdateOptsBuilder) (*servers.Server, error) {
+	return nil, e.error
 }
 
 func (e computeErrorClient) CreateServerGroup(_ context.Context, _ servergroups.CreateOptsBuilder) (*servergroups.ServerGroup, error) {

--- a/internal/osclients/mock/compute.go
+++ b/internal/osclients/mock/compute.go
@@ -232,3 +232,18 @@ func (mr *MockComputeClientMockRecorder) ListServers(ctx, listOpts any) *gomock.
 	mr.mock.ctrl.T.Helper()
 	return mr.mock.ctrl.RecordCallWithMethodType(mr.mock, "ListServers", reflect.TypeOf((*MockComputeClient)(nil).ListServers), ctx, listOpts)
 }
+
+// UpdateServer mocks base method.
+func (m *MockComputeClient) UpdateServer(ctx context.Context, id string, opts servers.UpdateOptsBuilder) (*servers.Server, error) {
+	m.ctrl.T.Helper()
+	ret := m.ctrl.Call(m, "UpdateServer", ctx, id, opts)
+	ret0, _ := ret[0].(*servers.Server)
+	ret1, _ := ret[1].(error)
+	return ret0, ret1
+}
+
+// UpdateServer indicates an expected call of UpdateServer.
+func (mr *MockComputeClientMockRecorder) UpdateServer(ctx, id, opts any) *gomock.Call {
+	mr.mock.ctrl.T.Helper()
+	return mr.mock.ctrl.RecordCallWithMethodType(mr.mock, "UpdateServer", reflect.TypeOf((*MockComputeClient)(nil).UpdateServer), ctx, id, opts)
+}


### PR DESCRIPTION
Allow mutability for all the fields available in gophercloud's server `UpdateOpts` structure.

Fixes https://github.com/k-orc/openstack-resource-controller/issues/470