### PR TITLE
Bump go to 1.24.9

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -1,5 +1,5 @@
 # Build the manager binary
-ARG GO_VERSION="1.23"
+ARG GO_VERSION="1.24"
 FROM golang:${GO_VERSION} AS builder
 ARG TARGETOS
 ARG TARGETARCH

--- a/Makefile
+++ b/Makefile
@@ -3,7 +3,7 @@ IMG ?= controller:latest
 # ENVTEST_K8S_VERSION refers to the version of kubebuilder assets to be downloaded by envtest binary.
 ENVTEST_K8S_VERSION = 1.30.0
 TRIVY_VERSION = 0.49.1
-GO_VERSION ?= 1.23.12
+GO_VERSION ?= 1.24.9
 
 # Get the currently used golang install path (in GOPATH/bin, unless GOBIN is set)
 ifeq (,$(shell go env GOBIN))


### PR DESCRIPTION
Version 1.24.8 contains multiple security fixes, but it also introduced a TLS validation regression (https://github.com/golang/go/issues/75860) that has now been fixed in 1.24.9. Let's bump the version to include both the security fixes and the fix to the regression.