### PR TITLE
Scaffold Controller tool: required dependency field will generate dependency E2E tests

### DIFF
--- a/cmd/scaffold-controller/main.go
+++ b/cmd/scaffold-controller/main.go
@@ -202,7 +202,7 @@ func render(srcDir, distDir string, resource *templateFields) {
 
 	for _, file := range files {
 		if file.IsDir() {
-			if file.Name() == "dependency" && len(resource.OptionalCreateDependencies) == 0 {
+			if file.Name() == "dependency" && len(resource.AllCreateDependencies) == 0 {
 				continue
 			}
 			if file.Name() == "import-dependency" && len(resource.ImportDependencies) == 0 {


### PR DESCRIPTION
Minor Fix: scaffold generator will create dependency test for either types of dependencies `required-create-dependency` or `optional-create-dependency`

`go run ./cmd/scaffold-controller -interactive=false \
 -kind Snapshot \
 -gophercloud-client NewBlockStorageV3  \
-gophercloud-module github.com/gophercloud/gophercloud/v2/openstack/blockstorage/v3/volumes \
 -import-dependency Volume  -required-create-dependency Volume -available-polling-period 15         \
-deleting-polling-period 15 ` 