### PR TITLE
Bump go to v1.24.12

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -4,7 +4,7 @@ BUNDLE_IMG ?= bundle:latest
 # ENVTEST_K8S_VERSION refers to the version of kubebuilder assets to be downloaded by envtest binary.
 ENVTEST_K8S_VERSION = 1.29.0
 TRIVY_VERSION = 0.49.1
-GO_VERSION ?= 1.24.11
+GO_VERSION ?= 1.24.12
 
 # Get the currently used golang install path (in GOPATH/bin, unless GOBIN is set)
 ifeq (,$(shell go env GOBIN))


### PR DESCRIPTION
This fixes 2 CVEs:
- https://pkg.go.dev/vuln/GO-2026-4341
- https://pkg.go.dev/vuln/GO-2026-4340