### PR TITLE
Fix actuator errors going silently

### DIFF
--- a/internal/controllers/floatingip/actuator.go
+++ b/internal/controllers/floatingip/actuator.go
@@ -356,11 +356,11 @@ func newActuator(ctx context.Context, orcObject *orcv1alpha1.FloatingIP, control
 
 	clientScope, err := controller.GetScopeFactory().NewClientScopeFromObject(ctx, controller.GetK8sClient(), log, orcObject)
 	if err != nil {
-		return floatingipActuator{}, nil
+		return floatingipActuator{}, progress.WrapError(err)
 	}
 	osClient, err := clientScope.NewNetworkClient()
 	if err != nil {
-		return floatingipActuator{}, nil
+		return floatingipActuator{}, progress.WrapError(err)
 	}
 
 	return floatingipActuator{

--- a/internal/controllers/router/actuator.go
+++ b/internal/controllers/router/actuator.go
@@ -304,11 +304,11 @@ func newActuator(ctx context.Context, orcObject *orcv1alpha1.Router, controller 
 
 	clientScope, err := controller.GetScopeFactory().NewClientScopeFromObject(ctx, controller.GetK8sClient(), log, orcObject)
 	if err != nil {
-		return routerActuator{}, nil
+		return routerActuator{}, progress.WrapError(err)
 	}
 	osClient, err := clientScope.NewNetworkClient()
 	if err != nil {
-		return routerActuator{}, nil
+		return routerActuator{}, progress.WrapError(err)
 	}
 
 	return routerActuator{


### PR DESCRIPTION
Router and floating ip controller panics due to any client error in
newActuator due to errors not bubbling up. Add proper error handling to
avoid panics.

fixes: https://github.com/k-orc/openstack-resource-controller/issues/587