### PR TITLE
OSASINFRA-3982: Fix token validation for application credentials with access rules

### DIFF
--- a/internal/scope/provider.go
+++ b/internal/scope/provider.go
@@ -178,6 +178,12 @@ func (s *providerScope) ExtractToken() (*tokens.Token, error) {
 	if err != nil {
 		return nil, fmt.Errorf("create new identity service client: %w", err)
 	}
+
+	// allows to validate a token derived from application credentials
+	client.MoreHeaders = map[string]string{
+		"OpenStack-Identity-Access-Rules": "1.0",
+	}
+
 	return tokens.Get(context.TODO(), client, s.providerClient.Token()).ExtractToken()
 }
 


### PR DESCRIPTION
Add the OpenStack-Identity-Access-Rules header when validating tokens
to support application credentials created with access rules. Without
this header, Keystone rejects tokens from such credentials with a 404
error.

Fixes #596 