### PR TITLE
dependabot: ignore modules requiring go1.24

### DIFF
--- a/.github/dependabot.yml
+++ b/.github/dependabot.yml
@@ -38,6 +38,8 @@ updates:
   # Ignore k8s major and minor bumps and its transitives modules
   - dependency-name: "k8s.io/*"
     update-types: ["version-update:semver-major", "version-update:semver-minor"]
+  # Bump from 1.38.0 to 1.38.1 requires go 1.24
+  - dependency-name: "github.com/onsi/gomega"
 ## main branch config ends here
 ## release-1.0 branch config starts here
 # github-actions
@@ -75,4 +77,6 @@ updates:
   # Ignore k8s major and minor bumps and its transitives modules
   - dependency-name: "k8s.io/*"
     update-types: ["version-update:semver-major", "version-update:semver-minor"]
+  # Bump from 1.38.0 to 1.38.1 requires go 1.24
+  - dependency-name: "github.com/onsi/gomega"
 ## release-1.0 branch config ends here


### PR DESCRIPTION
The bump of "github.com/onsi/gomega" from 1.38.0 to 1.38.1 requires go 1.24, while we're still on 1.23.