### PR TITLE
fix(docs): fix examples in getting-started.md

### DIFF
--- a/website/docs/getting-started.md
+++ b/website/docs/getting-started.md
@@ -47,8 +47,8 @@ spec:
     cloudName: openstack
     secretName: openstack-clouds
   managementPolicy: managed
-  networkRef: network-1
   resource:
+    networkRef: network-1
     description: |
       Example subnet
     tags:
@@ -137,8 +137,8 @@ spec:
     cloudName: openstack
     secretName: openstack-clouds
   managementPolicy: managed
-  networkRef: network-1
   resource:
+    networkRef: network-1
     allocationPools:
     - end: 192.168.1.60
       start: 192.168.1.5


### PR DESCRIPTION
Hello,

This PR fixes the documentation: example with `kind: Subnet`