### PR TITLE
FloatingIP: add mutability for all fields that support it

### DIFF
--- a/api/v1alpha1/floatingip_types.go
+++ b/api/v1alpha1/floatingip_types.go
@@ -49,7 +49,6 @@ type FloatingIPFilter struct {
 }
 
 // FloatingIPResourceSpec contains the desired state of a floating IP
-// +kubebuilder:validation:XValidation:rule="self == oldSelf",message="FloatingIPResourceSpec is immutable"
 // +kubebuilder:validation:XValidation:rule="has(self.floatingNetworkRef) != has(self.floatingSubnetRef)",message="Exactly one of 'floatingNetworkRef' or 'floatingSubnetRef' must be set"
 type FloatingIPResourceSpec struct {
 	// description is a human-readable description for the resource.
@@ -64,28 +63,34 @@ type FloatingIPResourceSpec struct {
 
 	// floatingNetworkRef references the network to which the floatingip is associated.
 	// +optional
+	// +kubebuilder:validation:XValidation:rule="self == oldSelf",message="floatingNetworkRef is immutable"
 	FloatingNetworkRef *KubernetesNameRef `json:"floatingNetworkRef,omitempty"`
 
 	// floatingSubnetRef references the subnet to which the floatingip is associated.
 	// +optional
+	// +kubebuilder:validation:XValidation:rule="self == oldSelf",message="floatingSubnetRef is immutable"
 	FloatingSubnetRef *KubernetesNameRef `json:"floatingSubnetRef,omitempty"`
 
 	// floatingIP is the IP that will be assigned to the floatingip. If not set, it will
 	// be assigned automatically.
 	// +optional
+	// +kubebuilder:validation:XValidation:rule="self == oldSelf",message="floatingIP is immutable"
 	FloatingIP *IPvAny `json:"floatingIP,omitempty"`
 
 	// portRef is a reference to the ORC Port which this resource is associated with.
 	// +optional
+	// +kubebuilder:validation:XValidation:rule="self == oldSelf",message="portRef is immutable"
 	PortRef *KubernetesNameRef `json:"portRef,omitempty"`
 
 	// fixedIP is the IP address of the port to which the floatingip is associated.
 	// +optional
+	// +kubebuilder:validation:XValidation:rule="self == oldSelf",message="fixedIP is immutable"
 	FixedIP *IPvAny `json:"fixedIP,omitempty"`
 
 	// projectRef is a reference to the ORC Project this resource is associated with.
 	// Typically, only used by admin.
 	// +optional
+	// +kubebuilder:validation:XValidation:rule="self == oldSelf",message="projectRef is immutable"
 	ProjectRef *KubernetesNameRef `json:"projectRef,omitempty"`
 }
 

--- a/config/crd/bases/openstack.k-orc.cloud_floatingips.yaml
+++ b/config/crd/bases/openstack.k-orc.cloud_floatingips.yaml
@@ -244,6 +244,9 @@ spec:
                     maxLength: 45
                     minLength: 1
                     type: string
+                    x-kubernetes-validations:
+                    - message: fixedIP is immutable
+                      rule: self == oldSelf
                   floatingIP:
                     description: |-
                       floatingIP is the IP that will be assigned to the floatingip. If not set, it will
@@ -251,24 +254,36 @@ spec:
                     maxLength: 45
                     minLength: 1
                     type: string
+                    x-kubernetes-validations:
+                    - message: floatingIP is immutable
+                      rule: self == oldSelf
                   floatingNetworkRef:
                     description: floatingNetworkRef references the network to which
                       the floatingip is associated.
                     maxLength: 253
                     minLength: 1
                     type: string
+                    x-kubernetes-validations:
+                    - message: floatingNetworkRef is immutable
+                      rule: self == oldSelf
                   floatingSubnetRef:
                     description: floatingSubnetRef references the subnet to which
                       the floatingip is associated.
                     maxLength: 253
                     minLength: 1
                     type: string
+                    x-kubernetes-validations:
+                    - message: floatingSubnetRef is immutable
+                      rule: self == oldSelf
                   portRef:
                     description: portRef is a reference to the ORC Port which this
                       resource is associated with.
                     maxLength: 253
                     minLength: 1
                     type: string
+                    x-kubernetes-validations:
+                    - message: portRef is immutable
+                      rule: self == oldSelf
                   projectRef:
                     description: |-
                       projectRef is a reference to the ORC Project this resource is associated with.
@@ -276,6 +291,9 @@ spec:
                     maxLength: 253
                     minLength: 1
                     type: string
+                    x-kubernetes-validations:
+                    - message: projectRef is immutable
+                      rule: self == oldSelf
                   tags:
                     description: tags is a list of tags which will be applied to the
                       floatingip.
@@ -291,8 +309,6 @@ spec:
                     x-kubernetes-list-type: set
                 type: object
                 x-kubernetes-validations:
-                - message: FloatingIPResourceSpec is immutable
-                  rule: self == oldSelf
                 - message: Exactly one of 'floatingNetworkRef' or 'floatingSubnetRef'
                     must be set
                   rule: has(self.floatingNetworkRef) != has(self.floatingSubnetRef)

--- a/internal/controllers/floatingip/actuator_test.go
+++ b/internal/controllers/floatingip/actuator_test.go
@@ -1,0 +1,73 @@
+package floatingip
+
+import (
+	"testing"
+
+	"github.com/gophercloud/gophercloud/v2/openstack/networking/v2/extensions/layer3/floatingips"
+	orcv1alpha1 "github.com/k-orc/openstack-resource-controller/v2/api/v1alpha1"
+	"k8s.io/utils/ptr"
+)
+
+func TestNeedsUpdate(t *testing.T) {
+	testCases := []struct {
+		name         string
+		updateOpts   floatingips.UpdateOptsBuilder
+		expectChange bool
+	}{
+		{
+			name:         "Empty base opts",
+			updateOpts:   floatingips.UpdateOpts{},
+			expectChange: false,
+		},
+		{
+			name:         "Empty base opts with revision number",
+			updateOpts:   floatingips.UpdateOpts{RevisionNumber: ptr.To(4)},
+			expectChange: false,
+		},
+		{
+			name:         "Updated opts",
+			updateOpts:   floatingips.UpdateOpts{Description: ptr.To("updated")},
+			expectChange: true,
+		},
+	}
+
+	for _, tt := range testCases {
+		t.Run(tt.name, func(t *testing.T) {
+			got, _ := needsUpdate(tt.updateOpts)
+			if got != tt.expectChange {
+				t.Errorf("Expected change: %v, got: %v", tt.expectChange, got)
+			}
+		})
+	}
+}
+
+func TestHandleDescriptionUpdate(t *testing.T) {
+	ptrToDescription := ptr.To[orcv1alpha1.NeutronDescription]
+	testCases := []struct {
+		name          string
+		newValue      *orcv1alpha1.NeutronDescription
+		existingValue string
+		expectChange  bool
+	}{
+		{name: "Identical", newValue: ptrToDescription("desc"), existingValue: "desc", expectChange: false},
+		{name: "Different", newValue: ptrToDescription("new-desc"), existingValue: "desc", expectChange: true},
+		{name: "No value provided, existing is set", newValue: nil, existingValue: "desc", expectChange: true},
+		{name: "No value provided, existing is empty", newValue: nil, existingValue: "", expectChange: false},
+	}
+
+	for _, tt := range testCases {
+		t.Run(tt.name, func(t *testing.T) {
+			resource := &orcv1alpha1.FloatingIPResourceSpec{Description: tt.newValue}
+			osResource := &floatingips.FloatingIP{Description: tt.existingValue}
+
+			updateOpts := floatingips.UpdateOpts{}
+			handleDescriptionUpdate(&updateOpts, resource, osResource)
+
+			got, _ := needsUpdate(updateOpts)
+			if got != tt.expectChange {
+				t.Errorf("Expected change: %v, got: %v", tt.expectChange, got)
+			}
+		})
+
+	}
+}

--- a/internal/controllers/floatingip/tests/floatingip-update/00-assert.yaml
+++ b/internal/controllers/floatingip/tests/floatingip-update/00-assert.yaml
@@ -1,0 +1,30 @@
+---
+apiVersion: kuttl.dev/v1beta1
+kind: TestAssert
+resourceRefs:
+    - apiVersion: openstack.k-orc.cloud/v1alpha1
+      kind: FloatingIP
+      name: floatingip-update
+      ref: floatingIP
+    - apiVersion: openstack.k-orc.cloud/v1alpha1
+      kind: Network
+      name: floatingip-update
+      ref: network
+assertAll:
+    - celExpr: "floatingIP.status.resource.floatingNetworkID == network.status.id"
+    - celExpr: "floatingIP.status.resource.floatingIP != ''"
+    - celExpr: "!has(floatingIP.status.resource.tags)"
+    - celExpr: "!has(floatingIP.status.resource.description)"
+---
+apiVersion: openstack.k-orc.cloud/v1alpha1
+kind: FloatingIP
+metadata:
+  name: floatingip-update
+status:
+  conditions:
+  - type: Available
+    status: "True"
+    reason: Success
+  - type: Progressing
+    status: "False"
+    reason: Success

--- a/internal/controllers/floatingip/tests/floatingip-update/00-minimal-resource.yaml
+++ b/internal/controllers/floatingip/tests/floatingip-update/00-minimal-resource.yaml
@@ -1,0 +1,11 @@
+apiVersion: openstack.k-orc.cloud/v1alpha1
+kind: FloatingIP
+metadata:
+  name: floatingip-update
+spec:
+  cloudCredentialsRef:
+    cloudName: openstack-admin
+    secretName: openstack-clouds
+  managementPolicy: managed
+  resource:
+    floatingNetworkRef: floatingip-update

--- a/internal/controllers/floatingip/tests/floatingip-update/00-prerequisites.yaml
+++ b/internal/controllers/floatingip/tests/floatingip-update/00-prerequisites.yaml
@@ -1,0 +1,31 @@
+apiVersion: kuttl.dev/v1beta1
+kind: TestStep
+commands:
+  - command: kubectl create secret generic openstack-clouds --from-file=clouds.yaml=${E2E_KUTTL_OSCLOUDS} ${E2E_KUTTL_CACERT_OPT}
+    namespaced: true
+---
+apiVersion: openstack.k-orc.cloud/v1alpha1
+kind: Network
+metadata:
+  name: floatingip-update
+spec:
+  cloudCredentialsRef:
+    cloudName: openstack-admin
+    secretName: openstack-clouds
+  managementPolicy: managed
+  resource:
+    external: true
+---
+apiVersion: openstack.k-orc.cloud/v1alpha1
+kind: Subnet
+metadata:
+  name: floatingip-update
+spec:
+  cloudCredentialsRef:
+    cloudName: openstack
+    secretName: openstack-clouds
+  managementPolicy: managed
+  resource:
+    networkRef: floatingip-update
+    ipVersion: 4
+    cidr: 192.168.155.0/24

--- a/internal/controllers/floatingip/tests/floatingip-update/01-assert.yaml
+++ b/internal/controllers/floatingip/tests/floatingip-update/01-assert.yaml
@@ -1,0 +1,33 @@
+---
+apiVersion: kuttl.dev/v1beta1
+kind: TestAssert
+resourceRefs:
+    - apiVersion: openstack.k-orc.cloud/v1alpha1
+      kind: FloatingIP
+      name: floatingip-update
+      ref: floatingIP
+    - apiVersion: openstack.k-orc.cloud/v1alpha1
+      kind: Network
+      name: floatingip-update
+      ref: network
+assertAll:
+    - celExpr: "floatingIP.status.resource.floatingNetworkID == network.status.id"
+    - celExpr: "floatingIP.status.resource.floatingIP != ''"
+---
+apiVersion: openstack.k-orc.cloud/v1alpha1
+kind: FloatingIP
+metadata:
+  name: floatingip-update
+status:
+  resource:
+    description: floatingip-update-updated
+    tags:
+      - tag1
+      - tag2
+  conditions:
+  - type: Available
+    status: "True"
+    reason: Success
+  - type: Progressing
+    status: "False"
+    reason: Success

--- a/internal/controllers/floatingip/tests/floatingip-update/01-updated-resource.yaml
+++ b/internal/controllers/floatingip/tests/floatingip-update/01-updated-resource.yaml
@@ -1,0 +1,11 @@
+apiVersion: openstack.k-orc.cloud/v1alpha1
+kind: FloatingIP
+metadata:
+  name: floatingip-update
+spec:
+  resource:
+    floatingNetworkRef: floatingip-update
+    description: floatingip-update-updated
+    tags:
+      - tag1
+      - tag2

--- a/internal/controllers/floatingip/tests/floatingip-update/02-assert.yaml
+++ b/internal/controllers/floatingip/tests/floatingip-update/02-assert.yaml
@@ -1,0 +1,30 @@
+---
+apiVersion: kuttl.dev/v1beta1
+kind: TestAssert
+resourceRefs:
+    - apiVersion: openstack.k-orc.cloud/v1alpha1
+      kind: FloatingIP
+      name: floatingip-update
+      ref: floatingIP
+    - apiVersion: openstack.k-orc.cloud/v1alpha1
+      kind: Network
+      name: floatingip-update
+      ref: network
+assertAll:
+    - celExpr: "floatingIP.status.resource.floatingNetworkID == network.status.id"
+    - celExpr: "floatingIP.status.resource.floatingIP != ''"
+    - celExpr: "!has(floatingIP.status.resource.tags)"
+    - celExpr: "!has(floatingIP.status.resource.description)"
+---
+apiVersion: openstack.k-orc.cloud/v1alpha1
+kind: FloatingIP
+metadata:
+  name: floatingip-update
+status:
+  conditions:
+  - type: Available
+    status: "True"
+    reason: Success
+  - type: Progressing
+    status: "False"
+    reason: Success

--- a/internal/controllers/floatingip/tests/floatingip-update/02-reverted-resource.yaml
+++ b/internal/controllers/floatingip/tests/floatingip-update/02-reverted-resource.yaml
@@ -1,0 +1,7 @@
+# NOTE: kuttl only does patch updates, which means we can't delete a field.
+# We have to use a kubectl apply command instead.
+apiVersion: kuttl.dev/v1beta1
+kind: TestStep
+commands:
+  - command: kubectl replace -f 00-minimal-resource.yaml
+    namespaced: true


### PR DESCRIPTION
Allow mutability for all the fields available in gophercloud's floatingIP `UpdateOpts` structure.

Fixes: https://github.com/k-orc/openstack-resource-controller/issues/466