### PR TITLE
Simplify dependency ready filters to use IsAvailable directly

### DIFF
--- a/api/v1alpha1/conditions.go
+++ b/api/v1alpha1/conditions.go
@@ -113,7 +113,7 @@ func GetTerminalError(obj ObjectWithConditions) error {
 	return nil
 }
 
-func IsAvailable(obj ObjectWithConditions) bool {
+func IsAvailable[T ObjectWithConditions](obj T) bool {
 	conditions := obj.GetConditions()
 	available := meta.FindStatusCondition(conditions, ConditionAvailable)
 

--- a/cmd/scaffold-controller/data/controller/actuator.go.template
+++ b/cmd/scaffold-controller/data/controller/actuator.go.template
@@ -106,10 +106,10 @@ func (actuator {{ .PackageName }}Actuator) ListOSResourcesForImport(ctx context.
 	var reconcileStatus progress.ReconcileStatus
 {{- range .ImportDependencies }}
 {{ $depNameCamelCase := . | camelCase }}
-	{{ $depNameCamelCase }}, rs := dependency.FetchDependency(
+	{{ $depNameCamelCase }}, rs := dependency.FetchDependency[*orcv1alpha1.{{ . }}](
 		ctx, actuator.k8sClient, obj.Namespace,
 		filter.{{ . }}Ref, "{{ . }}",
-		func(dep *orcv1alpha1.{{ . }}) bool { return orcv1alpha1.IsAvailable(dep) && dep.Status.ID != nil },
+		orcv1alpha1.IsAvailable,
 	)
 	reconcileStatus = reconcileStatus.WithReconcileStatus(rs)
 {{- end }}
@@ -145,15 +145,13 @@ func (actuator {{ .PackageName }}Actuator) CreateResource(ctx context.Context, o
 {{- range .RequiredCreateDependencies }}
 {{ $depNameCamelCase := . | camelCase }}
 	var {{ $depNameCamelCase }}ID string
-        {{ $depNameCamelCase }}, {{ $depNameCamelCase }}DepRS := {{ $depNameCamelCase }}Dependency.GetDependency(
-                ctx, actuator.k8sClient, obj, func(dep *orcv1alpha1.{{ . }}) bool {
-                        return orcv1alpha1.IsAvailable(dep) && dep.Status.ID != nil
-                },
-        )
-        reconcileStatus = reconcileStatus.WithReconcileStatus({{ $depNameCamelCase }}DepRS)
-        if {{ $depNameCamelCase }} != nil {
-                {{ $depNameCamelCase }}ID = ptr.Deref({{ $depNameCamelCase }}.Status.ID, "")
-        }
+	{{ $depNameCamelCase }}, {{ $depNameCamelCase }}DepRS := {{ $depNameCamelCase }}Dependency.GetDependency(
+		ctx, actuator.k8sClient, obj, orcv1alpha1.IsAvailable,
+	)
+	reconcileStatus = reconcileStatus.WithReconcileStatus({{ $depNameCamelCase }}DepRS)
+	if {{ $depNameCamelCase }} != nil {
+		{{ $depNameCamelCase }}ID = ptr.Deref({{ $depNameCamelCase }}.Status.ID, "")
+	}
 
 {{- end }}
 {{- range .OptionalCreateDependencies }}
@@ -161,9 +159,7 @@ func (actuator {{ .PackageName }}Actuator) CreateResource(ctx context.Context, o
 	var {{ $depNameCamelCase }}ID string
 	if resource.{{ . }}Ref != nil {
 		{{ $depNameCamelCase }}, {{ $depNameCamelCase }}DepRS := {{ $depNameCamelCase }}Dependency.GetDependency(
-			ctx, actuator.k8sClient, obj, func(dep *orcv1alpha1.{{ . }}) bool {
-				return orcv1alpha1.IsAvailable(dep) && dep.Status.ID != nil
-			},
+			ctx, actuator.k8sClient, obj, orcv1alpha1.IsAvailable,
 		)
 		reconcileStatus = reconcileStatus.WithReconcileStatus({{ $depNameCamelCase }}DepRS)
 		if {{ $depNameCamelCase }} != nil {

--- a/internal/controllers/addressscope/actuator.go
+++ b/internal/controllers/addressscope/actuator.go
@@ -81,10 +81,10 @@ func (actuator addressscopeActuator) ListOSResourcesForAdoption(ctx context.Cont
 func (actuator addressscopeActuator) ListOSResourcesForImport(ctx context.Context, obj orcObjectPT, filter filterT) (iter.Seq2[*osResourceT, error], progress.ReconcileStatus) {
 	var reconcileStatus progress.ReconcileStatus
 
-	project, rs := dependency.FetchDependency(
+	project, rs := dependency.FetchDependency[*orcv1alpha1.Project](
 		ctx, actuator.k8sClient, obj.Namespace,
 		filter.ProjectRef, "Project",
-		func(dep *orcv1alpha1.Project) bool { return orcv1alpha1.IsAvailable(dep) && dep.Status.ID != nil },
+		orcv1alpha1.IsAvailable,
 	)
 	reconcileStatus = reconcileStatus.WithReconcileStatus(rs)
 
@@ -115,9 +115,7 @@ func (actuator addressscopeActuator) CreateResource(ctx context.Context, obj orc
 	var projectID string
 	if resource.ProjectRef != nil {
 		project, projectDepRS := projectDependency.GetDependency(
-			ctx, actuator.k8sClient, obj, func(dep *orcv1alpha1.Project) bool {
-				return orcv1alpha1.IsAvailable(dep) && dep.Status.ID != nil
-			},
+			ctx, actuator.k8sClient, obj, orcv1alpha1.IsAvailable,
 		)
 		reconcileStatus = reconcileStatus.WithReconcileStatus(projectDepRS)
 		if project != nil {

--- a/internal/controllers/applicationcredential/actuator.go
+++ b/internal/controllers/applicationcredential/actuator.go
@@ -70,10 +70,10 @@ func (actuator applicationcredentialActuator) ListOSResourcesForAdoption(ctx con
 		return nil, false
 	}
 
-	user, _ := dependency.FetchDependency(
+	user, _ := dependency.FetchDependency[*orcv1alpha1.User](
 		ctx, actuator.k8sClient, orcObject.Namespace,
 		&resourceSpec.UserRef, "User",
-		func(dep *orcv1alpha1.User) bool { return orcv1alpha1.IsAvailable(dep) && dep.Status.ID != nil },
+		orcv1alpha1.IsAvailable,
 	)
 
 	if user.Status.ID == nil {
@@ -99,10 +99,10 @@ func (actuator applicationcredentialActuator) ListOSResourcesForAdoption(ctx con
 func (actuator applicationcredentialActuator) ListOSResourcesForImport(ctx context.Context, obj orcObjectPT, filter filterT) (iter.Seq2[*osResourceT, error], progress.ReconcileStatus) {
 	var reconcileStatus progress.ReconcileStatus
 
-	user, rs := dependency.FetchDependency(
+	user, rs := dependency.FetchDependency[*orcv1alpha1.User](
 		ctx, actuator.k8sClient, obj.Namespace,
 		&filter.UserRef, "User",
-		func(dep *orcv1alpha1.User) bool { return orcv1alpha1.IsAvailable(dep) && dep.Status.ID != nil },
+		orcv1alpha1.IsAvailable,
 	)
 	reconcileStatus = reconcileStatus.WithReconcileStatus(rs)
 
@@ -143,21 +143,15 @@ func (actuator applicationcredentialActuator) CreateResource(ctx context.Context
 	var reconcileStatus progress.ReconcileStatus
 
 	user, userDepRS := userDependency.GetDependency(
-		ctx, actuator.k8sClient, obj, func(dep *orcv1alpha1.User) bool {
-			return orcv1alpha1.IsAvailable(dep) && dep.Status.ID != nil
-		},
+		ctx, actuator.k8sClient, obj, orcv1alpha1.IsAvailable,
 	)
 
 	rolesMap, roleDepRs := roleDependency.GetDependencies(
-		ctx, actuator.k8sClient, obj, func(dep *orcv1alpha1.Role) bool {
-			return orcv1alpha1.IsAvailable(dep) && dep.Status.ID != nil
-		},
+		ctx, actuator.k8sClient, obj, orcv1alpha1.IsAvailable,
 	)
 
 	serviceMap, serviceDepRS := serviceDependency.GetDependencies(
-		ctx, actuator.k8sClient, obj, func(dep *orcv1alpha1.Service) bool {
-			return orcv1alpha1.IsAvailable(dep) && dep.Status.ID != nil
-		},
+		ctx, actuator.k8sClient, obj, orcv1alpha1.IsAvailable,
 	)
 
 	secret, secretReconcileStatus := dependency.FetchDependency(
@@ -250,9 +244,7 @@ func (actuator applicationcredentialActuator) DeleteResource(ctx context.Context
 	var reconcileStatus progress.ReconcileStatus
 
 	user, userDepRS := userDependency.GetDependency(
-		ctx, actuator.k8sClient, orcObject, func(dep *orcv1alpha1.User) bool {
-			return orcv1alpha1.IsAvailable(dep) && dep.Status.ID != nil
-		},
+		ctx, actuator.k8sClient, orcObject, orcv1alpha1.IsAvailable,
 	)
 
 	reconcileStatus = reconcileStatus.WithReconcileStatus(userDepRS)

--- a/internal/controllers/endpoint/actuator.go
+++ b/internal/controllers/endpoint/actuator.go
@@ -73,9 +73,7 @@ func (actuator endpointActuator) ListOSResourcesForAdoption(ctx context.Context,
 	}
 
 	service, _ := serviceDependency.GetDependency(
-		ctx, actuator.k8sClient, orcObject, func(dep *orcv1alpha1.Service) bool {
-			return orcv1alpha1.IsAvailable(dep) && dep.Status.ID != nil
-		},
+		ctx, actuator.k8sClient, orcObject, orcv1alpha1.IsAvailable,
 	)
 
 	if service == nil {
@@ -99,10 +97,10 @@ func (actuator endpointActuator) ListOSResourcesForAdoption(ctx context.Context,
 func (actuator endpointActuator) ListOSResourcesForImport(ctx context.Context, obj orcObjectPT, filter filterT) (iter.Seq2[*osResourceT, error], progress.ReconcileStatus) {
 	var reconcileStatus progress.ReconcileStatus
 
-	service, rs := dependency.FetchDependency(
+	service, rs := dependency.FetchDependency[*orcv1alpha1.Service](
 		ctx, actuator.k8sClient, obj.Namespace,
 		filter.ServiceRef, "Service",
-		func(dep *orcv1alpha1.Service) bool { return orcv1alpha1.IsAvailable(dep) && dep.Status.ID != nil },
+		orcv1alpha1.IsAvailable,
 	)
 	reconcileStatus = reconcileStatus.WithReconcileStatus(rs)
 
@@ -142,9 +140,7 @@ func (actuator endpointActuator) CreateResource(ctx context.Context, obj orcObje
 
 	var serviceID string
 	service, serviceDepRS := serviceDependency.GetDependency(
-		ctx, actuator.k8sClient, obj, func(dep *orcv1alpha1.Service) bool {
-			return orcv1alpha1.IsAvailable(dep) && dep.Status.ID != nil
-		},
+		ctx, actuator.k8sClient, obj, orcv1alpha1.IsAvailable,
 	)
 
 	reconcileStatus = reconcileStatus.WithReconcileStatus(serviceDepRS)

--- a/internal/controllers/floatingip/actuator.go
+++ b/internal/controllers/floatingip/actuator.go
@@ -88,27 +88,21 @@ func (actuator floatingipActuator) ListOSResourcesForAdoption(ctx context.Contex
 func (actuator floatingipCreateActuator) ListOSResourcesForImport(ctx context.Context, obj orcObjectPT, filter filterT) (iter.Seq2[*osResourceT, error], progress.ReconcileStatus) {
 	var reconcileStatus progress.ReconcileStatus
 
-	network, rs := dependency.FetchDependency(
+	network, rs := dependency.FetchDependency[*orcv1alpha1.Network](
 		ctx, actuator.k8sClient, obj.Namespace, filter.FloatingNetworkRef, "Network",
-		func(dep *orcv1alpha1.Network) bool {
-			return orcv1alpha1.IsAvailable(dep) && dep.Status.ID != nil
-		},
+		orcv1alpha1.IsAvailable,
 	)
 	reconcileStatus = reconcileStatus.WithReconcileStatus(rs)
 
-	port, rs := dependency.FetchDependency(
+	port, rs := dependency.FetchDependency[*orcv1alpha1.Port](
 		ctx, actuator.k8sClient, obj.Namespace, filter.PortRef, "Port",
-		func(dep *orcv1alpha1.Port) bool {
-			return orcv1alpha1.IsAvailable(dep) && dep.Status.ID != nil
-		},
+		orcv1alpha1.IsAvailable,
 	)
 	reconcileStatus = reconcileStatus.WithReconcileStatus(rs)
 
-	project, rs := dependency.FetchDependency(
+	project, rs := dependency.FetchDependency[*orcv1alpha1.Project](
 		ctx, actuator.k8sClient, obj.Namespace, filter.ProjectRef, "Project",
-		func(dep *orcv1alpha1.Project) bool {
-			return orcv1alpha1.IsAvailable(dep) && dep.Status.ID != nil
-		},
+		orcv1alpha1.IsAvailable,
 	)
 	reconcileStatus = reconcileStatus.WithReconcileStatus(rs)
 
@@ -145,9 +139,7 @@ func (actuator floatingipCreateActuator) CreateResource(ctx context.Context, obj
 	if resource.FloatingNetworkRef != nil {
 		// Fetch dependencies and ensure they have our finalizer
 		network, networkDepRS := networkDep.GetDependency(
-			ctx, actuator.k8sClient, obj, func(dep *orcv1alpha1.Network) bool {
-				return orcv1alpha1.IsAvailable(dep) && dep.Status.ID != nil
-			},
+			ctx, actuator.k8sClient, obj, orcv1alpha1.IsAvailable,
 		)
 		reconcileStatus = reconcileStatus.WithReconcileStatus(networkDepRS)
 		if network != nil {
@@ -160,9 +152,7 @@ func (actuator floatingipCreateActuator) CreateResource(ctx context.Context, obj
 	if resource.FloatingSubnetRef != nil {
 		// Fetch dependencies and ensure they have our finalizer
 		subnet, subnetDepRS := subnetDep.GetDependency(
-			ctx, actuator.k8sClient, obj, func(dep *orcv1alpha1.Subnet) bool {
-				return orcv1alpha1.IsAvailable(dep) && dep.Status.ID != nil
-			},
+			ctx, actuator.k8sClient, obj, orcv1alpha1.IsAvailable,
 		)
 		reconcileStatus = reconcileStatus.WithReconcileStatus(subnetDepRS)
 		if subnet != nil {
@@ -175,9 +165,7 @@ func (actuator floatingipCreateActuator) CreateResource(ctx context.Context, obj
 	if resource.PortRef != nil {
 		// Fetch dependencies and ensure they have our finalizer
 		port, portDepRS := portDep.GetDependency(
-			ctx, actuator.k8sClient, obj, func(dep *orcv1alpha1.Port) bool {
-				return orcv1alpha1.IsAvailable(dep) && dep.Status.ID != nil
-			},
+			ctx, actuator.k8sClient, obj, orcv1alpha1.IsAvailable,
 		)
 		reconcileStatus = reconcileStatus.WithReconcileStatus(portDepRS)
 		if port != nil {
@@ -188,9 +176,7 @@ func (actuator floatingipCreateActuator) CreateResource(ctx context.Context, obj
 	var projectID string
 	if resource.ProjectRef != nil {
 		project, projectDepRS := projectDependency.GetDependency(
-			ctx, actuator.k8sClient, obj, func(dep *orcv1alpha1.Project) bool {
-				return orcv1alpha1.IsAvailable(dep) && dep.Status.ID != nil
-			},
+			ctx, actuator.k8sClient, obj, orcv1alpha1.IsAvailable,
 		)
 		reconcileStatus = reconcileStatus.WithReconcileStatus(projectDepRS)
 		if project != nil {

--- a/internal/controllers/group/actuator.go
+++ b/internal/controllers/group/actuator.go
@@ -82,11 +82,9 @@ func (actuator groupActuator) ListOSResourcesForImport(ctx context.Context, obj 
 
 	var reconcileStatus progress.ReconcileStatus
 
-	domain, rs := dependency.FetchDependency(
+	domain, rs := dependency.FetchDependency[*orcv1alpha1.Domain](
 		ctx, actuator.k8sClient, obj.Namespace, filter.DomainRef, "Domain",
-		func(dep *orcv1alpha1.Domain) bool {
-			return orcv1alpha1.IsAvailable(dep) && dep.Status.ID != nil
-		},
+		orcv1alpha1.IsAvailable,
 	)
 	reconcileStatus = reconcileStatus.WithReconcileStatus(rs)
 
@@ -115,9 +113,7 @@ func (actuator groupActuator) CreateResource(ctx context.Context, obj orcObjectP
 	var domainID string
 	if resource.DomainRef != nil {
 		domain, domainDepRS := domainDependency.GetDependency(
-			ctx, actuator.k8sClient, obj, func(dep *orcv1alpha1.Domain) bool {
-				return orcv1alpha1.IsAvailable(dep) && dep.Status.ID != nil
-			},
+			ctx, actuator.k8sClient, obj, orcv1alpha1.IsAvailable,
 		)
 		reconcileStatus = reconcileStatus.WithReconcileStatus(domainDepRS)
 		if domain != nil {

--- a/internal/controllers/network/actuator.go
+++ b/internal/controllers/network/actuator.go
@@ -83,11 +83,9 @@ func (actuator networkActuator) ListOSResourcesForAdoption(ctx context.Context, 
 func (actuator networkActuator) ListOSResourcesForImport(ctx context.Context, obj orcObjectPT, filter filterT) (iter.Seq2[*osResourceT, error], progress.ReconcileStatus) {
 	var reconcileStatus progress.ReconcileStatus
 
-	project, rs := dependency.FetchDependency(
+	project, rs := dependency.FetchDependency[*orcv1alpha1.Project](
 		ctx, actuator.k8sClient, obj.Namespace, filter.ProjectRef, "Project",
-		func(dep *orcv1alpha1.Project) bool {
-			return orcv1alpha1.IsAvailable(dep) && dep.Status.ID != nil
-		},
+		orcv1alpha1.IsAvailable,
 	)
 	reconcileStatus = reconcileStatus.WithReconcileStatus(rs)
 
@@ -118,9 +116,7 @@ func (actuator networkActuator) CreateResource(ctx context.Context, obj orcObjec
 	var projectID string
 	if resource.ProjectRef != nil {
 		project, reconcileStatus := projectDependency.GetDependency(
-			ctx, actuator.k8sClient, obj, func(dep *orcv1alpha1.Project) bool {
-				return orcv1alpha1.IsAvailable(dep) && dep.Status.ID != nil
-			},
+			ctx, actuator.k8sClient, obj, orcv1alpha1.IsAvailable,
 		)
 		if needsReschedule, _ := reconcileStatus.NeedsReschedule(); needsReschedule {
 			return nil, reconcileStatus

--- a/internal/controllers/port/actuator.go
+++ b/internal/controllers/port/actuator.go
@@ -128,19 +128,15 @@ func (actuator portActuator) ListOSResourcesForAdoption(ctx context.Context, obj
 func (actuator portActuator) ListOSResourcesForImport(ctx context.Context, obj orcObjectPT, filter filterT) (iter.Seq2[*osResourceT, error], progress.ReconcileStatus) {
 	var reconcileStatus progress.ReconcileStatus
 
-	network, rs := dependency.FetchDependency(
+	network, rs := dependency.FetchDependency[*orcv1alpha1.Network](
 		ctx, actuator.k8sClient, obj.Namespace, &filter.NetworkRef, "Network",
-		func(dep *orcv1alpha1.Network) bool {
-			return orcv1alpha1.IsAvailable(dep) && dep.Status.ID != nil
-		},
+		orcv1alpha1.IsAvailable,
 	)
 	reconcileStatus = reconcileStatus.WithReconcileStatus(rs)
 
-	project, rs := dependency.FetchDependency(
+	project, rs := dependency.FetchDependency[*orcv1alpha1.Project](
 		ctx, actuator.k8sClient, obj.Namespace, filter.ProjectRef, "Project",
-		func(dep *orcv1alpha1.Project) bool {
-			return orcv1alpha1.IsAvailable(dep) && dep.Status.ID != nil
-		},
+		orcv1alpha1.IsAvailable,
 	)
 	reconcileStatus = reconcileStatus.WithReconcileStatus(rs)
 
@@ -173,19 +169,13 @@ func (actuator portActuator) CreateResource(ctx context.Context, obj *orcv1alpha
 
 	// Fetch all dependencies and ensure they have our finalizer
 	network, networkDepRS := networkDependency.GetDependency(
-		ctx, actuator.k8sClient, obj, func(dep *orcv1alpha1.Network) bool {
-			return orcv1alpha1.IsAvailable(dep) && dep.Status.ID != nil
-		},
+		ctx, actuator.k8sClient, obj, orcv1alpha1.IsAvailable,
 	)
 	subnetMap, subnetDepRS := subnetDependency.GetDependencies(
-		ctx, actuator.k8sClient, obj, func(dep *orcv1alpha1.Subnet) bool {
-			return orcv1alpha1.IsAvailable(dep) && dep.Status.ID != nil
-		},
+		ctx, actuator.k8sClient, obj, orcv1alpha1.IsAvailable,
 	)
 	secGroupMap, secGroupDepRS := securityGroupDependency.GetDependencies(
-		ctx, actuator.k8sClient, obj, func(dep *orcv1alpha1.SecurityGroup) bool {
-			return orcv1alpha1.IsAvailable(dep) && dep.Status.ID != nil
-		},
+		ctx, actuator.k8sClient, obj, orcv1alpha1.IsAvailable,
 	)
 	reconcileStatus := progress.NewReconcileStatus().
 		WithReconcileStatus(networkDepRS).
@@ -195,9 +185,7 @@ func (actuator portActuator) CreateResource(ctx context.Context, obj *orcv1alpha
 	var projectID string
 	if resource.ProjectRef != nil {
 		project, projectDepRS := projectDependency.GetDependency(
-			ctx, actuator.k8sClient, obj, func(dep *orcv1alpha1.Project) bool {
-				return orcv1alpha1.IsAvailable(dep) && dep.Status.ID != nil
-			},
+			ctx, actuator.k8sClient, obj, orcv1alpha1.IsAvailable,
 		)
 		reconcileStatus = reconcileStatus.WithReconcileStatus(projectDepRS)
 		if project != nil {
@@ -369,9 +357,7 @@ func (actuator portActuator) updateResource(ctx context.Context, obj orcObjectPT
 	}
 
 	secGroupMap, secGroupDepRS := securityGroupDependency.GetDependencies(
-		ctx, actuator.k8sClient, obj, func(dep *orcv1alpha1.SecurityGroup) bool {
-			return orcv1alpha1.IsAvailable(dep) && dep.Status.ID != nil
-		},
+		ctx, actuator.k8sClient, obj, orcv1alpha1.IsAvailable,
 	)
 
 	reconcileStatus := progress.NewReconcileStatus().

--- a/internal/controllers/project/actuator.go
+++ b/internal/controllers/project/actuator.go
@@ -90,11 +90,9 @@ func (actuator projectActuator) ListOSResourcesForAdoption(ctx context.Context, 
 func (actuator projectActuator) ListOSResourcesForImport(ctx context.Context, orcObject orcObjectPT, filter filterT) (iter.Seq2[*osResourceT, error], progress.ReconcileStatus) {
 	var reconcileStatus progress.ReconcileStatus
 
-	domain, rs := dependency.FetchDependency(
+	domain, rs := dependency.FetchDependency[*orcv1alpha1.Domain](
 		ctx, actuator.k8sClient, orcObject.Namespace, filter.DomainRef, "Domain",
-		func(dep *orcv1alpha1.Domain) bool {
-			return orcv1alpha1.IsAvailable(dep) && dep.Status.ID != nil
-		},
+		orcv1alpha1.IsAvailable,
 	)
 	reconcileStatus = reconcileStatus.WithReconcileStatus(rs)
 
@@ -127,9 +125,7 @@ func (actuator projectActuator) CreateResource(ctx context.Context, obj orcObjec
 	var domainID string
 	if resource.DomainRef != nil {
 		domain, domainDepRS := domainDependency.GetDependency(
-			ctx, actuator.k8sClient, obj, func(dep *orcv1alpha1.Domain) bool {
-				return orcv1alpha1.IsAvailable(dep) && dep.Status.ID != nil
-			},
+			ctx, actuator.k8sClient, obj, orcv1alpha1.IsAvailable,
 		)
 		reconcileStatus = reconcileStatus.WithReconcileStatus(domainDepRS)
 		if domain != nil {

--- a/internal/controllers/role/actuator.go
+++ b/internal/controllers/role/actuator.go
@@ -93,11 +93,9 @@ func (actuator roleActuator) ListOSResourcesForAdoption(ctx context.Context, orc
 func (actuator roleActuator) ListOSResourcesForImport(ctx context.Context, obj orcObjectPT, filter filterT) (iter.Seq2[*osResourceT, error], progress.ReconcileStatus) {
 	var reconcileStatus progress.ReconcileStatus
 
-	domain, rs := dependency.FetchDependency(
+	domain, rs := dependency.FetchDependency[*orcv1alpha1.Domain](
 		ctx, actuator.k8sClient, obj.Namespace, filter.DomainRef, "Domain",
-		func(dep *orcv1alpha1.Domain) bool {
-			return orcv1alpha1.IsAvailable(dep) && dep.Status.ID != nil
-		},
+		orcv1alpha1.IsAvailable,
 	)
 	reconcileStatus = reconcileStatus.WithReconcileStatus(rs)
 
@@ -126,9 +124,7 @@ func (actuator roleActuator) CreateResource(ctx context.Context, obj orcObjectPT
 	var domainID string
 	if resource.DomainRef != nil {
 		domain, domainDepRS := domainDependency.GetDependency(
-			ctx, actuator.k8sClient, obj, func(dep *orcv1alpha1.Domain) bool {
-				return orcv1alpha1.IsAvailable(dep) && dep.Status.ID != nil
-			},
+			ctx, actuator.k8sClient, obj, orcv1alpha1.IsAvailable,
 		)
 		reconcileStatus = reconcileStatus.WithReconcileStatus(domainDepRS)
 		if domain != nil {

--- a/internal/controllers/router/actuator.go
+++ b/internal/controllers/router/actuator.go
@@ -83,11 +83,9 @@ func (actuator routerActuator) ListOSResourcesForAdoption(ctx context.Context, o
 func (actuator routerCreateActuator) ListOSResourcesForImport(ctx context.Context, obj orcObjectPT, filter filterT) (iter.Seq2[*osResourceT, error], progress.ReconcileStatus) {
 	var reconcileStatus progress.ReconcileStatus
 
-	project, rs := dependency.FetchDependency(
+	project, rs := dependency.FetchDependency[*orcv1alpha1.Project](
 		ctx, actuator.k8sClient, obj.Namespace, filter.ProjectRef, "Project",
-		func(dep *orcv1alpha1.Project) bool {
-			return orcv1alpha1.IsAvailable(dep) && dep.Status.ID != nil
-		},
+		orcv1alpha1.IsAvailable,
 	)
 	reconcileStatus = reconcileStatus.WithReconcileStatus(rs)
 
@@ -123,9 +121,7 @@ func (actuator routerCreateActuator) CreateResource(ctx context.Context, obj *or
 		var externalGW *orcv1alpha1.Network
 		// Fetch dependencies and ensure they have our finalizer
 		externalGW, reconcileStatus = externalGWDep.GetDependency(
-			ctx, actuator.k8sClient, obj, func(dep *orcv1alpha1.Network) bool {
-				return orcv1alpha1.IsAvailable(dep) && dep.Status.ID != nil
-			},
+			ctx, actuator.k8sClient, obj, orcv1alpha1.IsAvailable,
 		)
 		if externalGW != nil {
 			gatewayInfo.NetworkID = ptr.Deref(externalGW.Status.ID, "")
@@ -135,9 +131,7 @@ func (actuator routerCreateActuator) CreateResource(ctx context.Context, obj *or
 	var projectID string
 	if resource.ProjectRef != nil {
 		project, projectDepRS := projectDependency.GetDependency(
-			ctx, actuator.k8sClient, obj, func(dep *orcv1alpha1.Project) bool {
-				return orcv1alpha1.IsAvailable(dep) && dep.Status.ID != nil
-			},
+			ctx, actuator.k8sClient, obj, orcv1alpha1.IsAvailable,
 		)
 		reconcileStatus = reconcileStatus.WithReconcileStatus(projectDepRS)
 		if project != nil {

--- a/internal/controllers/securitygroup/actuator.go
+++ b/internal/controllers/securitygroup/actuator.go
@@ -88,11 +88,9 @@ func (actuator securityGroupActuator) ListOSResourcesForAdoption(ctx context.Con
 func (actuator securityGroupActuator) ListOSResourcesForImport(ctx context.Context, obj orcObjectPT, filter filterT) (iter.Seq2[*osResourceT, error], progress.ReconcileStatus) {
 	var reconcileStatus progress.ReconcileStatus
 
-	project, rs := dependency.FetchDependency(
+	project, rs := dependency.FetchDependency[*orcv1alpha1.Project](
 		ctx, actuator.k8sClient, obj.Namespace, filter.ProjectRef, "Project",
-		func(dep *orcv1alpha1.Project) bool {
-			return orcv1alpha1.IsAvailable(dep) && dep.Status.ID != nil
-		},
+		orcv1alpha1.IsAvailable,
 	)
 	reconcileStatus = reconcileStatus.WithReconcileStatus(rs)
 
@@ -123,9 +121,7 @@ func (actuator securityGroupActuator) CreateResource(ctx context.Context, obj *o
 	var projectID string
 	if resource.ProjectRef != nil {
 		project, reconcileStatus := projectDependency.GetDependency(
-			ctx, actuator.k8sClient, obj, func(dep *orcv1alpha1.Project) bool {
-				return orcv1alpha1.IsAvailable(dep) && dep.Status.ID != nil
-			},
+			ctx, actuator.k8sClient, obj, orcv1alpha1.IsAvailable,
 		)
 		if needsReschedule, _ := reconcileStatus.NeedsReschedule(); needsReschedule {
 			return nil, reconcileStatus
@@ -280,9 +276,7 @@ func (actuator securityGroupActuator) updateRules(ctx context.Context, orcObject
 	var projectID string
 	if resource.ProjectRef != nil {
 		project, reconcileStatus := projectDependency.GetDependency(
-			ctx, actuator.k8sClient, orcObject, func(dep *orcv1alpha1.Project) bool {
-				return orcv1alpha1.IsAvailable(dep) && dep.Status.ID != nil
-			},
+			ctx, actuator.k8sClient, orcObject, orcv1alpha1.IsAvailable,
 		)
 		if needsReschedule, _ := reconcileStatus.NeedsReschedule(); needsReschedule {
 			return reconcileStatus

--- a/internal/controllers/server/actuator.go
+++ b/internal/controllers/server/actuator.go
@@ -163,27 +163,23 @@ func (actuator serverActuator) CreateResource(ctx context.Context, obj *orcv1alp
 	var image *orcv1alpha1.Image
 	{
 		dep, imageReconcileStatus := imageDependency.GetDependency(
-			ctx, actuator.k8sClient, obj, func(image *orcv1alpha1.Image) bool {
-				return orcv1alpha1.IsAvailable(image) && image.Status.ID != nil
-			},
+			ctx, actuator.k8sClient, obj, orcv1alpha1.IsAvailable,
 		)
 		reconcileStatus = reconcileStatus.WithReconcileStatus(imageReconcileStatus)
 		image = dep
 	}
 
-	flavor, flavorReconcileStatus := dependency.FetchDependency(
+	flavor, flavorReconcileStatus := dependency.FetchDependency[*orcv1alpha1.Flavor](
 		ctx, actuator.k8sClient, obj.Namespace,
 		&resource.FlavorRef, "Flavor",
-		func(f *orcv1alpha1.Flavor) bool { return orcv1alpha1.IsAvailable(f) && f.Status.ID != nil },
+		orcv1alpha1.IsAvailable,
 	)
 	reconcileStatus = reconcileStatus.WithReconcileStatus(flavorReconcileStatus)
 
 	portList := make([]servers.Network, len(resource.Ports))
 	{
 		portsMap, portsReconcileStatus := portDependency.GetDependencies(
-			ctx, actuator.k8sClient, obj, func(port *orcv1alpha1.Port) bool {
-				return orcv1alpha1.IsAvailable(port) && port.Status.ID != nil
-			},
+			ctx, actuator.k8sClient, obj, orcv1alpha1.IsAvailable,
 		)
 		reconcileStatus = reconcileStatus.WithReconcileStatus(portsReconcileStatus)
 		if needsReschedule, _ := portsReconcileStatus.NeedsReschedule(); !needsReschedule {
@@ -206,10 +202,10 @@ func (actuator serverActuator) CreateResource(ctx context.Context, obj *orcv1alp
 		}
 	}
 
-	serverGroup, serverGroupReconcileStatus := dependency.FetchDependency(
+	serverGroup, serverGroupReconcileStatus := dependency.FetchDependency[*orcv1alpha1.ServerGroup](
 		ctx, actuator.k8sClient, obj.Namespace,
 		resource.ServerGroupRef, "ServerGroup",
-		func(sg *orcv1alpha1.ServerGroup) bool { return orcv1alpha1.IsAvailable(sg) && sg.Status.ID != nil },
+		orcv1alpha1.IsAvailable,
 	)
 	reconcileStatus = reconcileStatus.WithReconcileStatus(serverGroupReconcileStatus)
 
@@ -444,9 +440,7 @@ func (actuator serverActuator) reconcilePortAttachments(ctx context.Context, obj
 	}
 
 	portDepsMap, reconcileStatus := portDependency.GetDependencies(
-		ctx, actuator.k8sClient, obj, func(port *orcv1alpha1.Port) bool {
-			return orcv1alpha1.IsAvailable(port) && port.Status.ID != nil
-		},
+		ctx, actuator.k8sClient, obj, orcv1alpha1.IsAvailable,
 	)
 
 	if needsReschedule, _ := reconcileStatus.NeedsReschedule(); needsReschedule {
@@ -524,9 +518,7 @@ func (actuator serverActuator) reconcileVolumeAttachments(ctx context.Context, o
 	}
 
 	volumeDepsMap, reconcileStatus := volumeDependency.GetDependencies(
-		ctx, actuator.k8sClient, obj, func(volume *orcv1alpha1.Volume) bool {
-			return orcv1alpha1.IsAvailable(volume) && volume.Status.ID != nil
-		},
+		ctx, actuator.k8sClient, obj, orcv1alpha1.IsAvailable,
 	)
 
 	if needsReschedule, _ := reconcileStatus.NeedsReschedule(); needsReschedule {

--- a/internal/controllers/subnet/actuator.go
+++ b/internal/controllers/subnet/actuator.go
@@ -87,19 +87,15 @@ func (actuator subnetActuator) ListOSResourcesForAdoption(ctx context.Context, o
 func (actuator subnetActuator) ListOSResourcesForImport(ctx context.Context, obj orcObjectPT, filter filterT) (iter.Seq2[*osResourceT, error], progress.ReconcileStatus) {
 	var reconcileStatus progress.ReconcileStatus
 
-	network, rs := dependency.FetchDependency(
+	network, rs := dependency.FetchDependency[*orcv1alpha1.Network](
 		ctx, actuator.k8sClient, obj.Namespace, &filter.NetworkRef, "Network",
-		func(dep *orcv1alpha1.Network) bool {
-			return orcv1alpha1.IsAvailable(dep) && dep.Status.ID != nil
-		},
+		orcv1alpha1.IsAvailable,
 	)
 	reconcileStatus = reconcileStatus.WithReconcileStatus(rs)
 
-	project, rs := dependency.FetchDependency(
+	project, rs := dependency.FetchDependency[*orcv1alpha1.Project](
 		ctx, actuator.k8sClient, obj.Namespace, filter.ProjectRef, "Project",
-		func(dep *orcv1alpha1.Project) bool {
-			return orcv1alpha1.IsAvailable(dep) && dep.Status.ID != nil
-		},
+		orcv1alpha1.IsAvailable,
 	)
 	reconcileStatus = reconcileStatus.WithReconcileStatus(rs)
 
@@ -137,16 +133,12 @@ func (actuator subnetActuator) CreateResource(ctx context.Context, obj orcObject
 	}
 
 	network, reconcileStatus := networkDependency.GetDependency(
-		ctx, actuator.k8sClient, obj, func(dep *orcv1alpha1.Network) bool {
-			return orcv1alpha1.IsAvailable(dep) && dep.Status.ID != nil
-		},
+		ctx, actuator.k8sClient, obj, orcv1alpha1.IsAvailable,
 	)
 
 	if resource.RouterRef != nil {
 		_, routerDepRS := routerDependency.GetDependency(
-			ctx, actuator.k8sClient, obj, func(dep *orcv1alpha1.Router) bool {
-				return orcv1alpha1.IsAvailable(dep) && dep.Status.ID != nil
-			},
+			ctx, actuator.k8sClient, obj, orcv1alpha1.IsAvailable,
 		)
 		reconcileStatus = reconcileStatus.WithReconcileStatus(routerDepRS)
 	}
@@ -154,9 +146,7 @@ func (actuator subnetActuator) CreateResource(ctx context.Context, obj orcObject
 	var projectID string
 	if resource.ProjectRef != nil {
 		project, projectDepRS := projectDependency.GetDependency(
-			ctx, actuator.k8sClient, obj, func(dep *orcv1alpha1.Project) bool {
-				return orcv1alpha1.IsAvailable(dep) && dep.Status.ID != nil
-			},
+			ctx, actuator.k8sClient, obj, orcv1alpha1.IsAvailable,
 		)
 		reconcileStatus = reconcileStatus.WithReconcileStatus(projectDepRS)
 		if project != nil {

--- a/internal/controllers/trunk/actuator.go
+++ b/internal/controllers/trunk/actuator.go
@@ -84,17 +84,17 @@ func (actuator trunkActuator) ListOSResourcesForAdoption(ctx context.Context, or
 func (actuator trunkActuator) ListOSResourcesForImport(ctx context.Context, obj orcObjectPT, filter filterT) (iter.Seq2[*osResourceT, error], progress.ReconcileStatus) {
 	var reconcileStatus progress.ReconcileStatus
 
-	port, rs := dependency.FetchDependency(
+	port, rs := dependency.FetchDependency[*orcv1alpha1.Port](
 		ctx, actuator.k8sClient, obj.Namespace,
 		filter.PortRef, "Port",
-		func(dep *orcv1alpha1.Port) bool { return orcv1alpha1.IsAvailable(dep) && dep.Status.ID != nil },
+		orcv1alpha1.IsAvailable,
 	)
 	reconcileStatus = reconcileStatus.WithReconcileStatus(rs)
 
-	project, rs := dependency.FetchDependency(
+	project, rs := dependency.FetchDependency[*orcv1alpha1.Project](
 		ctx, actuator.k8sClient, obj.Namespace,
 		filter.ProjectRef, "Project",
-		func(dep *orcv1alpha1.Project) bool { return orcv1alpha1.IsAvailable(dep) && dep.Status.ID != nil },
+		orcv1alpha1.IsAvailable,
 	)
 	reconcileStatus = reconcileStatus.WithReconcileStatus(rs)
 
@@ -129,9 +129,7 @@ func (actuator trunkActuator) CreateResource(ctx context.Context, obj orcObjectP
 
 	var portID string
 	port, portDepRS := portDependency.GetDependency(
-		ctx, actuator.k8sClient, obj, func(dep *orcv1alpha1.Port) bool {
-			return orcv1alpha1.IsAvailable(dep) && dep.Status.ID != nil
-		},
+		ctx, actuator.k8sClient, obj, orcv1alpha1.IsAvailable,
 	)
 	reconcileStatus = reconcileStatus.WithReconcileStatus(portDepRS)
 	if port != nil {
@@ -141,9 +139,7 @@ func (actuator trunkActuator) CreateResource(ctx context.Context, obj orcObjectP
 	var projectID string
 	if resource.ProjectRef != nil {
 		project, projectDepRS := projectDependency.GetDependency(
-			ctx, actuator.k8sClient, obj, func(dep *orcv1alpha1.Project) bool {
-				return orcv1alpha1.IsAvailable(dep) && dep.Status.ID != nil
-			},
+			ctx, actuator.k8sClient, obj, orcv1alpha1.IsAvailable,
 		)
 		reconcileStatus = reconcileStatus.WithReconcileStatus(projectDepRS)
 		if project != nil {
@@ -155,9 +151,7 @@ func (actuator trunkActuator) CreateResource(ctx context.Context, obj orcObjectP
 	var subports []trunks.Subport
 	if len(resource.Subports) > 0 {
 		subportPortMap, subportPortDepRS := subportPortDependency.GetDependencies(
-			ctx, actuator.k8sClient, obj, func(dep *orcv1alpha1.Port) bool {
-				return orcv1alpha1.IsAvailable(dep) && dep.Status.ID != nil
-			},
+			ctx, actuator.k8sClient, obj, orcv1alpha1.IsAvailable,
 		)
 		reconcileStatus = reconcileStatus.WithReconcileStatus(subportPortDepRS)
 		if needsReschedule, _ := subportPortDepRS.NeedsReschedule(); !needsReschedule {
@@ -293,9 +287,7 @@ func (actuator trunkActuator) reconcileSubports(ctx context.Context, obj orcObje
 	desiredSubports := make(map[string]*orcv1alpha1.TrunkSubportSpec, len(osResource.Subports))
 	if len(resource.Subports) > 0 {
 		subportPortMap, subportPortDepRS := subportPortDependency.GetDependencies(
-			ctx, actuator.k8sClient, obj, func(dep *orcv1alpha1.Port) bool {
-				return orcv1alpha1.IsAvailable(dep) && dep.Status.ID != nil
-			},
+			ctx, actuator.k8sClient, obj, orcv1alpha1.IsAvailable,
 		)
 		reconcileStatus = reconcileStatus.WithReconcileStatus(subportPortDepRS)
 		if needsReschedule, _ := subportPortDepRS.NeedsReschedule(); needsReschedule {

--- a/internal/controllers/user/actuator.go
+++ b/internal/controllers/user/actuator.go
@@ -84,10 +84,10 @@ func (actuator userActuator) ListOSResourcesForAdoption(ctx context.Context, orc
 func (actuator userActuator) ListOSResourcesForImport(ctx context.Context, obj orcObjectPT, filter filterT) (iter.Seq2[*osResourceT, error], progress.ReconcileStatus) {
 	var reconcileStatus progress.ReconcileStatus
 
-	domain, rs := dependency.FetchDependency(
+	domain, rs := dependency.FetchDependency[*orcv1alpha1.Domain](
 		ctx, actuator.k8sClient, obj.Namespace,
 		filter.DomainRef, "Domain",
-		func(dep *orcv1alpha1.Domain) bool { return orcv1alpha1.IsAvailable(dep) && dep.Status.ID != nil },
+		orcv1alpha1.IsAvailable,
 	)
 	reconcileStatus = reconcileStatus.WithReconcileStatus(rs)
 
@@ -116,9 +116,7 @@ func (actuator userActuator) CreateResource(ctx context.Context, obj orcObjectPT
 	var domainID string
 	if resource.DomainRef != nil {
 		domain, domainDepRS := domainDependency.GetDependency(
-			ctx, actuator.k8sClient, obj, func(dep *orcv1alpha1.Domain) bool {
-				return orcv1alpha1.IsAvailable(dep) && dep.Status.ID != nil
-			},
+			ctx, actuator.k8sClient, obj, orcv1alpha1.IsAvailable,
 		)
 		reconcileStatus = reconcileStatus.WithReconcileStatus(domainDepRS)
 		if domain != nil {
@@ -129,9 +127,7 @@ func (actuator userActuator) CreateResource(ctx context.Context, obj orcObjectPT
 	var defaultProjectID string
 	if resource.DefaultProjectRef != nil {
 		project, projectDepRS := projectDependency.GetDependency(
-			ctx, actuator.k8sClient, obj, func(dep *orcv1alpha1.Project) bool {
-				return orcv1alpha1.IsAvailable(dep) && dep.Status.ID != nil
-			},
+			ctx, actuator.k8sClient, obj, orcv1alpha1.IsAvailable,
 		)
 		reconcileStatus = reconcileStatus.WithReconcileStatus(projectDepRS)
 		if project != nil {

--- a/internal/controllers/volume/actuator.go
+++ b/internal/controllers/volume/actuator.go
@@ -156,9 +156,7 @@ func (actuator volumeActuator) CreateResource(ctx context.Context, obj orcObject
 	var volumetypeID string
 	if resource.VolumeTypeRef != nil {
 		volumetype, volumetypeDepRS := volumetypeDependency.GetDependency(
-			ctx, actuator.k8sClient, obj, func(dep *orcv1alpha1.VolumeType) bool {
-				return orcv1alpha1.IsAvailable(dep) && dep.Status.ID != nil
-			},
+			ctx, actuator.k8sClient, obj, orcv1alpha1.IsAvailable,
 		)
 		reconcileStatus = reconcileStatus.WithReconcileStatus(volumetypeDepRS)
 		if volumetype != nil {
@@ -167,12 +165,10 @@ func (actuator volumeActuator) CreateResource(ctx context.Context, obj orcObject
 	}
 
 	// Resolve image dependency for bootable volumes
-	image, imageDepRS := dependency.FetchDependency(
+	image, imageDepRS := dependency.FetchDependency[*orcv1alpha1.Image](
 		ctx, actuator.k8sClient, obj.Namespace,
 		resource.ImageRef, "Image",
-		func(dep *orcv1alpha1.Image) bool {
-			return orcv1alpha1.IsAvailable(dep) && dep.Status.ID != nil
-		},
+		orcv1alpha1.IsAvailable,
 	)
 	reconcileStatus = reconcileStatus.WithReconcileStatus(imageDepRS)
 	imageID := ptr.Deref(image.Status.ID, "")


### PR DESCRIPTION
Since IsAvailable implies Status.ID is set, the redundant check for
Status.ID != nil can be removed. Made IsAvailable generic to allow
passing it directly as a filter function, eliminating boilerplate
lambdas across all controllers.

This makes the code more concise and ensures consistent availability
checking for all dependencies.