### PR TITLE
Bump go to 1.24.9

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -1,5 +1,5 @@
 # Build the manager binary
-ARG GO_VERSION="1.23"
+ARG GO_VERSION="1.24"
 FROM golang:${GO_VERSION} AS builder
 ARG TARGETOS
 ARG TARGETARCH

--- a/Makefile
+++ b/Makefile
@@ -4,7 +4,7 @@ BUNDLE_IMG ?= bundle:latest
 # ENVTEST_K8S_VERSION refers to the version of kubebuilder assets to be downloaded by envtest binary.
 ENVTEST_K8S_VERSION = 1.29.0
 TRIVY_VERSION = 0.49.1
-GO_VERSION ?= 1.24.8
+GO_VERSION ?= 1.24.9
 
 # Get the currently used golang install path (in GOPATH/bin, unless GOBIN is set)
 ifeq (,$(shell go env GOBIN))


### PR DESCRIPTION
This version contains a fix for a TLS validation regression that was introduced in 1.24.8. Let's bump to avoid any risk of affecting our users.