### PR TITLE
README: fix broken link to dev docs

### DIFF
--- a/README.md
+++ b/README.md
@@ -30,7 +30,7 @@ We welcome contributions of all kinds! Whether you’re fixing bugs, adding new 
 * Fork the repository.
 * Create a new branch for your changes.
 * Setup a [local development environment](https://k-orc.cloud/development/quickstart/).
-* Read the [developers guide](https://k-orc.cloud/development/).
+* Read the [developers guide](https://k-orc.cloud/development/overview/).
 * Make your changes and test thoroughly.
 * Submit a pull request with a clear description of your changes.
 

--- a/website/mkdocs.yml
+++ b/website/mkdocs.yml
@@ -62,6 +62,11 @@ plugins:
   - redirects:
       redirect_maps:
         'getting_started.md': 'getting-started.md'
+        'development/index.md': 'development/overview.md'
+        'development/controller-design.md': 'development/controller-implementation.md'
+        'development/design-decisions.md': 'development/architecture.md'
+        'development/coding-convention.md': 'development/coding-standards.md'
+        'development/api-contracts.md': 'development/api-design.md'
 markdown_extensions:
   - admonition
   - attr_list


### PR DESCRIPTION
Also add redirects for pages we moved to that we don't break bookmarks.