### PR TITLE
CI: drop caracal, add epoxy and flamingo

### DIFF
--- a/.github/workflows/e2e.yaml
+++ b/.github/workflows/e2e.yaml
@@ -13,11 +13,14 @@ jobs:
       fail-fast: false
       matrix:
         include:
+          - name: "flamingo"
+            openstack_version: "stable/2025.2"
+            ubuntu_version: "24.04"
+          - name: "epoxy"
+            openstack_version: "stable/2025.1"
+            ubuntu_version: "24.04"
           - name: "dalmatian"
             openstack_version: "stable/2024.2"
-            ubuntu_version: "22.04"
-          - name: "caracal"
-            openstack_version: "stable/2024.1"
             ubuntu_version: "22.04"
     env:
       image_tag: virtual-registry.k-orc.cloud/ci:commit-${GITHUB_SHA::7}


### PR DESCRIPTION
Test on all maintained versions of OpenStack.

Partial backport of https://github.com/k-orc/openstack-resource-controller/pull/547.