### PR TITLE
Volume: support availability zone

### DIFF
--- a/api/v1alpha1/volume_types.go
+++ b/api/v1alpha1/volume_types.go
@@ -42,6 +42,12 @@ type VolumeResourceSpec struct {
 	// +kubebuilder:validation:XValidation:rule="self == oldSelf",message="volumeTypeRef is immutable"
 	VolumeTypeRef *KubernetesNameRef `json:"volumeTypeRef,omitempty"`
 
+	// availabilityZone is the availability zone in which to create the volume.
+	// +kubebuilder:validation:MaxLength:=255
+	// +optional
+	// +kubebuilder:validation:XValidation:rule="self == oldSelf",message="availabilityZone is immutable"
+	AvailabilityZone string `json:"availabilityZone,omitempty"`
+
 	// metadata key and value pairs to be associated with the volume.
 	// NOTE(mandre): gophercloud can't clear all metadata at the moment, we thus can't allow
 	// mutability for metadata as we might end up in a state that is not reconciliable
@@ -69,6 +75,11 @@ type VolumeFilter struct {
 	// +kubebuilder:validation:Minimum=1
 	// +optional
 	Size *int32 `json:"size,omitempty"`
+
+	// availabilityZone is the availability zone of the existing resource
+	// +kubebuilder:validation:MaxLength:=255
+	// +optional
+	AvailabilityZone string `json:"availabilityZone,omitempty"`
 }
 
 type VolumeAttachmentStatus struct {

--- a/cmd/models-schema/zz_generated.openapi.go
+++ b/cmd/models-schema/zz_generated.openapi.go
@@ -8380,6 +8380,13 @@ func schema_openstack_resource_controller_v2_api_v1alpha1_VolumeFilter(ref commo
 							Format:      "int32",
 						},
 					},
+					"availabilityZone": {
+						SchemaProps: spec.SchemaProps{
+							Description: "availabilityZone is the availability zone of the existing resource",
+							Type:        []string{"string"},
+							Format:      "",
+						},
+					},
 				},
 			},
 		},
@@ -8551,6 +8558,13 @@ func schema_openstack_resource_controller_v2_api_v1alpha1_VolumeResourceSpec(ref
 					"volumeTypeRef": {
 						SchemaProps: spec.SchemaProps{
 							Description: "volumeTypeRef is a reference to the ORC VolumeType which this resource is associated with.",
+							Type:        []string{"string"},
+							Format:      "",
+						},
+					},
+					"availabilityZone": {
+						SchemaProps: spec.SchemaProps{
+							Description: "availabilityZone is the availability zone in which to create the volume.",
 							Type:        []string{"string"},
 							Format:      "",
 						},

--- a/config/crd/bases/openstack.k-orc.cloud_volumes.yaml
+++ b/config/crd/bases/openstack.k-orc.cloud_volumes.yaml
@@ -91,6 +91,11 @@ spec:
                       error state and will not continue to retry.
                     minProperties: 1
                     properties:
+                      availabilityZone:
+                        description: availabilityZone is the availability zone of
+                          the existing resource
+                        maxLength: 255
+                        type: string
                       description:
                         description: description of the existing resource
                         maxLength: 255
@@ -154,6 +159,14 @@ spec:
 
                   resource must be specified if the management policy is `managed`.
                 properties:
+                  availabilityZone:
+                    description: availabilityZone is the availability zone in which
+                      to create the volume.
+                    maxLength: 255
+                    type: string
+                    x-kubernetes-validations:
+                    - message: availabilityZone is immutable
+                      rule: self == oldSelf
                   description:
                     description: description is a human-readable description for the
                       resource.

--- a/internal/controllers/volume/tests/volume-create-full/00-assert.yaml
+++ b/internal/controllers/volume/tests/volume-create-full/00-assert.yaml
@@ -10,6 +10,7 @@ status:
     description: Volume from "create full" test
     size: 1
     status: available
+    availabilityZone: nova
     bootable: false
     encrypted: false
     multiattach: false

--- a/internal/controllers/volume/tests/volume-create-full/00-create-resource.yaml
+++ b/internal/controllers/volume/tests/volume-create-full/00-create-resource.yaml
@@ -25,6 +25,7 @@ spec:
     description: Volume from "create full" test
     size: 1
     volumeTypeRef: volume-create-full
+    availabilityZone: nova
     metadata:
     - name: metadata
       value: value

--- a/internal/controllers/volume/tests/volume-import/00-import-resource.yaml
+++ b/internal/controllers/volume/tests/volume-import/00-import-resource.yaml
@@ -13,3 +13,4 @@ spec:
       name: volume-import-external
       description: Volume volume-import-external from "volume-import" test
       size: 1
+      availabilityZone: nova

--- a/internal/controllers/volume/tests/volume-import/01-assert.yaml
+++ b/internal/controllers/volume/tests/volume-import/01-assert.yaml
@@ -17,6 +17,7 @@ status:
     name: volume-import-external-not-this-one
     description: Volume volume-import-external from "volume-import" test
     size: 1
+    availabilityZone: nova
 ---
 apiVersion: openstack.k-orc.cloud/v1alpha1
 kind: Volume

--- a/internal/controllers/volume/tests/volume-import/01-create-trap-resource.yaml
+++ b/internal/controllers/volume/tests/volume-import/01-create-trap-resource.yaml
@@ -15,3 +15,4 @@ spec:
   resource:
     description: Volume volume-import-external from "volume-import" test
     size: 1
+    availabilityZone: nova

--- a/internal/controllers/volume/tests/volume-import/02-assert.yaml
+++ b/internal/controllers/volume/tests/volume-import/02-assert.yaml
@@ -31,3 +31,4 @@ status:
     name: volume-import-external
     description: Volume volume-import-external from "volume-import" test
     size: 1
+    availabilityZone: nova

--- a/internal/controllers/volume/tests/volume-import/02-create-resource.yaml
+++ b/internal/controllers/volume/tests/volume-import/02-create-resource.yaml
@@ -12,3 +12,4 @@ spec:
   resource:
     description: Volume volume-import-external from "volume-import" test
     size: 1
+    availabilityZone: nova

--- a/pkg/clients/applyconfiguration/api/v1alpha1/volumefilter.go
+++ b/pkg/clients/applyconfiguration/api/v1alpha1/volumefilter.go
@@ -25,9 +25,10 @@ import (
 // VolumeFilterApplyConfiguration represents a declarative configuration of the VolumeFilter type for use
 // with apply.
 type VolumeFilterApplyConfiguration struct {
-	Name        *apiv1alpha1.OpenStackName `json:"name,omitempty"`
-	Description *string                    `json:"description,omitempty"`
-	Size        *int32                     `json:"size,omitempty"`
+	Name             *apiv1alpha1.OpenStackName `json:"name,omitempty"`
+	Description      *string                    `json:"description,omitempty"`
+	Size             *int32                     `json:"size,omitempty"`
+	AvailabilityZone *string                    `json:"availabilityZone,omitempty"`
 }
 
 // VolumeFilterApplyConfiguration constructs a declarative configuration of the VolumeFilter type for use with
@@ -57,5 +58,13 @@ func (b *VolumeFilterApplyConfiguration) WithDescription(value string) *VolumeFi
 // If called multiple times, the Size field is set to the value of the last call.
 func (b *VolumeFilterApplyConfiguration) WithSize(value int32) *VolumeFilterApplyConfiguration {
 	b.Size = &value
+	return b
+}
+
+// WithAvailabilityZone sets the AvailabilityZone field in the declarative configuration to the given value
+// and returns the receiver, so that objects can be built by chaining "With" function invocations.
+// If called multiple times, the AvailabilityZone field is set to the value of the last call.
+func (b *VolumeFilterApplyConfiguration) WithAvailabilityZone(value string) *VolumeFilterApplyConfiguration {
+	b.AvailabilityZone = &value
 	return b
 }

--- a/pkg/clients/applyconfiguration/api/v1alpha1/volumeresourcespec.go
+++ b/pkg/clients/applyconfiguration/api/v1alpha1/volumeresourcespec.go
@@ -25,11 +25,12 @@ import (
 // VolumeResourceSpecApplyConfiguration represents a declarative configuration of the VolumeResourceSpec type for use
 // with apply.
 type VolumeResourceSpecApplyConfiguration struct {
-	Name          *apiv1alpha1.OpenStackName         `json:"name,omitempty"`
-	Description   *string                            `json:"description,omitempty"`
-	Size          *int32                             `json:"size,omitempty"`
-	VolumeTypeRef *apiv1alpha1.KubernetesNameRef     `json:"volumeTypeRef,omitempty"`
-	Metadata      []VolumeMetadataApplyConfiguration `json:"metadata,omitempty"`
+	Name             *apiv1alpha1.OpenStackName         `json:"name,omitempty"`
+	Description      *string                            `json:"description,omitempty"`
+	Size             *int32                             `json:"size,omitempty"`
+	VolumeTypeRef    *apiv1alpha1.KubernetesNameRef     `json:"volumeTypeRef,omitempty"`
+	AvailabilityZone *string                            `json:"availabilityZone,omitempty"`
+	Metadata         []VolumeMetadataApplyConfiguration `json:"metadata,omitempty"`
 }
 
 // VolumeResourceSpecApplyConfiguration constructs a declarative configuration of the VolumeResourceSpec type for use with
@@ -67,6 +68,14 @@ func (b *VolumeResourceSpecApplyConfiguration) WithSize(value int32) *VolumeReso
 // If called multiple times, the VolumeTypeRef field is set to the value of the last call.
 func (b *VolumeResourceSpecApplyConfiguration) WithVolumeTypeRef(value apiv1alpha1.KubernetesNameRef) *VolumeResourceSpecApplyConfiguration {
 	b.VolumeTypeRef = &value
+	return b
+}
+
+// WithAvailabilityZone sets the AvailabilityZone field in the declarative configuration to the given value
+// and returns the receiver, so that objects can be built by chaining "With" function invocations.
+// If called multiple times, the AvailabilityZone field is set to the value of the last call.
+func (b *VolumeResourceSpecApplyConfiguration) WithAvailabilityZone(value string) *VolumeResourceSpecApplyConfiguration {
+	b.AvailabilityZone = &value
 	return b
 }
 

--- a/pkg/clients/applyconfiguration/internal/internal.go
+++ b/pkg/clients/applyconfiguration/internal/internal.go
@@ -2492,6 +2492,9 @@ var schemaYAML = typed.YAMLObject(`types:
 - name: com.github.k-orc.openstack-resource-controller.v2.api.v1alpha1.VolumeFilter
   map:
     fields:
+    - name: availabilityZone
+      type:
+        scalar: string
     - name: description
       type:
         scalar: string
@@ -2533,6 +2536,9 @@ var schemaYAML = typed.YAMLObject(`types:
 - name: com.github.k-orc.openstack-resource-controller.v2.api.v1alpha1.VolumeResourceSpec
   map:
     fields:
+    - name: availabilityZone
+      type:
+        scalar: string
     - name: description
       type:
         scalar: string

--- a/website/docs/crd-reference.md
+++ b/website/docs/crd-reference.md
@@ -3297,6 +3297,7 @@ _Appears in:_
 | `name` _[OpenStackName](#openstackname)_ | name of the existing resource |  | MaxLength: 255 <br />MinLength: 1 <br />Pattern: `^[^,]+$` <br /> |
 | `description` _string_ | description of the existing resource |  | MaxLength: 255 <br />MinLength: 1 <br /> |
 | `size` _integer_ | size is the size of the volume in GiB. |  | Minimum: 1 <br /> |
+| `availabilityZone` _string_ | availabilityZone is the availability zone of the existing resource |  | MaxLength: 255 <br /> |
 
 
 #### VolumeImport
@@ -3370,6 +3371,7 @@ _Appears in:_
 | `description` _string_ | description is a human-readable description for the resource. |  | MaxLength: 255 <br />MinLength: 1 <br /> |
 | `size` _integer_ | size is the size of the volume, in gibibytes (GiB). |  | Minimum: 1 <br /> |
 | `volumeTypeRef` _[KubernetesNameRef](#kubernetesnameref)_ | volumeTypeRef is a reference to the ORC VolumeType which this resource is associated with. |  | MaxLength: 253 <br />MinLength: 1 <br /> |
+| `availabilityZone` _string_ | availabilityZone is the availability zone in which to create the volume. |  | MaxLength: 255 <br /> |
 | `metadata` _[VolumeMetadata](#volumemetadata) array_ | Refer to Kubernetes API documentation for fields of `metadata`. |  | MaxItems: 64 <br /> |
 
 


### PR DESCRIPTION
Add support for volume availability zone, at resource creation and import. It was already reported in the resource status.

For #577 