### PR TITLE
Mocks: use the mock keypair client

### DIFF
--- a/internal/scope/mock.go
+++ b/internal/scope/mock.go
@@ -35,39 +35,39 @@ import (
 // when we want to use mocked service clients which do not attempt to connect to a running OpenStack cloud.
 type MockScopeFactory struct {
 	ComputeClient    *mock.MockComputeClient
+	DomainClient     *mock.MockDomainClient
+	IdentityClient   *mock.MockIdentityClient
+	ImageClient      *mock.MockImageClient
 	KeyPairClient    *mock.MockKeyPairClient
 	NetworkClient    *mock.MockNetworkClient
-	ImageClient      *mock.MockImageClient
-	IdentityClient   *mock.MockIdentityClient
+	ServiceClient    *mock.MockServiceClient
 	VolumeClient     *mock.MockVolumeClient
 	VolumeTypeClient *mock.MockVolumeTypeClient
-	DomainClient     *mock.MockDomainClient
-	ServiceClient    *mock.MockServiceClient
 
 	clientScopeCreateError error
 }
 
 func NewMockScopeFactory(mockCtrl *gomock.Controller) *MockScopeFactory {
 	computeClient := mock.NewMockComputeClient(mockCtrl)
+	domainClient := mock.NewMockDomainClient(mockCtrl)
+	identityClient := mock.NewMockIdentityClient(mockCtrl)
 	imageClient := mock.NewMockImageClient(mockCtrl)
 	keypairClient := mock.NewMockKeyPairClient(mockCtrl)
 	networkClient := mock.NewMockNetworkClient(mockCtrl)
-	identityClient := mock.NewMockIdentityClient(mockCtrl)
+	serviceClient := mock.NewMockServiceClient(mockCtrl)
 	volumeClient := mock.NewMockVolumeClient(mockCtrl)
 	volumetypeClient := mock.NewMockVolumeTypeClient(mockCtrl)
-	domainClient := mock.NewMockDomainClient(mockCtrl)
-	serviceClient := mock.NewMockServiceClient(mockCtrl)
 
 	return &MockScopeFactory{
 		ComputeClient:    computeClient,
+		DomainClient:     domainClient,
+		IdentityClient:   identityClient,
 		ImageClient:      imageClient,
 		KeyPairClient:    keypairClient,
 		NetworkClient:    networkClient,
-		IdentityClient:   identityClient,
+		ServiceClient:    serviceClient,
 		VolumeClient:     volumeClient,
 		VolumeTypeClient: volumetypeClient,
-		DomainClient:     domainClient,
-		ServiceClient:    serviceClient,
 	}
 }
 

--- a/internal/scope/scope.go
+++ b/internal/scope/scope.go
@@ -49,15 +49,15 @@ type Factory interface {
 // Scope contains arguments common to most operations.
 type Scope interface {
 	NewComputeClient() (osclients.ComputeClient, error)
-	NewImageClient() (osclients.ImageClient, error)
-	NewNetworkClient() (osclients.NetworkClient, error)
+	NewDomainClient() (osclients.DomainClient, error)
 	NewIdentityClient() (osclients.IdentityClient, error)
+	NewImageClient() (osclients.ImageClient, error)
+	NewKeyPairClient() (osclients.KeyPairClient, error)
+	NewNetworkClient() (osclients.NetworkClient, error)
+	NewServiceClient() (osclients.ServiceClient, error)
 	NewVolumeClient() (osclients.VolumeClient, error)
 	NewVolumeTypeClient() (osclients.VolumeTypeClient, error)
-	NewDomainClient() (osclients.DomainClient, error)
-	NewServiceClient() (osclients.ServiceClient, error)
 	ExtractToken() (*tokens.Token, error)
-	NewKeyPairClient() (osclients.KeyPairClient, error)
 }
 
 // WithLogger extends Scope with a logger.


### PR DESCRIPTION
For some reason, the KeyPairClient used a real `osclients.KeyPairClient`, let's use a `*mock.MockKeyPairClient` instead.