### PR TITLE
Server: Add support for Availability Zone

### DIFF
--- a/api/v1alpha1/server_types.go
+++ b/api/v1alpha1/server_types.go
@@ -164,6 +164,12 @@ type ServerResourceSpec struct {
 	// +kubebuilder:validation:XValidation:rule="self == oldSelf",message="serverGroupRef is immutable"
 	ServerGroupRef *KubernetesNameRef `json:"serverGroupRef,omitempty"`
 
+	// availabilityZone is the availability zone in which to create the server.
+	// +kubebuilder:validation:MaxLength=255
+	// +optional
+	// +kubebuilder:validation:XValidation:rule="self == oldSelf",message="availabilityZone is immutable"
+	AvailabilityZone string `json:"availabilityZone,omitempty"`
+
 	// tags is a list of tags which will be applied to the server.
 	// +kubebuilder:validation:MaxItems:=64
 	// +listType=set
@@ -185,6 +191,11 @@ type ServerFilter struct {
 	// name of the existing resource
 	// +optional
 	Name *OpenStackName `json:"name,omitempty"`
+
+	// availabilityZone is the availability zone of the existing resource
+	// +kubebuilder:validation:MaxLength=255
+	// +optional
+	AvailabilityZone string `json:"availabilityZone,omitempty"`
 
 	FilterByServerTags `json:",inline"`
 }
@@ -211,6 +222,11 @@ type ServerResourceStatus struct {
 	// +kubebuilder:validation:MaxLength=1024
 	// +optional
 	ImageID string `json:"imageID,omitempty"`
+
+	// availabilityZone is the availability zone where the server is located.
+	// +kubebuilder:validation:MaxLength=1024
+	// +optional
+	AvailabilityZone string `json:"availabilityZone,omitempty"`
 
 	// serverGroups is a slice of strings containing the UUIDs of the
 	// server groups to which the server belongs. Currently this can

--- a/cmd/models-schema/zz_generated.openapi.go
+++ b/cmd/models-schema/zz_generated.openapi.go
@@ -6090,6 +6090,13 @@ func schema_openstack_resource_controller_v2_api_v1alpha1_ServerFilter(ref commo
 							Format:      "",
 						},
 					},
+					"availabilityZone": {
+						SchemaProps: spec.SchemaProps{
+							Description: "availabilityZone is the availability zone of the existing resource",
+							Type:        []string{"string"},
+							Format:      "",
+						},
+					},
 					"tags": {
 						VendorExtensible: spec.VendorExtensible{
 							Extensions: spec.Extensions{
@@ -6812,6 +6819,13 @@ func schema_openstack_resource_controller_v2_api_v1alpha1_ServerResourceSpec(ref
 							Format:      "",
 						},
 					},
+					"availabilityZone": {
+						SchemaProps: spec.SchemaProps{
+							Description: "availabilityZone is the availability zone in which to create the server.",
+							Type:        []string{"string"},
+							Format:      "",
+						},
+					},
 					"tags": {
 						VendorExtensible: spec.VendorExtensible{
 							Extensions: spec.Extensions{
@@ -6872,6 +6886,13 @@ func schema_openstack_resource_controller_v2_api_v1alpha1_ServerResourceStatus(r
 					"imageID": {
 						SchemaProps: spec.SchemaProps{
 							Description: "imageID indicates the OS image used to deploy the server.",
+							Type:        []string{"string"},
+							Format:      "",
+						},
+					},
+					"availabilityZone": {
+						SchemaProps: spec.SchemaProps{
+							Description: "availabilityZone is the availability zone where the server is located.",
 							Type:        []string{"string"},
 							Format:      "",
 						},

--- a/config/crd/bases/openstack.k-orc.cloud_servers.yaml
+++ b/config/crd/bases/openstack.k-orc.cloud_servers.yaml
@@ -91,6 +91,11 @@ spec:
                       error state and will not continue to retry.
                     minProperties: 1
                     properties:
+                      availabilityZone:
+                        description: availabilityZone is the availability zone of
+                          the existing resource
+                        maxLength: 255
+                        type: string
                       name:
                         description: name of the existing resource
                         maxLength: 255
@@ -189,6 +194,14 @@ spec:
 
                   resource must be specified if the management policy is `managed`.
                 properties:
+                  availabilityZone:
+                    description: availabilityZone is the availability zone in which
+                      to create the server.
+                    maxLength: 255
+                    type: string
+                    x-kubernetes-validations:
+                    - message: availabilityZone is immutable
+                      rule: self == oldSelf
                   flavorRef:
                     description: flavorRef references the flavor to use for the server
                       instance.
@@ -403,6 +416,11 @@ spec:
                 description: resource contains the observed state of the OpenStack
                   resource.
                 properties:
+                  availabilityZone:
+                    description: availabilityZone is the availability zone where the
+                      server is located.
+                    maxLength: 1024
+                    type: string
                   hostID:
                     description: hostID is the host where the server is located in
                       the cloud.

--- a/config/samples/openstack_v1alpha1_server.yaml
+++ b/config/samples/openstack_v1alpha1_server.yaml
@@ -15,6 +15,7 @@ spec:
     volumes:
       - volumeRef: server-sample
     serverGroupRef: server-sample
+    availabilityZone: nova
     tags:
       - tag1
       - tag2

--- a/internal/controllers/server/actuator.go
+++ b/internal/controllers/server/actuator.go
@@ -134,10 +134,11 @@ func (actuator serverActuator) ListOSResourcesForAdoption(ctx context.Context, o
 
 func (actuator serverActuator) ListOSResourcesForImport(ctx context.Context, obj orcObjectPT, filter filterT) (iter.Seq2[*osResourceT, error], progress.ReconcileStatus) {
 	listOpts := servers.ListOpts{
-		Tags:       tags.Join(filter.Tags),
-		TagsAny:    tags.Join(filter.TagsAny),
-		NotTags:    tags.Join(filter.NotTags),
-		NotTagsAny: tags.Join(filter.NotTagsAny),
+		Tags:             tags.Join(filter.Tags),
+		TagsAny:          tags.Join(filter.TagsAny),
+		NotTags:          tags.Join(filter.NotTags),
+		NotTagsAny:       tags.Join(filter.NotTagsAny),
+		AvailabilityZone: filter.AvailabilityZone,
 	}
 
 	if filter.Name != nil {
@@ -255,12 +256,13 @@ func (actuator serverActuator) CreateResource(ctx context.Context, obj *orcv1alp
 	slices.Sort(tags)
 
 	createOpts := servers.CreateOpts{
-		Name:      getResourceName(obj),
-		ImageRef:  *image.Status.ID,
-		FlavorRef: *flavor.Status.ID,
-		Networks:  portList,
-		UserData:  userData,
-		Tags:      tags,
+		Name:             getResourceName(obj),
+		ImageRef:         *image.Status.ID,
+		FlavorRef:        *flavor.Status.ID,
+		Networks:         portList,
+		UserData:         userData,
+		Tags:             tags,
+		AvailabilityZone: resource.AvailabilityZone,
 	}
 
 	schedulerHints := servers.SchedulerHintOpts{

--- a/internal/controllers/server/status.go
+++ b/internal/controllers/server/status.go
@@ -66,6 +66,7 @@ func (serverStatusWriter) ApplyResourceStatus(log logr.Logger, osResource *osRes
 		WithName(osResource.Name).
 		WithStatus(osResource.Status).
 		WithHostID(osResource.HostID).
+		WithAvailabilityZone(osResource.AvailabilityZone).
 		WithServerGroups(ptr.Deref(osResource.ServerGroups, []string{})...).
 		WithTags(ptr.Deref(osResource.Tags, []string{})...)
 

--- a/internal/controllers/server/tests/server-create-full/00-assert.yaml
+++ b/internal/controllers/server/tests/server-create-full/00-assert.yaml
@@ -32,6 +32,7 @@ resourceRefs:
       ref: subnet
 assertAll:
     - celExpr: "server.status.resource.hostID != ''"
+    - celExpr: "server.status.resource.availabilityZone == 'nova'"
     - celExpr: "server.status.resource.imageID == image.status.id"
     - celExpr: "server.status.resource.serverGroups[0] == sg.status.id"
     - celExpr: "server.status.resource.volumes[0].id == volume.status.id"

--- a/internal/controllers/server/tests/server-create-full/00-create-resource.yaml
+++ b/internal/controllers/server/tests/server-create-full/00-create-resource.yaml
@@ -43,6 +43,7 @@ spec:
     serverGroupRef: server-create-full
     volumes:
       - volumeRef: server-create-full
+    availabilityZone: nova
     tags:
       - tag1
       - tag2

--- a/internal/controllers/server/tests/server-create-minimal/00-assert.yaml
+++ b/internal/controllers/server/tests/server-create-minimal/00-assert.yaml
@@ -24,6 +24,7 @@ resourceRefs:
       ref: subnet
 assertAll:
     - celExpr: "server.status.resource.hostID != ''"
+    - celExpr: "server.status.resource.availabilityZone != ''"
     - celExpr: "server.status.resource.imageID == image.status.id"
     - celExpr: "port.status.resource.deviceID == server.status.id"
     - celExpr: "port.status.resource.status == 'ACTIVE'"

--- a/internal/controllers/server/tests/server-import/00-import-resource.yaml
+++ b/internal/controllers/server/tests/server-import/00-import-resource.yaml
@@ -11,6 +11,7 @@ spec:
   import:
     filter:
       name: server-import-external
+      availabilityZone: nova
       tags:
         - tag1
         - tag2

--- a/internal/controllers/server/tests/server-import/01-create-trap-resource.yaml
+++ b/internal/controllers/server/tests/server-import/01-create-trap-resource.yaml
@@ -30,6 +30,7 @@ spec:
     flavorRef: server-import
     ports:
       - portRef: server-import-external-not-this-one
+    availabilityZone: nova
     tags:
       - tag1
       - tag2

--- a/internal/controllers/server/tests/server-import/02-assert.yaml
+++ b/internal/controllers/server/tests/server-import/02-assert.yaml
@@ -30,6 +30,7 @@ status:
   resource:
     # TODO(mandre) add more fields
     name: server-import-external
+    availabilityZone: nova
     tags:
       - tag1
       - tag2

--- a/internal/controllers/server/tests/server-import/02-create-resource.yaml
+++ b/internal/controllers/server/tests/server-import/02-create-resource.yaml
@@ -27,6 +27,7 @@ spec:
     flavorRef: server-import
     ports:
       - portRef: server-import-external
+    availabilityZone: nova
     tags:
       - tag1
       - tag2

--- a/pkg/clients/applyconfiguration/api/v1alpha1/serverfilter.go
+++ b/pkg/clients/applyconfiguration/api/v1alpha1/serverfilter.go
@@ -26,6 +26,7 @@ import (
 // with apply.
 type ServerFilterApplyConfiguration struct {
 	Name                                 *apiv1alpha1.OpenStackName `json:"name,omitempty"`
+	AvailabilityZone                     *string                    `json:"availabilityZone,omitempty"`
 	FilterByServerTagsApplyConfiguration `json:",inline"`
 }
 
@@ -40,6 +41,14 @@ func ServerFilter() *ServerFilterApplyConfiguration {
 // If called multiple times, the Name field is set to the value of the last call.
 func (b *ServerFilterApplyConfiguration) WithName(value apiv1alpha1.OpenStackName) *ServerFilterApplyConfiguration {
 	b.Name = &value
+	return b
+}
+
+// WithAvailabilityZone sets the AvailabilityZone field in the declarative configuration to the given value
+// and returns the receiver, so that objects can be built by chaining "With" function invocations.
+// If called multiple times, the AvailabilityZone field is set to the value of the last call.
+func (b *ServerFilterApplyConfiguration) WithAvailabilityZone(value string) *ServerFilterApplyConfiguration {
+	b.AvailabilityZone = &value
 	return b
 }
 

--- a/pkg/clients/applyconfiguration/api/v1alpha1/serverresourcespec.go
+++ b/pkg/clients/applyconfiguration/api/v1alpha1/serverresourcespec.go
@@ -25,14 +25,15 @@ import (
 // ServerResourceSpecApplyConfiguration represents a declarative configuration of the ServerResourceSpec type for use
 // with apply.
 type ServerResourceSpecApplyConfiguration struct {
-	Name           *apiv1alpha1.OpenStackName           `json:"name,omitempty"`
-	ImageRef       *apiv1alpha1.KubernetesNameRef       `json:"imageRef,omitempty"`
-	FlavorRef      *apiv1alpha1.KubernetesNameRef       `json:"flavorRef,omitempty"`
-	UserData       *UserDataSpecApplyConfiguration      `json:"userData,omitempty"`
-	Ports          []ServerPortSpecApplyConfiguration   `json:"ports,omitempty"`
-	Volumes        []ServerVolumeSpecApplyConfiguration `json:"volumes,omitempty"`
-	ServerGroupRef *apiv1alpha1.KubernetesNameRef       `json:"serverGroupRef,omitempty"`
-	Tags           []apiv1alpha1.ServerTag              `json:"tags,omitempty"`
+	Name             *apiv1alpha1.OpenStackName           `json:"name,omitempty"`
+	ImageRef         *apiv1alpha1.KubernetesNameRef       `json:"imageRef,omitempty"`
+	FlavorRef        *apiv1alpha1.KubernetesNameRef       `json:"flavorRef,omitempty"`
+	UserData         *UserDataSpecApplyConfiguration      `json:"userData,omitempty"`
+	Ports            []ServerPortSpecApplyConfiguration   `json:"ports,omitempty"`
+	Volumes          []ServerVolumeSpecApplyConfiguration `json:"volumes,omitempty"`
+	ServerGroupRef   *apiv1alpha1.KubernetesNameRef       `json:"serverGroupRef,omitempty"`
+	AvailabilityZone *string                              `json:"availabilityZone,omitempty"`
+	Tags             []apiv1alpha1.ServerTag              `json:"tags,omitempty"`
 }
 
 // ServerResourceSpecApplyConfiguration constructs a declarative configuration of the ServerResourceSpec type for use with
@@ -104,6 +105,14 @@ func (b *ServerResourceSpecApplyConfiguration) WithVolumes(values ...*ServerVolu
 // If called multiple times, the ServerGroupRef field is set to the value of the last call.
 func (b *ServerResourceSpecApplyConfiguration) WithServerGroupRef(value apiv1alpha1.KubernetesNameRef) *ServerResourceSpecApplyConfiguration {
 	b.ServerGroupRef = &value
+	return b
+}
+
+// WithAvailabilityZone sets the AvailabilityZone field in the declarative configuration to the given value
+// and returns the receiver, so that objects can be built by chaining "With" function invocations.
+// If called multiple times, the AvailabilityZone field is set to the value of the last call.
+func (b *ServerResourceSpecApplyConfiguration) WithAvailabilityZone(value string) *ServerResourceSpecApplyConfiguration {
+	b.AvailabilityZone = &value
 	return b
 }
 

--- a/pkg/clients/applyconfiguration/api/v1alpha1/serverresourcestatus.go
+++ b/pkg/clients/applyconfiguration/api/v1alpha1/serverresourcestatus.go
@@ -21,14 +21,15 @@ package v1alpha1
 // ServerResourceStatusApplyConfiguration represents a declarative configuration of the ServerResourceStatus type for use
 // with apply.
 type ServerResourceStatusApplyConfiguration struct {
-	Name         *string                                   `json:"name,omitempty"`
-	HostID       *string                                   `json:"hostID,omitempty"`
-	Status       *string                                   `json:"status,omitempty"`
-	ImageID      *string                                   `json:"imageID,omitempty"`
-	ServerGroups []string                                  `json:"serverGroups,omitempty"`
-	Volumes      []ServerVolumeStatusApplyConfiguration    `json:"volumes,omitempty"`
-	Interfaces   []ServerInterfaceStatusApplyConfiguration `json:"interfaces,omitempty"`
-	Tags         []string                                  `json:"tags,omitempty"`
+	Name             *string                                   `json:"name,omitempty"`
+	HostID           *string                                   `json:"hostID,omitempty"`
+	Status           *string                                   `json:"status,omitempty"`
+	ImageID          *string                                   `json:"imageID,omitempty"`
+	AvailabilityZone *string                                   `json:"availabilityZone,omitempty"`
+	ServerGroups     []string                                  `json:"serverGroups,omitempty"`
+	Volumes          []ServerVolumeStatusApplyConfiguration    `json:"volumes,omitempty"`
+	Interfaces       []ServerInterfaceStatusApplyConfiguration `json:"interfaces,omitempty"`
+	Tags             []string                                  `json:"tags,omitempty"`
 }
 
 // ServerResourceStatusApplyConfiguration constructs a declarative configuration of the ServerResourceStatus type for use with
@@ -66,6 +67,14 @@ func (b *ServerResourceStatusApplyConfiguration) WithStatus(value string) *Serve
 // If called multiple times, the ImageID field is set to the value of the last call.
 func (b *ServerResourceStatusApplyConfiguration) WithImageID(value string) *ServerResourceStatusApplyConfiguration {
 	b.ImageID = &value
+	return b
+}
+
+// WithAvailabilityZone sets the AvailabilityZone field in the declarative configuration to the given value
+// and returns the receiver, so that objects can be built by chaining "With" function invocations.
+// If called multiple times, the AvailabilityZone field is set to the value of the last call.
+func (b *ServerResourceStatusApplyConfiguration) WithAvailabilityZone(value string) *ServerResourceStatusApplyConfiguration {
+	b.AvailabilityZone = &value
 	return b
 }
 

--- a/pkg/clients/applyconfiguration/internal/internal.go
+++ b/pkg/clients/applyconfiguration/internal/internal.go
@@ -1764,6 +1764,9 @@ var schemaYAML = typed.YAMLObject(`types:
 - name: com.github.k-orc.openstack-resource-controller.v2.api.v1alpha1.ServerFilter
   map:
     fields:
+    - name: availabilityZone
+      type:
+        scalar: string
     - name: name
       type:
         scalar: string
@@ -1953,6 +1956,9 @@ var schemaYAML = typed.YAMLObject(`types:
 - name: com.github.k-orc.openstack-resource-controller.v2.api.v1alpha1.ServerResourceSpec
   map:
     fields:
+    - name: availabilityZone
+      type:
+        scalar: string
     - name: flavorRef
       type:
         scalar: string
@@ -1989,6 +1995,9 @@ var schemaYAML = typed.YAMLObject(`types:
 - name: com.github.k-orc.openstack-resource-controller.v2.api.v1alpha1.ServerResourceStatus
   map:
     fields:
+    - name: availabilityZone
+      type:
+        scalar: string
     - name: hostID
       type:
         scalar: string

--- a/website/docs/crd-reference.md
+++ b/website/docs/crd-reference.md
@@ -2483,6 +2483,7 @@ _Appears in:_
 | Field | Description | Default | Validation |
 | --- | --- | --- | --- |
 | `name` _[OpenStackName](#openstackname)_ | name of the existing resource |  | MaxLength: 255 <br />MinLength: 1 <br />Pattern: `^[^,]+$` <br /> |
+| `availabilityZone` _string_ | availabilityZone is the availability zone of the existing resource |  | MaxLength: 255 <br /> |
 | `tags` _[ServerTag](#servertag) array_ | tags is a list of tags to filter by. If specified, the resource must<br />have all of the tags specified to be included in the result. |  | MaxItems: 64 <br />MaxLength: 80 <br />MinLength: 1 <br /> |
 | `tagsAny` _[ServerTag](#servertag) array_ | tagsAny is a list of tags to filter by. If specified, the resource<br />must have at least one of the tags specified to be included in the<br />result. |  | MaxItems: 64 <br />MaxLength: 80 <br />MinLength: 1 <br /> |
 | `notTags` _[ServerTag](#servertag) array_ | notTags is a list of tags to filter by. If specified, resources which<br />contain all of the given tags will be excluded from the result. |  | MaxItems: 64 <br />MaxLength: 80 <br />MinLength: 1 <br /> |
@@ -2768,6 +2769,7 @@ _Appears in:_
 | `ports` _[ServerPortSpec](#serverportspec) array_ | ports defines a list of ports which will be attached to the server. |  | MaxItems: 64 <br />MaxProperties: 1 <br />MinProperties: 1 <br /> |
 | `volumes` _[ServerVolumeSpec](#servervolumespec) array_ | volumes is a list of volumes attached to the server. |  | MaxItems: 64 <br />MinProperties: 1 <br /> |
 | `serverGroupRef` _[KubernetesNameRef](#kubernetesnameref)_ | serverGroupRef is a reference to a ServerGroup object. The server<br />will be created in the server group. |  | MaxLength: 253 <br />MinLength: 1 <br /> |
+| `availabilityZone` _string_ | availabilityZone is the availability zone in which to create the server. |  | MaxLength: 255 <br /> |
 | `tags` _[ServerTag](#servertag) array_ | tags is a list of tags which will be applied to the server. |  | MaxItems: 64 <br />MaxLength: 80 <br />MinLength: 1 <br /> |
 
 
@@ -2788,6 +2790,7 @@ _Appears in:_
 | `hostID` _string_ | hostID is the host where the server is located in the cloud. |  | MaxLength: 1024 <br /> |
 | `status` _string_ | status contains the current operational status of the server,<br />such as IN_PROGRESS or ACTIVE. |  | MaxLength: 1024 <br /> |
 | `imageID` _string_ | imageID indicates the OS image used to deploy the server. |  | MaxLength: 1024 <br /> |
+| `availabilityZone` _string_ | availabilityZone is the availability zone where the server is located. |  | MaxLength: 1024 <br /> |
 | `serverGroups` _string array_ | serverGroups is a slice of strings containing the UUIDs of the<br />server groups to which the server belongs. Currently this can<br />contain at most one entry. |  | MaxItems: 32 <br />items:MaxLength: 1024 <br /> |
 | `volumes` _[ServerVolumeStatus](#servervolumestatus) array_ | volumes contains the volumes attached to the server. |  | MaxItems: 64 <br /> |
 | `interfaces` _[ServerInterfaceStatus](#serverinterfacestatus) array_ | interfaces contains the list of interfaces attached to the server. |  | MaxItems: 64 <br /> |


### PR DESCRIPTION
This adds availability zone support to the Server resource, allowing users to control server placement across OpenStack availability zones and to filter existing servers by AZ during import.

Fixes #548