### PR TITLE
Fix RouterInterface status when waiting for routerRef

### DIFF
--- a/internal/controllers/routerinterface/tests/routerinterface-dependency/00-assert.yaml
+++ b/internal/controllers/routerinterface/tests/routerinterface-dependency/00-assert.yaml
@@ -3,17 +3,16 @@ apiVersion: openstack.k-orc.cloud/v1alpha1
 kind: RouterInterface
 metadata:
   name: routerinterface-dependency-no-router
-# FIXME: https://github.com/k-orc/openstack-resource-controller/issues/314
-# status:
-#   conditions:
-#     - type: Available
-#       message: Waiting for Router/routerinterface-dependency-pending to be created
-#       status: "False"
-#       reason: Progressing
-#     - type: Progressing
-#       message: Waiting for Router/routerinterface-dependency-pending to be created
-#       status: "True"
-#       reason: Progressing
+status:
+  conditions:
+    - type: Available
+      message: Waiting for Router/routerinterface-dependency-pending to be created
+      status: "False"
+      reason: Progressing
+    - type: Progressing
+      message: Waiting for Router/routerinterface-dependency-pending to be created
+      status: "True"
+      reason: Progressing
 ---
 apiVersion: openstack.k-orc.cloud/v1alpha1
 kind: RouterInterface


### PR DESCRIPTION
As described in #314 RouterInterface objects are not receiving any status (neither `Available` nor `Progressing`) when defining a RouterInterface with a `routerRef` that does not exist.

This is because the RouterInterface controller is special in that it uses a custom reconciler. The reconcile method is called with a Request object containing a reference to a Router not an RouterInterface, since RouterInterfaces require an underlying Router.
The custom reconciler does not take into account what happens when the underlying Router, defined by the `routerRef` field in the RouterInterface spec, does not (yet) exist: It returns an empty Result with no error. But the most important part is that it does not create an update for the RouterInterface in that case, which results in non-existent status conditions.

This is somewhat of a chicken and egg problem: We need our RouterInterface object to update its status before the Router exists, but we need a Router to query for RouterInterfaces. Luckily, we know exactly *when* we run into this exact problem (``apierrors.IsNotFound(err)``). So we can simply create a dummy router object containing name and namespace from the request and use that to query for our RouterInterfaces.
Then we are able to update any affected RouterInterfaces with a WaitingOnObject status.

Fixes #314 