### PR TITLE
Image: add mutability for all fields that support it

### DIFF
--- a/api/v1alpha1/image_types.go
+++ b/api/v1alpha1/image_types.go
@@ -309,12 +309,6 @@ type ImageHash struct {
 }
 
 // ImageResourceSpec contains the desired state of a Glance image
-// +kubebuilder:validation:XValidation:rule="has(self.name) ? self.name == oldSelf.name : !has(oldSelf.name)",message="name is immutable"
-// +kubebuilder:validation:XValidation:rule="has(self.protected) ? self.protected == oldSelf.protected : !has(oldSelf.protected)",message="name is immutable"
-// +kubebuilder:validation:XValidation:rule="has(self.tags) ? self.tags == oldSelf.tags : !has(oldSelf.tags)",message="tags is immutable"
-// +kubebuilder:validation:XValidation:rule="has(self.visibility) ? self.visibility == oldSelf.visibility : !has(oldSelf.visibility)",message="visibility is immutable"
-// +kubebuilder:validation:XValidation:rule="has(self.properties) ? self.properties == oldSelf.properties : !has(oldSelf.properties)",message="properties is immutable"
-// +kubebuilder:validation:XValidation:rule="self == oldSelf",message="ImageResourceSpec is immutable"
 type ImageResourceSpec struct {
 	// name will be the name of the created Glance image. If not specified, the
 	// name of the Image object will be used.
@@ -333,11 +327,11 @@ type ImageResourceSpec struct {
 	Tags []ImageTag `json:"tags,omitempty"`
 
 	// visibility of the image
-	// +kubebuilder:validation:XValidation:rule="self == oldSelf",message="visibility is immutable"
 	// +optional
 	Visibility *ImageVisibility `json:"visibility,omitempty"`
 
 	// properties is metadata available to consumers of the image
+	// +kubebuilder:validation:XValidation:rule="self == oldSelf",message="properties is immutable"
 	// +optional
 	Properties *ImageProperties `json:"properties,omitempty"`
 

--- a/config/crd/bases/openstack.k-orc.cloud_images.yaml
+++ b/config/crd/bases/openstack.k-orc.cloud_images.yaml
@@ -513,6 +513,9 @@ spec:
                             type: string
                         type: object
                     type: object
+                    x-kubernetes-validations:
+                    - message: properties is immutable
+                      rule: self == oldSelf
                   protected:
                     description: |-
                       protected specifies that the image is protected from deletion.
@@ -536,26 +539,7 @@ spec:
                     - shared
                     - community
                     type: string
-                    x-kubernetes-validations:
-                    - message: visibility is immutable
-                      rule: self == oldSelf
                 type: object
-                x-kubernetes-validations:
-                - message: name is immutable
-                  rule: 'has(self.name) ? self.name == oldSelf.name : !has(oldSelf.name)'
-                - message: name is immutable
-                  rule: 'has(self.protected) ? self.protected == oldSelf.protected
-                    : !has(oldSelf.protected)'
-                - message: tags is immutable
-                  rule: 'has(self.tags) ? self.tags == oldSelf.tags : !has(oldSelf.tags)'
-                - message: visibility is immutable
-                  rule: 'has(self.visibility) ? self.visibility == oldSelf.visibility
-                    : !has(oldSelf.visibility)'
-                - message: properties is immutable
-                  rule: 'has(self.properties) ? self.properties == oldSelf.properties
-                    : !has(oldSelf.properties)'
-                - message: ImageResourceSpec is immutable
-                  rule: self == oldSelf
             required:
             - cloudCredentialsRef
             type: object

--- a/internal/controllers/image/actuator_test.go
+++ b/internal/controllers/image/actuator_test.go
@@ -1,0 +1,297 @@
+package image
+
+import (
+	"testing"
+
+	"github.com/gophercloud/gophercloud/v2/openstack/image/v2/images"
+	orcv1alpha1 "github.com/k-orc/openstack-resource-controller/v2/api/v1alpha1"
+	"k8s.io/utils/ptr"
+)
+
+func TestNeedsUpdate(t *testing.T) {
+	testCases := []struct {
+		name         string
+		updateOpts   images.UpdateOpts
+		expectChange bool
+	}{
+		{
+			name:         "No changes (nil slice)",
+			updateOpts:   nil,
+			expectChange: false,
+		},
+		{
+			name:         "No changes (empty slice)",
+			updateOpts:   images.UpdateOpts{},
+			expectChange: false,
+		},
+		{
+			name: "One change (name update)",
+			updateOpts: images.UpdateOpts{
+				images.ReplaceImageName{NewName: "updated-name"},
+			},
+			expectChange: true,
+		},
+	}
+
+	for _, tt := range testCases {
+		t.Run(tt.name, func(t *testing.T) {
+
+			got := needsUpdate(tt.updateOpts)
+
+			if got != tt.expectChange {
+				t.Errorf("Expected change: %v, got: %v", tt.expectChange, got)
+			}
+		})
+	}
+}
+
+func TestHandleNameUpdate(t *testing.T) {
+	ptrToName := ptr.To[orcv1alpha1.OpenStackName]
+
+	testCases := []struct {
+		name          string
+		newValue      *orcv1alpha1.OpenStackName
+		existingValue string
+		expectChange  bool
+	}{
+		{name: "Identical", newValue: ptrToName("name"), existingValue: "name", expectChange: false},
+		{name: "Different", newValue: ptrToName("new-name"), existingValue: "name", expectChange: true},
+		{name: "No value provided, existing is identical to object name", newValue: nil, existingValue: "object-name", expectChange: false},
+		{name: "No value provided, existing is different from object name", newValue: nil, existingValue: "different-from-object-name", expectChange: true},
+	}
+
+	for _, tt := range testCases {
+		t.Run(tt.name, func(t *testing.T) {
+			resource := &orcv1alpha1.Image{}
+			resource.Name = "object-name"
+			resource.Spec = orcv1alpha1.ImageSpec{
+				Resource: &orcv1alpha1.ImageResourceSpec{
+					Name: tt.newValue,
+				},
+			}
+
+			osResource := &images.Image{Name: tt.existingValue}
+			updateOpts := images.UpdateOpts{}
+
+			updateOpts = handleNameUpdate(updateOpts, resource, osResource)
+
+			got := needsUpdate(updateOpts)
+			if got != tt.expectChange {
+				t.Errorf("Expected change: %v, got: %v", tt.expectChange, got)
+			}
+		})
+	}
+}
+
+func TestHandleVisibilityUpdate(t *testing.T) {
+	ptrToVis := ptr.To[orcv1alpha1.ImageVisibility]
+
+	testCases := []struct {
+		name          string
+		newValue      *orcv1alpha1.ImageVisibility
+		existingValue images.ImageVisibility
+		expectChange  bool
+	}{
+		{
+			name:          "Identical",
+			newValue:      ptrToVis("private"),
+			existingValue: "private",
+			expectChange:  false,
+		},
+		{
+			name:          "Different",
+			newValue:      ptrToVis("public"),
+			existingValue: "private",
+			expectChange:  true,
+		},
+		{
+			name:          "Not specified in spec",
+			newValue:      nil,
+			existingValue: "private",
+			expectChange:  false,
+		},
+		{
+			name:          "Changing to community",
+			newValue:      ptrToVis("community"),
+			existingValue: "public",
+			expectChange:  true,
+		},
+	}
+
+	for _, tt := range testCases {
+		t.Run(tt.name, func(t *testing.T) {
+
+			resource := &orcv1alpha1.ImageResourceSpec{
+				Visibility: tt.newValue,
+			}
+			osResource := &images.Image{Visibility: tt.existingValue}
+			updateOpts := images.UpdateOpts{}
+
+			updateOpts = handleVisibilityUpdate(updateOpts, resource, osResource)
+
+			got := needsUpdate(updateOpts)
+			if got != tt.expectChange {
+				t.Errorf("Expected change: %v, got: %v", tt.expectChange, got)
+			}
+		})
+	}
+}
+
+func TestHandleProtectedUpdate(t *testing.T) {
+	ptrToBool := ptr.To[bool]
+
+	testCases := []struct {
+		name          string
+		newValue      *bool
+		existingValue bool
+		expectChange  bool
+	}{
+		{
+			name:          "Identical (true)",
+			newValue:      ptrToBool(true),
+			existingValue: true,
+			expectChange:  false,
+		},
+		{
+			name:          "Identical (false)",
+			newValue:      ptrToBool(false),
+			existingValue: false,
+			expectChange:  false,
+		},
+		{
+			name:          "Different (spec is true, existing is false)",
+			newValue:      ptrToBool(true),
+			existingValue: false,
+			expectChange:  true,
+		},
+		{
+			name:          "Different (spec is false, existing is true)",
+			newValue:      ptrToBool(false),
+			existingValue: true,
+			expectChange:  true,
+		},
+		{
+			name:          "Not specified in spec",
+			newValue:      nil,
+			existingValue: false,
+			expectChange:  false,
+		},
+	}
+
+	for _, tt := range testCases {
+		t.Run(tt.name, func(t *testing.T) {
+			resource := &orcv1alpha1.ImageResourceSpec{
+				Protected: tt.newValue,
+			}
+
+			osResource := &images.Image{Protected: tt.existingValue}
+
+			updateOpts := images.UpdateOpts{}
+			updateOpts = handleProtectedUpdate(updateOpts, resource, osResource)
+
+			got := needsUpdate(updateOpts)
+			if got != tt.expectChange {
+				t.Errorf("Expected change: %v, got: %v", tt.expectChange, got)
+			}
+		})
+	}
+}
+
+func TestHandleTagsUpdate(t *testing.T) {
+	testCases := []struct {
+		name          string
+		newValue      []orcv1alpha1.ImageTag
+		existingValue []string
+		expectChange  bool
+	}{
+		{
+			name:          "Identical tags in same order",
+			newValue:      []orcv1alpha1.ImageTag{"tag1", "tag2"},
+			existingValue: []string{"tag1", "tag2"},
+			expectChange:  false,
+		},
+		{
+			name:          "Identical tags in different order",
+			newValue:      []orcv1alpha1.ImageTag{"tag2", "tag1"},
+			existingValue: []string{"tag1", "tag2"},
+			expectChange:  false,
+		},
+		{
+			name:          "Adding a tag",
+			newValue:      []orcv1alpha1.ImageTag{"tag1", "tag2", "tag3"},
+			existingValue: []string{"tag1", "tag2"},
+			expectChange:  true,
+		},
+		{
+			name:          "Removing a tag",
+			newValue:      []orcv1alpha1.ImageTag{"tag1"},
+			existingValue: []string{"tag1", "tag2"},
+			expectChange:  true,
+		},
+		{
+			name:          "Completely different tags",
+			newValue:      []orcv1alpha1.ImageTag{"alpha", "beta"},
+			existingValue: []string{"tag1", "tag2"},
+			expectChange:  true,
+		},
+		{
+			name:          "Spec is empty, existing has tags (clearing tags)",
+			newValue:      []orcv1alpha1.ImageTag{},
+			existingValue: []string{"tag1", "tag2"},
+			expectChange:  true,
+		},
+		{
+			name:          "Spec has tags, existing is empty",
+			newValue:      []orcv1alpha1.ImageTag{"tag1"},
+			existingValue: []string{},
+			expectChange:  true,
+		},
+		{
+			name:          "Spec has tags, existing is nil",
+			newValue:      []orcv1alpha1.ImageTag{"tag1"},
+			existingValue: nil,
+			expectChange:  true,
+		},
+		{
+			name:          "Spec is nil, existing has tags (clearing tags)",
+			newValue:      nil,
+			existingValue: []string{"tag1"},
+			expectChange:  true,
+		},
+		{
+			name:          "Spec is nil, existing is empty",
+			newValue:      nil,
+			existingValue: []string{},
+			expectChange:  false,
+		},
+		{
+			name:          "Spec is empty, existing is nil",
+			newValue:      []orcv1alpha1.ImageTag{},
+			existingValue: nil,
+			expectChange:  false,
+		},
+		{
+			name:          "Both spec and existing are nil",
+			newValue:      nil,
+			existingValue: nil,
+			expectChange:  false,
+		},
+	}
+
+	for _, tt := range testCases {
+		t.Run(tt.name, func(t *testing.T) {
+			resource := &orcv1alpha1.ImageResourceSpec{
+				Tags: tt.newValue,
+			}
+			osResource := &images.Image{Tags: tt.existingValue}
+			updateOpts := images.UpdateOpts{}
+
+			updateOpts = handleTagsUpdate(updateOpts, resource, osResource)
+
+			got := needsUpdate(updateOpts)
+			if got != tt.expectChange {
+				t.Errorf("Expected change: %v, got: %v", tt.expectChange, got)
+			}
+		})
+	}
+}

--- a/internal/controllers/image/tests/image-update/00-assert.yaml
+++ b/internal/controllers/image/tests/image-update/00-assert.yaml
@@ -1,0 +1,20 @@
+apiVersion: kuttl.dev/v1beta1
+kind: TestAssert
+resourceRefs:
+    - apiVersion: openstack.k-orc.cloud/v1alpha1
+      kind: Image
+      name: image-update
+      ref: image
+assertAll:
+    - celExpr: "!has(image.status.resource.tags)"
+---
+apiVersion: openstack.k-orc.cloud/v1alpha1
+kind: Image
+metadata:
+  name: image-update
+status:
+  resource:
+    name: image-update
+    protected: false
+    visibility: shared
+    status: active

--- a/internal/controllers/image/tests/image-update/00-minimal-resource.yaml
+++ b/internal/controllers/image/tests/image-update/00-minimal-resource.yaml
@@ -1,0 +1,20 @@
+---
+apiVersion: openstack.k-orc.cloud/v1alpha1
+kind: Image
+metadata:
+  name: image-update
+spec:
+  cloudCredentialsRef:
+    cloudName: openstack
+    secretName: openstack-clouds
+  managementPolicy: managed
+  resource:
+    name: image-update
+    protected: false
+    visibility: shared
+    content:
+      containerFormat: docker
+      diskFormat: qcow2
+      download:
+        url: https://github.com/k-orc/openstack-resource-controller/raw/690b760f49dfb61b173755e91cb51ed42472c7f3/internal/controllers/image/testdata/raw.img.gz
+        decompress: "gz"

--- a/internal/controllers/image/tests/image-update/00-prerequisites.yaml
+++ b/internal/controllers/image/tests/image-update/00-prerequisites.yaml
@@ -1,0 +1,5 @@
+apiVersion: kuttl.dev/v1beta1
+kind: TestStep
+commands:
+  - command: kubectl create secret generic openstack-clouds --from-file=clouds.yaml=${E2E_KUTTL_OSCLOUDS} ${E2E_KUTTL_CACERT_OPT}
+    namespaced: true

--- a/internal/controllers/image/tests/image-update/01-assert.yaml
+++ b/internal/controllers/image/tests/image-update/01-assert.yaml
@@ -1,0 +1,23 @@
+apiVersion: kuttl.dev/v1beta1
+kind: TestAssert
+resourceRefs:
+    - apiVersion: openstack.k-orc.cloud/v1alpha1
+      kind: Image
+      name: image-update
+      ref: image
+assertAll:
+    - celExpr: "image.status.resource.tags.size() == 2"
+---
+apiVersion: openstack.k-orc.cloud/v1alpha1
+kind: Image
+metadata:
+  name: image-update
+status:
+  resource:
+    name: image-update-updated
+    protected: true
+    visibility: private
+    status: active
+    tags:
+      - tag1
+      - tag2

--- a/internal/controllers/image/tests/image-update/01-updated-resource.yaml
+++ b/internal/controllers/image/tests/image-update/01-updated-resource.yaml
@@ -1,0 +1,13 @@
+---
+apiVersion: openstack.k-orc.cloud/v1alpha1
+kind: Image
+metadata:
+  name: image-update
+spec:
+  resource:
+    name: image-update-updated
+    visibility: private
+    protected: true
+    tags:
+      - tag1
+      - tag2

--- a/internal/controllers/image/tests/image-update/02-assert.yaml
+++ b/internal/controllers/image/tests/image-update/02-assert.yaml
@@ -1,0 +1,20 @@
+apiVersion: kuttl.dev/v1beta1
+kind: TestAssert
+resourceRefs:
+    - apiVersion: openstack.k-orc.cloud/v1alpha1
+      kind: Image
+      name: image-update
+      ref: image
+assertAll:
+    - celExpr: "!has(image.status.resource.tags)"
+---
+apiVersion: openstack.k-orc.cloud/v1alpha1
+kind: Image
+metadata:
+  name: image-update
+status:
+  resource:
+    name: image-update
+    protected: false
+    visibility: shared
+    status: active

--- a/internal/controllers/image/tests/image-update/02-reverted-resource.yaml
+++ b/internal/controllers/image/tests/image-update/02-reverted-resource.yaml
@@ -1,0 +1,5 @@
+apiVersion: kuttl.dev/v1beta1
+kind: TestStep
+commands:
+  - command: kubectl replace -f 00-minimal-resource.yaml
+    namespaced: true

--- a/internal/osclients/image.go
+++ b/internal/osclients/image.go
@@ -35,6 +35,7 @@ type ImageClient interface {
 	GetImage(ctx context.Context, id string) (*images.Image, error)
 	CreateImage(ctx context.Context, createOpts images.CreateOptsBuilder) (*images.Image, error)
 	DeleteImage(ctx context.Context, id string) error
+	UpdateImage(ctx context.Context, id string, updateOpts images.UpdateOptsBuilder) (*images.Image, error)
 	UploadData(ctx context.Context, id string, data io.Reader) error
 	GetImportInfo(ctx context.Context) (*imageimport.ImportInfo, error)
 	CreateImport(ctx context.Context, id string, createOpts imageimport.CreateOptsBuilder) error
@@ -83,6 +84,10 @@ func (c imageClient) DeleteImage(ctx context.Context, id string) error {
 	return images.Delete(ctx, c.client, id).ExtractErr()
 }
 
+func (c imageClient) UpdateImage(ctx context.Context, id string, opts images.UpdateOptsBuilder) (*images.Image, error) {
+	return images.Update(ctx, c.client, id, opts).Extract()
+}
+
 func (c imageClient) UploadData(ctx context.Context, id string, data io.Reader) error {
 	return imagedata.Upload(ctx, c.client, id, data).ExtractErr()
 }
@@ -118,6 +123,10 @@ func (e imageErrorClient) CreateImage(_ context.Context, _ images.CreateOptsBuil
 
 func (e imageErrorClient) DeleteImage(_ context.Context, _ string) error {
 	return e.error
+}
+
+func (e imageErrorClient) UpdateImage(_ context.Context, _ string, _ images.UpdateOptsBuilder) (*images.Image, error) {
+	return nil, e.error
 }
 
 func (e imageErrorClient) UploadData(_ context.Context, _ string, _ io.Reader) error {

--- a/internal/osclients/mock/image.go
+++ b/internal/osclients/mock/image.go
@@ -146,6 +146,21 @@ func (mr *MockImageClientMockRecorder) ListImages(ctx, listOpts any) *gomock.Cal
 	return mr.mock.ctrl.RecordCallWithMethodType(mr.mock, "ListImages", reflect.TypeOf((*MockImageClient)(nil).ListImages), ctx, listOpts)
 }
 
+// UpdateImage mocks base method.
+func (m *MockImageClient) UpdateImage(ctx context.Context, id string, updateOpts images.UpdateOptsBuilder) (*images.Image, error) {
+	m.ctrl.T.Helper()
+	ret := m.ctrl.Call(m, "UpdateImage", ctx, id, updateOpts)
+	ret0, _ := ret[0].(*images.Image)
+	ret1, _ := ret[1].(error)
+	return ret0, ret1
+}
+
+// UpdateImage indicates an expected call of UpdateImage.
+func (mr *MockImageClientMockRecorder) UpdateImage(ctx, id, updateOpts any) *gomock.Call {
+	mr.mock.ctrl.T.Helper()
+	return mr.mock.ctrl.RecordCallWithMethodType(mr.mock, "UpdateImage", reflect.TypeOf((*MockImageClient)(nil).UpdateImage), ctx, id, updateOpts)
+}
+
 // UploadData mocks base method.
 func (m *MockImageClient) UploadData(ctx context.Context, id string, data io.Reader) error {
 	m.ctrl.T.Helper()


### PR DESCRIPTION
Although the glance API supports updating image properties, we've chosen
to restrict mutability for them as they can't be tested at the moment,
since they're note included in the image status.

Fixes: https://github.com/k-orc/openstack-resource-controller/issues/467