### PR TITLE
Use go 1.24.8 for building and testing

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -4,7 +4,7 @@ BUNDLE_IMG ?= bundle:latest
 # ENVTEST_K8S_VERSION refers to the version of kubebuilder assets to be downloaded by envtest binary.
 ENVTEST_K8S_VERSION = 1.29.0
 TRIVY_VERSION = 0.49.1
-GO_VERSION ?= 1.23.12
+GO_VERSION ?= 1.24.8
 
 # Get the currently used golang install path (in GOPATH/bin, unless GOBIN is set)
 ifeq (,$(shell go env GOBIN))


### PR DESCRIPTION
I have noticed that #522 fails because we have too old go version.
This version that I am bumping to also has a bunch of security fixes so it would be good to do the bump from that perspective as well. (Go 1.23 is no longer supported.)