### PR TITLE
CI: Enable openstack-cli-server

### DIFF
--- a/.github/workflows/e2e.yaml
+++ b/.github/workflows/e2e.yaml
@@ -35,6 +35,7 @@ jobs:
       with:
         enable_workaround_docker_io: 'false'
         branch: ${{ matrix.openstack_version }}
+        enabled_services: "openstack-cli-server"
 
     - name: Deploy a Kind Cluster
       uses: helm/kind-action@92086f6be054225fa813e0a4b13787fc9088faab


### PR DESCRIPTION
Similar to what was done in https://github.com/gophercloud/gophercloud/commit/f018747518afe2ec0e703bb510112ba363a559a1

This allows to save a couple of minutes standing up devstack.

Partial backport of https://github.com/k-orc/openstack-resource-controller/pull/205.