### PR TITLE
Update Manager memory limit to 256Mi

### DIFF
--- a/config/manager/manager.yaml
+++ b/config/manager/manager.yaml
@@ -62,7 +62,7 @@ spec:
         resources:
           limits:
             cpu: 500m
-            memory: 128Mi
+            memory: 256Mi
           requests:
             cpu: 10m
             memory: 64Mi


### PR DESCRIPTION
Increase the memory resource limit in manager.yaml to 256Mi. 
This addresses the OOMKilled issues observed in our deployment environment.