### PR TITLE
Server: Fix a panic during tag reconcile

### DIFF
--- a/internal/controllers/server/actuator.go
+++ b/internal/controllers/server/actuator.go
@@ -248,7 +248,7 @@ var _ reconcileResourceActuator = serverActuator{}
 
 func (actuator serverActuator) GetResourceReconcilers(ctx context.Context, orcObject orcObjectPT, osResource *osResourceT, controller interfaces.ResourceController) ([]resourceReconciler, progress.ReconcileStatus) {
 	return []resourceReconciler{
-		tags.ReconcileTags[orcObjectPT, osResourceT](orcObject.Spec.Resource.Tags, *osResource.Tags, tags.NewServerTagReplacer(actuator.osClient, osResource.ID)),
+		tags.ReconcileTags[orcObjectPT, osResourceT](orcObject.Spec.Resource.Tags, ptr.Deref(osResource.Tags, []string{}), tags.NewServerTagReplacer(actuator.osClient, osResource.ID)),
 		actuator.checkStatus,
 		actuator.updateResource,
 		actuator.reconcileVolumeAttachments,


### PR DESCRIPTION
For some reason, gophercloud returns server tags as a pointer to a slice of strings. It could be nil if the server has no tags yet. We need to properly deref it.

Fixes https://github.com/k-orc/openstack-resource-controller/issues/529.