### PR TITLE
Bump kuttl timeout

### DIFF
--- a/cmd/resource-generator/data/kuttl-test.yaml.template
+++ b/cmd/resource-generator/data/kuttl-test.yaml.template
@@ -4,4 +4,4 @@ testDirs:
 {{- range . }}
 - ./internal/controllers/{{ .NameLower }}/tests/
 {{- end}}
-timeout: 120
+timeout: 240

--- a/kuttl-test.yaml
+++ b/kuttl-test.yaml
@@ -16,4 +16,4 @@ testDirs:
 - ./internal/controllers/subnet/tests/
 - ./internal/controllers/volume/tests/
 - ./internal/controllers/volumetype/tests/
-timeout: 120
+timeout: 240


### PR DESCRIPTION
We started seeing the CI flake on the server-update test, where the port does not have the expected status. This is most likely a timeout occurring in CI, as this is both our longest test to run, and the port check is a new addition that makes the test take even longer.

Let's give kuttl more time to run the tests and see if it stabilizes the CI.