### PR TITLE
Flavor: add mutability for all fields that support it

### DIFF
--- a/api/v1alpha1/flavor_types.go
+++ b/api/v1alpha1/flavor_types.go
@@ -17,11 +17,11 @@ limitations under the License.
 package v1alpha1
 
 // FlavorResourceSpec contains the desired state of a flavor
-// +kubebuilder:validation:XValidation:rule="self == oldSelf",message="FlavorResourceSpec is immutable"
 type FlavorResourceSpec struct {
 	// name will be the name of the created resource. If not specified, the
 	// name of the ORC object will be used.
 	// +optional
+	// +kubebuilder:validation:XValidation:rule="self == oldSelf",message="name is immutable"
 	Name *OpenStackName `json:"name,omitempty"`
 
 	// description contains a free form description of the flavor.
@@ -33,11 +33,13 @@ type FlavorResourceSpec struct {
 	// ram is the memory of the flavor, measured in MB.
 	// +kubebuilder:validation:Minimum=1
 	// +required
+	// +kubebuilder:validation:XValidation:rule="self == oldSelf",message="ram is immutable"
 	RAM int32 `json:"ram"`
 
 	// vcpus is the number of vcpus for the flavor.
 	// +kubebuilder:validation:Minimum=1
 	// +required
+	// +kubebuilder:validation:XValidation:rule="self == oldSelf",message="vcpus is immutable"
 	Vcpus int32 `json:"vcpus"`
 
 	// disk is the size of the root disk that will be created in GiB. If 0
@@ -50,16 +52,19 @@ type FlavorResourceSpec struct {
 	// os_compute_api:servers:create:zero_disk_flavor policy rule.
 	// +kubebuilder:validation:Minimum=0
 	// +required
+	// +kubebuilder:validation:XValidation:rule="self == oldSelf",message="disk is immutable"
 	Disk int32 `json:"disk"`
 
 	// swap is the size of a dedicated swap disk that will be allocated, in
 	// MiB. If 0 (the default), no dedicated swap disk will be created.
 	// +kubebuilder:validation:Minimum=0
 	// +optional
+	// +kubebuilder:validation:XValidation:rule="self == oldSelf",message="swap is immutable"
 	Swap int32 `json:"swap,omitempty"`
 
 	// isPublic flags a flavor as being available to all projects or not.
 	// +optional
+	// +kubebuilder:validation:XValidation:rule="self == oldSelf",message="isPublic is immutable"
 	IsPublic *bool `json:"isPublic,omitempty"`
 
 	// ephemeral is the size of the ephemeral disk that will be created, in GiB.
@@ -68,6 +73,7 @@ type FlavorResourceSpec struct {
 	// limitations. Defaults to 0.
 	// +kubebuilder:validation:Minimum=0
 	// +optional
+	// +kubebuilder:validation:XValidation:rule="self == oldSelf",message="ephemeral is immutable"
 	Ephemeral int32 `json:"ephemeral,omitempty"`
 }
 

--- a/config/crd/bases/openstack.k-orc.cloud_flavors.yaml
+++ b/config/crd/bases/openstack.k-orc.cloud_flavors.yaml
@@ -179,6 +179,9 @@ spec:
                     format: int32
                     minimum: 0
                     type: integer
+                    x-kubernetes-validations:
+                    - message: disk is immutable
+                      rule: self == oldSelf
                   ephemeral:
                     description: |-
                       ephemeral is the size of the ephemeral disk that will be created, in GiB.
@@ -188,10 +191,16 @@ spec:
                     format: int32
                     minimum: 0
                     type: integer
+                    x-kubernetes-validations:
+                    - message: ephemeral is immutable
+                      rule: self == oldSelf
                   isPublic:
                     description: isPublic flags a flavor as being available to all
                       projects or not.
                     type: boolean
+                    x-kubernetes-validations:
+                    - message: isPublic is immutable
+                      rule: self == oldSelf
                   name:
                     description: |-
                       name will be the name of the created resource. If not specified, the
@@ -200,11 +209,17 @@ spec:
                     minLength: 1
                     pattern: ^[^,]+$
                     type: string
+                    x-kubernetes-validations:
+                    - message: name is immutable
+                      rule: self == oldSelf
                   ram:
                     description: ram is the memory of the flavor, measured in MB.
                     format: int32
                     minimum: 1
                     type: integer
+                    x-kubernetes-validations:
+                    - message: ram is immutable
+                      rule: self == oldSelf
                   swap:
                     description: |-
                       swap is the size of a dedicated swap disk that will be allocated, in
@@ -212,19 +227,22 @@ spec:
                     format: int32
                     minimum: 0
                     type: integer
+                    x-kubernetes-validations:
+                    - message: swap is immutable
+                      rule: self == oldSelf
                   vcpus:
                     description: vcpus is the number of vcpus for the flavor.
                     format: int32
                     minimum: 1
                     type: integer
+                    x-kubernetes-validations:
+                    - message: vcpus is immutable
+                      rule: self == oldSelf
                 required:
                 - disk
                 - ram
                 - vcpus
                 type: object
-                x-kubernetes-validations:
-                - message: FlavorResourceSpec is immutable
-                  rule: self == oldSelf
             required:
             - cloudCredentialsRef
             type: object

--- a/internal/controllers/flavor/tests/flavor-update/00-assert.yaml
+++ b/internal/controllers/flavor/tests/flavor-update/00-assert.yaml
@@ -1,0 +1,20 @@
+---
+apiVersion: openstack.k-orc.cloud/v1alpha1
+kind: Flavor
+metadata:
+  name: flavor-update
+status:
+  resource:
+    name: flavor-update
+    description: flavor-update
+    ram: 1
+    vcpus: 2
+    disk: 0
+    isPublic: true
+  conditions:
+  - type: Available
+    status: "True"
+    reason: Success
+  - type: Progressing
+    status: "False"
+    reason: Success

--- a/internal/controllers/flavor/tests/flavor-update/00-minimal-resource.yaml
+++ b/internal/controllers/flavor/tests/flavor-update/00-minimal-resource.yaml
@@ -1,0 +1,16 @@
+---
+apiVersion: openstack.k-orc.cloud/v1alpha1
+kind: Flavor
+metadata:
+  name: flavor-update
+spec:
+  cloudCredentialsRef:
+    cloudName: openstack-admin
+    secretName: openstack-clouds
+  managementPolicy: managed
+  resource:
+    name: flavor-update
+    description: flavor-update
+    ram: 1
+    vcpus: 2
+    disk: 0

--- a/internal/controllers/flavor/tests/flavor-update/00-prerequisites.yaml
+++ b/internal/controllers/flavor/tests/flavor-update/00-prerequisites.yaml
@@ -1,0 +1,5 @@
+apiVersion: kuttl.dev/v1beta1
+kind: TestStep
+commands:
+  - command: kubectl create secret generic openstack-clouds --from-file=clouds.yaml=${E2E_KUTTL_OSCLOUDS} ${E2E_KUTTL_CACERT_OPT}
+    namespaced: true

--- a/internal/controllers/flavor/tests/flavor-update/01-assert.yaml
+++ b/internal/controllers/flavor/tests/flavor-update/01-assert.yaml
@@ -1,0 +1,20 @@
+---
+apiVersion: openstack.k-orc.cloud/v1alpha1
+kind: Flavor
+metadata:
+  name: flavor-update
+status:
+  resource:
+    name: flavor-update
+    description: flavor-update-updated
+    ram: 1
+    vcpus: 2
+    disk: 0
+    isPublic: true
+  conditions:
+  - type: Available
+    status: "True"
+    reason: Success
+  - type: Progressing
+    status: "False"
+    reason: Success

--- a/internal/controllers/flavor/tests/flavor-update/01-updated-resource.yaml
+++ b/internal/controllers/flavor/tests/flavor-update/01-updated-resource.yaml
@@ -1,0 +1,16 @@
+---
+apiVersion: openstack.k-orc.cloud/v1alpha1
+kind: Flavor
+metadata:
+  name: flavor-update
+spec:
+  cloudCredentialsRef:
+    cloudName: openstack-admin
+    secretName: openstack-clouds
+  managementPolicy: managed
+  resource:
+    name: flavor-update
+    description: flavor-update-updated
+    ram: 1
+    vcpus: 2
+    disk: 0

--- a/internal/controllers/flavor/tests/flavor-update/02-assert.yaml
+++ b/internal/controllers/flavor/tests/flavor-update/02-assert.yaml
@@ -1,0 +1,20 @@
+---
+apiVersion: openstack.k-orc.cloud/v1alpha1
+kind: Flavor
+metadata:
+  name: flavor-update
+status:
+  resource:
+    name: flavor-update
+    description: flavor-update
+    ram: 1
+    vcpus: 2
+    disk: 0
+    isPublic: true
+  conditions:
+  - type: Available
+    status: "True"
+    reason: Success
+  - type: Progressing
+    status: "False"
+    reason: Success

--- a/internal/controllers/flavor/tests/flavor-update/02-reverted-resource.yaml
+++ b/internal/controllers/flavor/tests/flavor-update/02-reverted-resource.yaml
@@ -1,0 +1,7 @@
+# NOTE: kuttl only does patch updates, which means we can't delete a field.
+# We have to use a kubectl apply command instead.
+apiVersion: kuttl.dev/v1beta1
+kind: TestStep
+commands:
+  - command: kubectl replace -f 00-minimal-resource.yaml
+    namespaced: true

--- a/internal/osclients/compute.go
+++ b/internal/osclients/compute.go
@@ -50,6 +50,7 @@ type ComputeClient interface {
 	GetFlavor(ctx context.Context, id string) (*flavors.Flavor, error)
 	DeleteFlavor(ctx context.Context, id string) error
 	ListFlavors(ctx context.Context, listOpts flavors.ListOptsBuilder) iter.Seq2[*flavors.Flavor, error]
+	UpdateFlavor(ctx context.Context, id string, opts flavors.UpdateOptsBuilder) (*flavors.Flavor, error)
 
 	CreateServer(ctx context.Context, createOpts servers.CreateOptsBuilder, schedulerHints servers.SchedulerHintOptsBuilder) (*servers.Server, error)
 	DeleteServer(ctx context.Context, serverID string) error
@@ -104,6 +105,10 @@ func (c computeClient) ListFlavors(ctx context.Context, opts flavors.ListOptsBui
 	return func(yield func(*flavors.Flavor, error) bool) {
 		_ = pager.EachPage(ctx, yieldPage(flavors.ExtractFlavors, yield))
 	}
+}
+
+func (c computeClient) UpdateFlavor(ctx context.Context, id string, opts flavors.UpdateOptsBuilder) (*flavors.Flavor, error) {
+	return flavors.Update(ctx, c.client, id, opts).Extract()
 }
 
 func (c computeClient) CreateServer(ctx context.Context, createOpts servers.CreateOptsBuilder, schedulerHints servers.SchedulerHintOptsBuilder) (*servers.Server, error) {
@@ -179,6 +184,10 @@ func (e computeErrorClient) ListFlavors(_ context.Context, _ flavors.ListOptsBui
 	return func(yield func(*flavors.Flavor, error) bool) {
 		yield(nil, e.error)
 	}
+}
+
+func (e computeErrorClient) UpdateFlavor(_ context.Context, _ string, _ flavors.UpdateOptsBuilder) (*flavors.Flavor, error) {
+	return nil, e.error
 }
 
 func (e computeErrorClient) ListAvailabilityZones(_ context.Context) ([]availabilityzones.AvailabilityZone, error) {

--- a/internal/osclients/mock/compute.go
+++ b/internal/osclients/mock/compute.go
@@ -233,6 +233,21 @@ func (mr *MockComputeClientMockRecorder) ListServers(ctx, listOpts any) *gomock.
 	return mr.mock.ctrl.RecordCallWithMethodType(mr.mock, "ListServers", reflect.TypeOf((*MockComputeClient)(nil).ListServers), ctx, listOpts)
 }
 
+// UpdateFlavor mocks base method.
+func (m *MockComputeClient) UpdateFlavor(ctx context.Context, id string, opts flavors.UpdateOptsBuilder) (*flavors.Flavor, error) {
+	m.ctrl.T.Helper()
+	ret := m.ctrl.Call(m, "UpdateFlavor", ctx, id, opts)
+	ret0, _ := ret[0].(*flavors.Flavor)
+	ret1, _ := ret[1].(error)
+	return ret0, ret1
+}
+
+// UpdateFlavor indicates an expected call of UpdateFlavor.
+func (mr *MockComputeClientMockRecorder) UpdateFlavor(ctx, id, opts any) *gomock.Call {
+	mr.mock.ctrl.T.Helper()
+	return mr.mock.ctrl.RecordCallWithMethodType(mr.mock, "UpdateFlavor", reflect.TypeOf((*MockComputeClient)(nil).UpdateFlavor), ctx, id, opts)
+}
+
 // UpdateServer mocks base method.
 func (m *MockComputeClient) UpdateServer(ctx context.Context, id string, opts servers.UpdateOptsBuilder) (*servers.Server, error) {
 	m.ctrl.T.Helper()

--- a/test/apivalidations/flavor_test.go
+++ b/test/apivalidations/flavor_test.go
@@ -81,7 +81,7 @@ var _ = Describe("ORC Flavor API validations", func() {
 		patch.Spec.WithResource(applyconfigv1alpha1.FlavorResourceSpec().WithRAM(1).WithVcpus(1).WithDisk(1))
 		Expect(applyObj(ctx, flavor, patch)).To(Succeed())
 		patch.Spec.WithResource(applyconfigv1alpha1.FlavorResourceSpec().WithRAM(2).WithVcpus(1).WithDisk(1))
-		Expect(applyObj(ctx, flavor, patch)).To(MatchError(ContainSubstring("FlavorResourceSpec is immutable")))
+		Expect(applyObj(ctx, flavor, patch)).To(MatchError(ContainSubstring("ram is immutable")))
 	})
 
 	It("should reject a flavor without required fields", func(ctx context.Context) {


### PR DESCRIPTION
Allow mutability for all the fields available in gophercloud's flavor UpdateOpts structure.

Fixes: https://github.com/k-orc/openstack-resource-controller/issues/465