### PR TITLE
Server: limit the number of tags to 50

### DIFF
--- a/api/v1alpha1/server_types.go
+++ b/api/v1alpha1/server_types.go
@@ -25,7 +25,7 @@ type FilterByServerTags struct {
 	// have all of the tags specified to be included in the result.
 	// +listType=set
 	// +optional
-	// +kubebuilder:validation:MaxItems:=64
+	// +kubebuilder:validation:MaxItems:=50
 	Tags []ServerTag `json:"tags,omitempty"`
 
 	// tagsAny is a list of tags to filter by. If specified, the resource
@@ -33,21 +33,21 @@ type FilterByServerTags struct {
 	// result.
 	// +listType=set
 	// +optional
-	// +kubebuilder:validation:MaxItems:=64
+	// +kubebuilder:validation:MaxItems:=50
 	TagsAny []ServerTag `json:"tagsAny,omitempty"`
 
 	// notTags is a list of tags to filter by. If specified, resources which
 	// contain all of the given tags will be excluded from the result.
 	// +listType=set
 	// +optional
-	// +kubebuilder:validation:MaxItems:=64
+	// +kubebuilder:validation:MaxItems:=50
 	NotTags []ServerTag `json:"notTags,omitempty"`
 
 	// notTagsAny is a list of tags to filter by. If specified, resources
 	// which contain any of the given tags will be excluded from the result.
 	// +listType=set
 	// +optional
-	// +kubebuilder:validation:MaxItems:=64
+	// +kubebuilder:validation:MaxItems:=50
 	NotTagsAny []ServerTag `json:"notTagsAny,omitempty"`
 }
 
@@ -171,7 +171,7 @@ type ServerResourceSpec struct {
 	AvailabilityZone string `json:"availabilityZone,omitempty"`
 
 	// tags is a list of tags which will be applied to the server.
-	// +kubebuilder:validation:MaxItems:=64
+	// +kubebuilder:validation:MaxItems:=50
 	// +listType=set
 	// +optional
 	Tags []ServerTag `json:"tags,omitempty"`
@@ -250,7 +250,7 @@ type ServerResourceStatus struct {
 	Interfaces []ServerInterfaceStatus `json:"interfaces,omitempty"`
 
 	// tags is the list of tags on the resource.
-	// +kubebuilder:validation:MaxItems:=64
+	// +kubebuilder:validation:MaxItems:=50
 	// +kubebuilder:validation:items:MaxLength=1024
 	// +listType=atomic
 	// +optional

--- a/config/crd/bases/openstack.k-orc.cloud_servers.yaml
+++ b/config/crd/bases/openstack.k-orc.cloud_servers.yaml
@@ -110,7 +110,7 @@ spec:
                           maxLength: 80
                           minLength: 1
                           type: string
-                        maxItems: 64
+                        maxItems: 50
                         type: array
                         x-kubernetes-list-type: set
                       notTagsAny:
@@ -121,7 +121,7 @@ spec:
                           maxLength: 80
                           minLength: 1
                           type: string
-                        maxItems: 64
+                        maxItems: 50
                         type: array
                         x-kubernetes-list-type: set
                       tags:
@@ -132,7 +132,7 @@ spec:
                           maxLength: 80
                           minLength: 1
                           type: string
-                        maxItems: 64
+                        maxItems: 50
                         type: array
                         x-kubernetes-list-type: set
                       tagsAny:
@@ -144,7 +144,7 @@ spec:
                           maxLength: 80
                           minLength: 1
                           type: string
-                        maxItems: 64
+                        maxItems: 50
                         type: array
                         x-kubernetes-list-type: set
                     type: object
@@ -264,7 +264,7 @@ spec:
                       maxLength: 80
                       minLength: 1
                       type: string
-                    maxItems: 64
+                    maxItems: 50
                     type: array
                     x-kubernetes-list-type: set
                   userData:
@@ -505,7 +505,7 @@ spec:
                     items:
                       maxLength: 1024
                       type: string
-                    maxItems: 64
+                    maxItems: 50
                     type: array
                     x-kubernetes-list-type: atomic
                   volumes:

--- a/website/docs/crd-reference.md
+++ b/website/docs/crd-reference.md
@@ -300,10 +300,10 @@ _Appears in:_
 
 | Field | Description | Default | Validation |
 | --- | --- | --- | --- |
-| `tags` _[ServerTag](#servertag) array_ | tags is a list of tags to filter by. If specified, the resource must<br />have all of the tags specified to be included in the result. |  | MaxItems: 64 <br />MaxLength: 80 <br />MinLength: 1 <br /> |
-| `tagsAny` _[ServerTag](#servertag) array_ | tagsAny is a list of tags to filter by. If specified, the resource<br />must have at least one of the tags specified to be included in the<br />result. |  | MaxItems: 64 <br />MaxLength: 80 <br />MinLength: 1 <br /> |
-| `notTags` _[ServerTag](#servertag) array_ | notTags is a list of tags to filter by. If specified, resources which<br />contain all of the given tags will be excluded from the result. |  | MaxItems: 64 <br />MaxLength: 80 <br />MinLength: 1 <br /> |
-| `notTagsAny` _[ServerTag](#servertag) array_ | notTagsAny is a list of tags to filter by. If specified, resources<br />which contain any of the given tags will be excluded from the result. |  | MaxItems: 64 <br />MaxLength: 80 <br />MinLength: 1 <br /> |
+| `tags` _[ServerTag](#servertag) array_ | tags is a list of tags to filter by. If specified, the resource must<br />have all of the tags specified to be included in the result. |  | MaxItems: 50 <br />MaxLength: 80 <br />MinLength: 1 <br /> |
+| `tagsAny` _[ServerTag](#servertag) array_ | tagsAny is a list of tags to filter by. If specified, the resource<br />must have at least one of the tags specified to be included in the<br />result. |  | MaxItems: 50 <br />MaxLength: 80 <br />MinLength: 1 <br /> |
+| `notTags` _[ServerTag](#servertag) array_ | notTags is a list of tags to filter by. If specified, resources which<br />contain all of the given tags will be excluded from the result. |  | MaxItems: 50 <br />MaxLength: 80 <br />MinLength: 1 <br /> |
+| `notTagsAny` _[ServerTag](#servertag) array_ | notTagsAny is a list of tags to filter by. If specified, resources<br />which contain any of the given tags will be excluded from the result. |  | MaxItems: 50 <br />MaxLength: 80 <br />MinLength: 1 <br /> |
 
 
 #### FixedIPStatus
@@ -2484,10 +2484,10 @@ _Appears in:_
 | --- | --- | --- | --- |
 | `name` _[OpenStackName](#openstackname)_ | name of the existing resource |  | MaxLength: 255 <br />MinLength: 1 <br />Pattern: `^[^,]+$` <br /> |
 | `availabilityZone` _string_ | availabilityZone is the availability zone of the existing resource |  | MaxLength: 255 <br /> |
-| `tags` _[ServerTag](#servertag) array_ | tags is a list of tags to filter by. If specified, the resource must<br />have all of the tags specified to be included in the result. |  | MaxItems: 64 <br />MaxLength: 80 <br />MinLength: 1 <br /> |
-| `tagsAny` _[ServerTag](#servertag) array_ | tagsAny is a list of tags to filter by. If specified, the resource<br />must have at least one of the tags specified to be included in the<br />result. |  | MaxItems: 64 <br />MaxLength: 80 <br />MinLength: 1 <br /> |
-| `notTags` _[ServerTag](#servertag) array_ | notTags is a list of tags to filter by. If specified, resources which<br />contain all of the given tags will be excluded from the result. |  | MaxItems: 64 <br />MaxLength: 80 <br />MinLength: 1 <br /> |
-| `notTagsAny` _[ServerTag](#servertag) array_ | notTagsAny is a list of tags to filter by. If specified, resources<br />which contain any of the given tags will be excluded from the result. |  | MaxItems: 64 <br />MaxLength: 80 <br />MinLength: 1 <br /> |
+| `tags` _[ServerTag](#servertag) array_ | tags is a list of tags to filter by. If specified, the resource must<br />have all of the tags specified to be included in the result. |  | MaxItems: 50 <br />MaxLength: 80 <br />MinLength: 1 <br /> |
+| `tagsAny` _[ServerTag](#servertag) array_ | tagsAny is a list of tags to filter by. If specified, the resource<br />must have at least one of the tags specified to be included in the<br />result. |  | MaxItems: 50 <br />MaxLength: 80 <br />MinLength: 1 <br /> |
+| `notTags` _[ServerTag](#servertag) array_ | notTags is a list of tags to filter by. If specified, resources which<br />contain all of the given tags will be excluded from the result. |  | MaxItems: 50 <br />MaxLength: 80 <br />MinLength: 1 <br /> |
+| `notTagsAny` _[ServerTag](#servertag) array_ | notTagsAny is a list of tags to filter by. If specified, resources<br />which contain any of the given tags will be excluded from the result. |  | MaxItems: 50 <br />MaxLength: 80 <br />MinLength: 1 <br /> |
 
 
 #### ServerGroup
@@ -2770,7 +2770,7 @@ _Appears in:_
 | `volumes` _[ServerVolumeSpec](#servervolumespec) array_ | volumes is a list of volumes attached to the server. |  | MaxItems: 64 <br />MinProperties: 1 <br /> |
 | `serverGroupRef` _[KubernetesNameRef](#kubernetesnameref)_ | serverGroupRef is a reference to a ServerGroup object. The server<br />will be created in the server group. |  | MaxLength: 253 <br />MinLength: 1 <br /> |
 | `availabilityZone` _string_ | availabilityZone is the availability zone in which to create the server. |  | MaxLength: 255 <br /> |
-| `tags` _[ServerTag](#servertag) array_ | tags is a list of tags which will be applied to the server. |  | MaxItems: 64 <br />MaxLength: 80 <br />MinLength: 1 <br /> |
+| `tags` _[ServerTag](#servertag) array_ | tags is a list of tags which will be applied to the server. |  | MaxItems: 50 <br />MaxLength: 80 <br />MinLength: 1 <br /> |
 
 
 #### ServerResourceStatus
@@ -2794,7 +2794,7 @@ _Appears in:_
 | `serverGroups` _string array_ | serverGroups is a slice of strings containing the UUIDs of the<br />server groups to which the server belongs. Currently this can<br />contain at most one entry. |  | MaxItems: 32 <br />items:MaxLength: 1024 <br /> |
 | `volumes` _[ServerVolumeStatus](#servervolumestatus) array_ | volumes contains the volumes attached to the server. |  | MaxItems: 64 <br /> |
 | `interfaces` _[ServerInterfaceStatus](#serverinterfacestatus) array_ | interfaces contains the list of interfaces attached to the server. |  | MaxItems: 64 <br /> |
-| `tags` _string array_ | tags is the list of tags on the resource. |  | MaxItems: 64 <br />items:MaxLength: 1024 <br /> |
+| `tags` _string array_ | tags is the list of tags on the resource. |  | MaxItems: 50 <br />items:MaxLength: 1024 <br /> |
 
 
 #### ServerSpec


### PR DESCRIPTION
Nova has a hardcoded limit of 50 tags per instance [1]. Let's make sure we don't allow more than that.

[1] https://github.com/openstack/nova/blob/a79fea0347d4171a423eed65f8b28010745ca3f9/nova/objects/instance.py#L74