### PR TITLE
add: timeout env variable for kuttl tests

### DIFF
--- a/hack/e2e.sh
+++ b/hack/e2e.sh
@@ -23,10 +23,16 @@ if [ -n "$E2E_CACERT" ]; then
     E2E_KUTTL_CACERT_OPT="--from-file=cacert=${E2E_CACERT}"
 fi
 
+E2E_KUTTL_TIMEOUT=${E2E_KUTTL_TIMEOUT:-}
+E2E_KUTTL_TIMEOUT_OPT=
+if [ -n "$E2E_KUTTL_TIMEOUT" ]; then
+    E2E_KUTTL_TIMEOUT_OPT="--timeout $E2E_KUTTL_TIMEOUT"
+fi
+
 # Export variables referenced in kuttl tests.
 export E2E_EXTERNAL_NETWORK_NAME
 export E2E_KUTTL_OSCLOUDS=${PREPARED_OSCLOUDS}
 export E2E_KUTTL_CACERT_OPT
 export E2E_KUTTL_FLAVOR
 
-kubectl kuttl test $E2E_KUTTL_DIR --test "$E2E_KUTTL_TEST"
+kubectl kuttl test $E2E_KUTTL_DIR $E2E_KUTTL_TIMEOUT_OPT --test "$E2E_KUTTL_TEST"

--- a/website/docs/development/writing-tests.md
+++ b/website/docs/development/writing-tests.md
@@ -328,6 +328,7 @@ We use environment variables to configure how the tests run.
 | `E2E_KUTTL_DIR` | Run tests from specific directory | |
 | `E2E_KUTTL_TEST` | Run a specific kuttl test | |
 | `E2E_KUTTL_FLAVOR` | Flavor name to use for tests | `m1.tiny` |
+| `E2E_KUTTL_TIMEOUT` | Override default timeout for tests | |
 
 For example, to run the `import-dependency` test from the `subnet` controller:
 


### PR DESCRIPTION
When running E2E tests, it may be useful to override the default timeout value (240s), so if something fails, you don't need to wait that time.

Issue: #611