### PR TITLE
Add lightweight enhancement proposal process

### DIFF
--- a/.github/ISSUE_TEMPLATE/feature_request.yaml
+++ b/.github/ISSUE_TEMPLATE/feature_request.yaml
@@ -6,6 +6,10 @@ body:
     attributes:
       value: |
         Thanks for taking the time to fill out this feature request!
+
+        **Note:** For significant new features or architectural changes, consider writing an
+        [enhancement proposal](https://github.com/k-orc/openstack-resource-controller/tree/main/enhancements)
+        instead of or in addition to this issue.
   - type: textarea
     id: request
     attributes:

--- a/.github/labels.yaml
+++ b/.github/labels.yaml
@@ -26,3 +26,6 @@
 - color: 'C2E0C6'
   description: Documentation
   name: docs
+- color: 'A2EEEF'
+  description: Enhancement proposal
+  name: enhancement

--- a/README.md
+++ b/README.md
@@ -34,6 +34,9 @@ We welcome contributions of all kinds! Whether you’re fixing bugs, adding new 
 * Make your changes and test thoroughly.
 * Submit a pull request with a clear description of your changes.
 
+For significant new features or architectural changes, please review our
+[enhancement proposal process](enhancements/README.md) before starting work.
+
 If you're unsure where to start, check out the [open issues](https://github.com/k-orc/openstack-resource-controller/issues) and feel free to ask
 questions or propose ideas!
 

--- a/enhancements/README.md
+++ b/enhancements/README.md
@@ -1,0 +1,104 @@
+# ORC Enhancement Process
+
+This document describes the process for proposing significant changes to ORC.
+The process is intentionally lightweight, inspired by the [Kubernetes
+Enhancement Proposal (KEP)][kep] process but tailored to ORC's scope and
+community size.
+
+[kep]: https://github.com/kubernetes/enhancements/tree/master/keps
+
+## When to Write an Enhancement
+
+Write an enhancement proposal when you want to:
+
+- Add a significant new feature or capability
+- Make breaking changes to existing APIs
+- Deprecate or remove functionality
+- Make cross-cutting architectural changes
+- Change behavior that users depend on
+
+You do **not** need an enhancement for:
+
+- Bug fixes
+- Small improvements or refactoring
+- Documentation updates
+- Adding support for additional OpenStack resource fields
+- Test improvements
+
+When in doubt, open a GitHub issue first to discuss whether an enhancement
+proposal is needed.
+
+## Enhancement Lifecycle
+
+Enhancements move through the following statuses:
+
+| Status | Description |
+|--------|-------------|
+| `implementable` | The enhancement has been approved and is ready for implementation. |
+| `implemented` | The enhancement has been fully implemented and merged. |
+| `withdrawn` | The enhancement is no longer being pursued. |
+
+## How to Submit an Enhancement
+
+1. **Copy the template** from [TEMPLATE.md](TEMPLATE.md) to a new file named
+   after your feature:
+   ```
+   enhancements/your-feature-name.md
+   ```
+
+   If your enhancement requires supporting files (images, diagrams), create a
+   directory instead:
+   ```
+   enhancements/your-feature-name/
+   ├── your-feature-name.md
+   └── diagram.png
+   ```
+
+2. **Fill out the template** with your proposal details.
+
+3. **Open a pull request** with your enhancement proposal. Use a descriptive
+   title like: `Enhancement: Add support for feature X`
+
+4. **Iterate based on feedback**. Discussion happens on the PR.
+
+5. **Create a tracking issue** once the enhancement is merged. Label the issue
+   with `enhancement` and link it in your enhancement's metadata table.
+
+## Review Process
+
+- Any community member can propose an enhancement
+- Maintainers review proposals and provide feedback on the PR
+- Enhancements are approved using lazy consensus: if no maintainer has objected
+  after a reasonable review period (typically one week), the enhancement can be
+  merged
+- The enhancement author is typically expected to drive implementation, though
+  others may volunteer
+
+## Directory Structure
+
+```
+enhancements/
+├── README.md                    # This document
+├── TEMPLATE.md                  # Template for new enhancements
+├── your-feature-name.md         # Simple enhancement (single file)
+└── complex-feature/             # Enhancement with supporting files
+    ├── complex-feature.md
+    └── architecture.png
+```
+
+## Tips for Writing Good Enhancements
+
+1. **Be concise but complete**. Include enough detail for reviewers to
+   understand the proposal without unnecessary verbosity.
+
+2. **Focus on the "why"**. Motivation is often more important than
+   implementation details.
+
+3. **Think about edge cases**. The Risks and Edge Cases section is where you
+   demonstrate you've thought through the implications.
+
+4. **Consider alternatives**. Showing that you've evaluated other approaches
+   strengthens your proposal.
+
+5. **Keep it updated**. As implementation progresses, update the Implementation
+   History section.

--- a/enhancements/TEMPLATE.md
+++ b/enhancements/TEMPLATE.md
@@ -1,0 +1,102 @@
+# Enhancement: Your Feature Title
+
+<!--
+Instructions:
+1. Copy this file to: enhancements/your-feature-name.md
+   (or enhancements/your-feature-name/your-feature-name.md if you need supporting files)
+2. Fill in the metadata table below
+3. Complete each section (remove the HTML comments when done)
+4. Open a PR for review
+-->
+
+| Field | Value |
+|-------|-------|
+| **Status** | implementable |
+| **Author(s)** | @your-github-username |
+| **Created** | YYYY-MM-DD |
+| **Last Updated** | YYYY-MM-DD |
+| **Tracking Issue** | TBD |
+
+## Summary
+
+<!--
+Provide a 1-2 paragraph overview of your enhancement. This should be
+understandable by someone who hasn't read the rest of the document.
+What are you proposing and what will it enable?
+-->
+
+## Motivation
+
+<!--
+Why is this change needed? What problem does it solve? Who is affected?
+Include links to issues, discussions, or user feedback that motivated this
+proposal if available.
+-->
+
+## Goals
+
+<!--
+List the specific objectives of this enhancement. What will be true when
+this is complete? Be specific and measurable where possible.
+
+- Goal 1
+- Goal 2
+-->
+
+## Non-Goals
+
+<!--
+What is explicitly out of scope for this enhancement? Listing non-goals helps
+focus discussion and prevents scope creep.
+
+- Non-goal 1
+- Non-goal 2
+-->
+
+## Proposal
+
+<!--
+Describe your proposed solution in detail. This should include:
+
+- How the feature will work from a user's perspective
+- Any new APIs, fields, or resources being introduced
+- How it integrates with existing functionality
+
+Include code examples, API snippets, or diagrams where helpful.
+-->
+
+## Risks and Edge Cases
+
+<!--
+Think critically about what could go wrong or what corner cases exist.
+Consider:
+
+- API compatibility: Will this break existing users?
+- Security: Are there any security implications?
+- Performance: Could this impact controller performance at scale?
+- Error handling: What happens when things fail?
+- Upgrade/downgrade: How does this affect users upgrading or downgrading ORC?
+- OpenStack compatibility: Does this work across different OpenStack versions?
+- Interaction with other features: Could this conflict with existing behavior?
+
+For each risk identified, describe how it will be mitigated.
+-->
+
+## Alternatives Considered
+
+<!--
+What other approaches did you consider? Why were they rejected?
+This demonstrates due diligence and helps reviewers understand the design space.
+-->
+
+## Implementation History
+
+<!--
+Track major milestones here. Keep it lightweight.
+
+- YYYY-MM-DD: Enhancement proposed
+- YYYY-MM-DD: Implementation started
+- YYYY-MM-DD: Implemented in vX.Y.Z
+-->
+
+- YYYY-MM-DD: Enhancement proposed

--- a/website/docs/index.md
+++ b/website/docs/index.md
@@ -76,6 +76,10 @@ We welcome contributions of all kinds! Whether you're fixing bugs, adding new fe
 * Make your changes and test thoroughly.
 * Submit a pull request with a clear description of your changes.
 
+For significant new features or architectural changes, please review our
+[enhancement proposal process](https://github.com/k-orc/openstack-resource-controller/tree/main/enhancements)
+before starting work.
+
 If you're unsure where to start, check out the [open issues](https://github.com/k-orc/openstack-resource-controller/issues) and feel free to ask
 questions or propose ideas!
 


### PR DESCRIPTION
Introduce a process for contributors to propose significant enhancements, inspired by Kubernetes KEPs but tailored to ORC's scope.

- Add enhancements/ directory with process README and template
- Reference enhancement process from README, website, and feature request template
- Support single-file enhancements or directories for proposals with supporting files