### PR TITLE
docs: fix broken links

### DIFF
--- a/website/docs/development/overview.md
+++ b/website/docs/development/overview.md
@@ -44,9 +44,9 @@ See the [local development quickstart](quickstart.md) for setting up your enviro
 
 ## Reference documentation
 
-- [Controller design patterns](controller-design.md) - Conditions, errors, and dependency management
-- [General design decisions](design-decisions.md) - Architectural decisions and rationale
-- [Coding conventions](coding-conventions.md) - Code style and patterns
+- [Controller implementation](controller-implementation.md) - Conditions, errors, and dependency management
+- [Architecture](architecture.md) - Architectural decisions and rationale
+- [Coding Standards](coding-standards.md) - Code style and patterns
 
 ### Generated documentation
 

--- a/website/docs/development/scaffolding.md
+++ b/website/docs/development/scaffolding.md
@@ -176,7 +176,7 @@ grep -r "TODO(scaffolding)" api/ internal/controllers/<kind>/
 
 Key areas requiring implementation:
 
-- [API types](api-contracts.md): Define `Filter`, `ResourceSpec`, and `ResourceStatus` structs
+- [API types](api-design.md): Define `Filter`, `ResourceSpec`, and `ResourceStatus` structs
 - [Actuator](interfaces.md#actuator): Implement `CreateResource`, `DeleteResource`, and optionally `GetResourceReconcilers`
 - [Status writer](interfaces.md#resourcestatuswriter): Implement `ResourceAvailableStatus` and `ApplyResourceStatus`
 - [Tests](writing-tests.md): Ensure the tests for your controller are complete


### PR DESCRIPTION
I broke existing links with my recent developers docs reorganization. Fix them so that the website builds again.