### PR TITLE
Bump go to 1.23.12

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -4,7 +4,7 @@ BUNDLE_IMG ?= bundle:latest
 # ENVTEST_K8S_VERSION refers to the version of kubebuilder assets to be downloaded by envtest binary.
 ENVTEST_K8S_VERSION = 1.29.0
 TRIVY_VERSION = 0.49.1
-GO_VERSION ?= 1.23.10
+GO_VERSION ?= 1.23.12
 
 # Get the currently used golang install path (in GOPATH/bin, unless GOBIN is set)
 ifeq (,$(shell go env GOBIN))


### PR DESCRIPTION
This addresses GO-2025-3956.
See https://pkg.go.dev/vuln/GO-2025-3956 for details.