### PR TITLE
Get orc resources via their full names

### DIFF
--- a/cmd/scaffold-controller/data/tests/dependency/02-delete-dependencies.yaml.template
+++ b/cmd/scaffold-controller/data/tests/dependency/02-delete-dependencies.yaml.template
@@ -5,7 +5,7 @@ kind: TestStep
 commands:
   # We expect the deletion to hang due to the finalizer, so use --wait=false
 {{- range .AllCreateDependencies }}
-  - command: kubectl delete {{ . | lower }} {{ $packageName }}-dependency --wait=false
+  - command: kubectl delete {{ . | lower }}.openstack.k-orc.cloud {{ $packageName }}-dependency --wait=false
     namespaced: true
 {{- end }}
   - command: kubectl delete secret {{ $packageName }}-dependency --wait=false

--- a/cmd/scaffold-controller/data/tests/dependency/03-assert.yaml.template
+++ b/cmd/scaffold-controller/data/tests/dependency/03-assert.yaml.template
@@ -5,7 +5,7 @@ kind: TestAssert
 commands:
 # Dependencies that were prevented deletion before should now be gone
 {{- range .AllCreateDependencies }}
-- script: "! kubectl get {{ . | lower }} {{ $packageName }}-dependency --namespace $NAMESPACE"
+- script: "! kubectl get {{ . | lower }}.openstack.k-orc.cloud {{ $packageName }}-dependency --namespace $NAMESPACE"
   skipLogOutput: true
 {{- end }}
 - script: "! kubectl get secret {{ $packageName }}-dependency --namespace $NAMESPACE"

--- a/cmd/scaffold-controller/data/tests/import-dependency/03-assert.yaml.template
+++ b/cmd/scaffold-controller/data/tests/import-dependency/03-assert.yaml.template
@@ -4,6 +4,6 @@ apiVersion: kuttl.dev/v1beta1
 kind: TestAssert
 commands:
 {{- range .ImportDependencies }}
-- script: "! kubectl get {{ . | lower }} {{ $packageName }}-import-dependency --namespace $NAMESPACE"
+- script: "! kubectl get {{ . | lower }}.openstack.k-orc.cloud {{ $packageName }}-import-dependency --namespace $NAMESPACE"
   skipLogOutput: true
 {{- end }}

--- a/cmd/scaffold-controller/data/tests/import-dependency/03-delete-import-dependencies.yaml.template
+++ b/cmd/scaffold-controller/data/tests/import-dependency/03-delete-import-dependencies.yaml.template
@@ -5,6 +5,6 @@ kind: TestStep
 commands:
   # We should be able to delete the import dependencies
 {{- range .ImportDependencies }}
-  - command: kubectl delete {{ . | lower }} {{ $packageName }}-import-dependency
+  - command: kubectl delete {{ . | lower }}.openstack.k-orc.cloud {{ $packageName }}-import-dependency
     namespaced: true
 {{- end }}

--- a/cmd/scaffold-controller/data/tests/import-dependency/04-assert.yaml.template
+++ b/cmd/scaffold-controller/data/tests/import-dependency/04-assert.yaml.template
@@ -2,5 +2,5 @@
 apiVersion: kuttl.dev/v1beta1
 kind: TestAssert
 commands:
-- script: "! kubectl get {{ .PackageName }} {{ .PackageName }}-import-dependency --namespace $NAMESPACE"
+- script: "! kubectl get {{ .PackageName }}.openstack.k-orc.cloud {{ .PackageName }}-import-dependency --namespace $NAMESPACE"
   skipLogOutput: true


### PR DESCRIPTION
This avoids issues when the resource name conflicts with existing resources and we can't use shortcuts in kubectl commands (e.g. service or role).