### PR TITLE
e2e: empty line generated at top of dependency KUTTL test

### DIFF
--- a/cmd/scaffold-controller/data/tests/dependency/00-create-resources-missing-deps.yaml.template
+++ b/cmd/scaffold-controller/data/tests/dependency/00-create-resources-missing-deps.yaml.template
@@ -9,7 +9,7 @@ metadata:
   name: {{ $packageName }}-dependency
 spec:
   cloudCredentialsRef:
-    # TODO(scaffolding): Use openstack-admin if the resouce needs admin credentials to be created
+    # TODO(scaffolding): Use openstack-admin if the resource needs admin credentials to be created
     cloudName: openstack
     secretName: openstack-clouds
   managementPolicy: managed
@@ -25,7 +25,7 @@ metadata:
   name: {{ $packageName }}-dependency-no-{{ . | lower }}
 spec:
   cloudCredentialsRef:
-    # TODO(scaffolding): Use openstack-admin if the resouce needs admin credentials to be created
+    # TODO(scaffolding): Use openstack-admin if the resource needs admin credentials to be created
     cloudName: openstack
     secretName: openstack-clouds
   managementPolicy: managed
@@ -37,9 +37,9 @@ spec:
     {{ . | camelCase }}Ref: {{ $packageName }}-dependency
 {{- end }}
     # TODO(scaffolding): Add the necessary fields to create the resource
-{{- end }}
-{{- end }}
-{{- range .OptionalCreateDependencies }}
+{{ end -}}
+{{ end -}}
+{{ range .OptionalCreateDependencies -}}
 ---
 apiVersion: openstack.k-orc.cloud/v1alpha1
 kind: {{ $kind }}
@@ -47,7 +47,7 @@ metadata:
   name: {{ $packageName }}-dependency-no-{{ . | lower }}
 spec:
   cloudCredentialsRef:
-    # TODO(scaffolding): Use openstack-admin if the resouce needs admin credentials to be created
+    # TODO(scaffolding): Use openstack-admin if the resource needs admin credentials to be created
     cloudName: openstack
     secretName: openstack-clouds
   managementPolicy: managed
@@ -65,7 +65,7 @@ metadata:
   name: {{ .PackageName }}-dependency-no-secret
 spec:
   cloudCredentialsRef:
-    # TODO(scaffolding): Use openstack-admin if the resouce needs admin credentials to be created
+    # TODO(scaffolding): Use openstack-admin if the resource needs admin credentials to be created
     cloudName: openstack
     secretName: {{ .PackageName }}-dependency
   managementPolicy: managed


### PR DESCRIPTION
Noticed that when using scaffolding tool to create a controller with `-optional-create-dependency`, but without `-required-create-dependency`, an empty line would appear at the top of the  step 00-create-resources-missing-deps.yaml, check it out [here](https://github.com/k-orc/openstack-resource-controller/pull/597#:~:text=Tested%20it%20out%20and%20yep!%20the%20scaffold%20is%20the%20culprit%2C%20will%20look%20more%20into%20why%20at%20a%20later%20time%20%F0%9F%91%8D) .

As shown in #580  the empty line needs to be removed to fix kuttl warnings.
