### PR TITLE
Router: add mutability for all fields that support it

### DIFF
--- a/api/v1alpha1/router_types.go
+++ b/api/v1alpha1/router_types.go
@@ -49,7 +49,6 @@ type ExternalGatewayStatus struct {
 	NetworkID string `json:"networkID,omitempty"`
 }
 
-// +kubebuilder:validation:XValidation:rule="self == oldSelf",message="RouterResourceSpec is immutable"
 type RouterResourceSpec struct {
 	// name is a human-readable name of the router. If not set, the
 	// object's name will be used.
@@ -76,22 +75,26 @@ type RouterResourceSpec struct {
 	// +kubebuilder:validation:MaxItems:=1
 	// +listType=atomic
 	// +optional
+	// +kubebuilder:validation:XValidation:rule="self == oldSelf",message="externalGateways is immutable"
 	ExternalGateways []ExternalGateway `json:"externalGateways,omitempty"`
 
 	// distributed indicates whether the router is distributed or not. It
 	// is available when dvr extension is enabled.
 	// +optional
+	// +kubebuilder:validation:XValidation:rule="self == oldSelf",message="distributed is immutable"
 	Distributed *bool `json:"distributed,omitempty"`
 
 	// availabilityZoneHints is the availability zone candidate for the router.
 	// +kubebuilder:validation:MaxItems:=32
 	// +listType=set
 	// +optional
+	// +kubebuilder:validation:XValidation:rule="self == oldSelf",message="availabilityZoneHints is immutable"
 	AvailabilityZoneHints []AvailabilityZoneHint `json:"availabilityZoneHints,omitempty"`
 
 	// projectRef is a reference to the ORC Project this resource is associated with.
 	// Typically, only used by admin.
 	// +optional
+	// +kubebuilder:validation:XValidation:rule="self == oldSelf",message="projectRef is immutable"
 	ProjectRef *KubernetesNameRef `json:"projectRef,omitempty"`
 }
 

--- a/config/crd/bases/openstack.k-orc.cloud_routers.yaml
+++ b/config/crd/bases/openstack.k-orc.cloud_routers.yaml
@@ -228,6 +228,9 @@ spec:
                     maxItems: 32
                     type: array
                     x-kubernetes-list-type: set
+                    x-kubernetes-validations:
+                    - message: availabilityZoneHints is immutable
+                      rule: self == oldSelf
                   description:
                     description: description is a human-readable description for the
                       resource.
@@ -239,6 +242,9 @@ spec:
                       distributed indicates whether the router is distributed or not. It
                       is available when dvr extension is enabled.
                     type: boolean
+                    x-kubernetes-validations:
+                    - message: distributed is immutable
+                      rule: self == oldSelf
                   externalGateways:
                     description: |-
                       externalGateways is a list of external gateways for the router.
@@ -258,6 +264,9 @@ spec:
                     maxItems: 1
                     type: array
                     x-kubernetes-list-type: atomic
+                    x-kubernetes-validations:
+                    - message: externalGateways is immutable
+                      rule: self == oldSelf
                   name:
                     description: |-
                       name is a human-readable name of the router. If not set, the
@@ -273,6 +282,9 @@ spec:
                     maxLength: 253
                     minLength: 1
                     type: string
+                    x-kubernetes-validations:
+                    - message: projectRef is immutable
+                      rule: self == oldSelf
                   tags:
                     description: tags is a list of tags which will be applied to the
                       router.
@@ -287,9 +299,6 @@ spec:
                     type: array
                     x-kubernetes-list-type: set
                 type: object
-                x-kubernetes-validations:
-                - message: RouterResourceSpec is immutable
-                  rule: self == oldSelf
             required:
             - cloudCredentialsRef
             type: object

--- a/internal/controllers/router/actuator_test.go
+++ b/internal/controllers/router/actuator_test.go
@@ -1,0 +1,137 @@
+package router
+
+import (
+	"testing"
+
+	"github.com/gophercloud/gophercloud/v2/openstack/networking/v2/extensions/layer3/routers"
+	orcv1alpha1 "github.com/k-orc/openstack-resource-controller/v2/api/v1alpha1"
+	"k8s.io/utils/ptr"
+)
+
+func TestNeedsUpdate(t *testing.T) {
+	testCases := []struct {
+		name         string
+		updateOpts   routers.UpdateOptsBuilder
+		expectChange bool
+	}{
+		{
+			name:         "Empty base opts",
+			updateOpts:   routers.UpdateOpts{},
+			expectChange: false,
+		},
+		{
+			name:         "Empty base opts with revision number",
+			updateOpts:   routers.UpdateOpts{RevisionNumber: ptr.To(4)},
+			expectChange: false,
+		},
+		{
+			name:         "Updated opts",
+			updateOpts:   routers.UpdateOpts{Name: "updated"},
+			expectChange: true,
+		},
+	}
+
+	for _, tt := range testCases {
+		t.Run(tt.name, func(t *testing.T) {
+			got, _ := needsUpdate(tt.updateOpts)
+			if got != tt.expectChange {
+				t.Errorf("Expected change: %v, got: %v", tt.expectChange, got)
+			}
+		})
+	}
+}
+
+func TestHandleNameUpdate(t *testing.T) {
+	ptrToName := ptr.To[orcv1alpha1.OpenStackName]
+	testCases := []struct {
+		name          string
+		newValue      *orcv1alpha1.OpenStackName
+		existingValue string
+		expectChange  bool
+	}{
+		{name: "Identical", newValue: ptrToName("name"), existingValue: "name", expectChange: false},
+		{name: "Different", newValue: ptrToName("new-name"), existingValue: "name", expectChange: true},
+		{name: "No value provided, existing is identical to object name", newValue: nil, existingValue: "object-name", expectChange: false},
+		{name: "No value provided, existing is different from object name", newValue: nil, existingValue: "different-from-object-name", expectChange: true},
+	}
+
+	for _, tt := range testCases {
+		t.Run(tt.name, func(t *testing.T) {
+			resource := &orcv1alpha1.Router{}
+			resource.Name = "object-name"
+			resource.Spec = orcv1alpha1.RouterSpec{
+				Resource: &orcv1alpha1.RouterResourceSpec{Name: tt.newValue},
+			}
+			osResource := &routers.Router{Name: tt.existingValue}
+
+			updateOpts := routers.UpdateOpts{}
+			handleNameUpdate(&updateOpts, resource, osResource)
+
+			got, _ := needsUpdate(updateOpts)
+			if got != tt.expectChange {
+				t.Errorf("Expected change: %v, got: %v", tt.expectChange, got)
+			}
+		})
+
+	}
+}
+
+func TestHandleDescriptionUpdate(t *testing.T) {
+	ptrToDescription := ptr.To[orcv1alpha1.NeutronDescription]
+	testCases := []struct {
+		name          string
+		newValue      *orcv1alpha1.NeutronDescription
+		existingValue string
+		expectChange  bool
+	}{
+		{name: "Identical", newValue: ptrToDescription("desc"), existingValue: "desc", expectChange: false},
+		{name: "Different", newValue: ptrToDescription("new-desc"), existingValue: "desc", expectChange: true},
+		{name: "No value provided, existing is set", newValue: nil, existingValue: "desc", expectChange: true},
+		{name: "No value provided, existing is empty", newValue: nil, existingValue: "", expectChange: false},
+	}
+
+	for _, tt := range testCases {
+		t.Run(tt.name, func(t *testing.T) {
+			resource := &orcv1alpha1.RouterResourceSpec{Description: tt.newValue}
+			osResource := &routers.Router{Description: tt.existingValue}
+
+			updateOpts := routers.UpdateOpts{}
+			handleDescriptionUpdate(&updateOpts, resource, osResource)
+
+			got, _ := needsUpdate(updateOpts)
+			if got != tt.expectChange {
+				t.Errorf("Expected change: %v, got: %v", tt.expectChange, got)
+			}
+		})
+
+	}
+}
+
+func TestHandleAdminStateUpUpdate(t *testing.T) {
+	ptrToBool := ptr.To[bool]
+	testCases := []struct {
+		name          string
+		newValue      *bool
+		existingValue bool
+		expectChange  bool
+	}{
+		{name: "Identical", newValue: ptrToBool(true), existingValue: true, expectChange: false},
+		{name: "Different", newValue: ptrToBool(true), existingValue: false, expectChange: true},
+		{name: "No value provided, existing is default", newValue: nil, existingValue: true, expectChange: false},
+	}
+
+	for _, tt := range testCases {
+		t.Run(tt.name, func(t *testing.T) {
+			resource := &orcv1alpha1.RouterResourceSpec{AdminStateUp: tt.newValue}
+			osResource := &routers.Router{AdminStateUp: tt.existingValue}
+
+			updateOpts := routers.UpdateOpts{}
+			handleAdminStateUpUpdate(&updateOpts, resource, osResource)
+
+			got, _ := needsUpdate(updateOpts)
+			if got != tt.expectChange {
+				t.Errorf("Expected change: %v, got: %v", tt.expectChange, got)
+			}
+		})
+	}
+}

--- a/internal/controllers/router/tests/router-update/00-assert.yaml
+++ b/internal/controllers/router/tests/router-update/00-assert.yaml
@@ -1,0 +1,26 @@
+apiVersion: kuttl.dev/v1beta1
+kind: TestAssert
+resourceRefs:
+    - apiVersion: openstack.k-orc.cloud/v1alpha1
+      kind: Router
+      name: router-update
+      ref: router
+assertAll:
+    - celExpr: "!has(router.status.resource.tags)"
+---
+apiVersion: openstack.k-orc.cloud/v1alpha1
+kind: Router
+metadata:
+  name: router-update
+status:
+  resource: 
+    name: router-update
+    description: router-update
+    adminStateUp: true
+  conditions:
+  - type: Available
+    status: "True"
+    reason: Success
+  - type: Progressing
+    status: "False"
+    reason: Success

--- a/internal/controllers/router/tests/router-update/00-minimal-resource.yaml
+++ b/internal/controllers/router/tests/router-update/00-minimal-resource.yaml
@@ -1,0 +1,14 @@
+apiVersion: openstack.k-orc.cloud/v1alpha1
+kind: Router
+metadata:
+  name: router-update
+spec:
+  cloudCredentialsRef:
+    cloudName: openstack
+    secretName: openstack-clouds
+  managementPolicy: managed
+  resource:
+    name: router-update
+    description: router-update
+    # Need to set the default values to revert them correctly in the 02-revert-resource step.
+    adminStateUp: true

--- a/internal/controllers/router/tests/router-update/00-prerequisites.yaml
+++ b/internal/controllers/router/tests/router-update/00-prerequisites.yaml
@@ -1,0 +1,5 @@
+apiVersion: kuttl.dev/v1beta1
+kind: TestStep
+commands:
+  - command: kubectl create secret generic openstack-clouds --from-file=clouds.yaml=${E2E_KUTTL_OSCLOUDS} ${E2E_KUTTL_CACERT_OPT}
+    namespaced: true

--- a/internal/controllers/router/tests/router-update/01-assert.yaml
+++ b/internal/controllers/router/tests/router-update/01-assert.yaml
@@ -1,0 +1,19 @@
+apiVersion: openstack.k-orc.cloud/v1alpha1
+kind: Router
+metadata:
+  name: router-update
+status:
+  resource: 
+    name: router-update-updated
+    description: router-update-updated
+    adminStateUp: false
+    tags:
+      - tag1
+      - tag2
+  conditions:
+  - type: Available
+    status: "True"
+    reason: Success
+  - type: Progressing
+    status: "False"
+    reason: Success

--- a/internal/controllers/router/tests/router-update/01-updated-resource.yaml
+++ b/internal/controllers/router/tests/router-update/01-updated-resource.yaml
@@ -1,0 +1,12 @@
+apiVersion: openstack.k-orc.cloud/v1alpha1
+kind: Router
+metadata:
+  name: router-update
+spec:
+  resource:
+    name: router-update-updated
+    description: router-update-updated
+    adminStateUp: false
+    tags:
+      - tag1
+      - tag2

--- a/internal/controllers/router/tests/router-update/02-assert.yaml
+++ b/internal/controllers/router/tests/router-update/02-assert.yaml
@@ -1,0 +1,26 @@
+apiVersion: kuttl.dev/v1beta1
+kind: TestAssert
+resourceRefs:
+    - apiVersion: openstack.k-orc.cloud/v1alpha1
+      kind: Router
+      name: router-update
+      ref: router
+assertAll:
+    - celExpr: "!has(router.status.resource.tags)"
+---
+apiVersion: openstack.k-orc.cloud/v1alpha1
+kind: Router
+metadata:
+  name: router-update
+status:
+  resource: 
+    name: router-update
+    description: router-update
+    adminStateUp: true
+  conditions:
+  - type: Available
+    status: "True"
+    reason: Success
+  - type: Progressing
+    status: "False"
+    reason: Success

--- a/internal/controllers/router/tests/router-update/02-reverted-resource.yaml
+++ b/internal/controllers/router/tests/router-update/02-reverted-resource.yaml
@@ -1,0 +1,7 @@
+# NOTE: kuttl only does patch updates, which means we can't delete a field.
+# We have to use a kubectl apply command instead.
+apiVersion: kuttl.dev/v1beta1
+kind: TestStep
+commands:
+  - command: kubectl replace -f 00-minimal-resource.yaml
+    namespaced: true


### PR DESCRIPTION
Allow mutability for all the fields available in gophercloud's flavor UpdateOpts structure.

Fixes: https://github.com/k-orc/openstack-resource-controller/issues/468