### PR TITLE
Add AI agent instructions and skills using open standards

### DIFF
--- a/.agents/skills/add-dependency/SKILL.md
+++ b/.agents/skills/add-dependency/SKILL.md
@@ -1,0 +1,250 @@
+---
+name: add-dependency
+description: Add a dependency on another ORC resource to a controller. Use when a resource needs to reference or wait for another resource (e.g., Subnet depends on Network).
+disable-model-invocation: true
+---
+
+# Add Dependency to Controller
+
+Guide for adding a dependency on another ORC resource.
+
+**Reference**: See `website/docs/development/controller-implementation.md` for detailed rationale on dependency patterns.
+
+## When to Use Dependencies
+
+Use a dependency when your controller needs to:
+- Wait for another resource to be available before creating
+- Reference another resource's OpenStack ID
+- Optionally prevent deletion of a resource that's still in use (deletion guard)
+
+## Key Principles
+
+See also "Dependency Timing" in @.agents/skills/new-controller/patterns.md
+
+### 1. Resolve Dependencies Late
+
+Resolve dependencies as late as possible, as close to the point of use as possible. This reduces coupling and gives users flexibility when fixing failed deployments.
+
+**Examples:**
+- Subnet depends on Network for creation, but NOT for import by ID or after `status.ID` is set
+- Don't require recreating a deleted Network just to delete a Subnet
+- Add finalizers only immediately before the OpenStack create/update call
+
+### 2. Choose the Right Dependency Type
+
+| Type | Use When | Example |
+|------|----------|---------|
+| **Normal** (`NewDependency`) | Dependency is optional OR deletion is allowed by OpenStack | Import filter refs, Flavor ref |
+| **Deletion Guard** (`NewDeletionGuardDependency`) | Deletion would fail or corrupt your resource | Subnet→Network, Port→Subnet |
+
+### 3. Use Descriptive Names
+
+When multiple dependencies of the same type exist, use descriptive prefixes:
+- `vipSubnetDependency` not `subnetDependency` (when there could be other subnet refs)
+- `sourcePortDependency` vs `destinationPortDependency`
+- `memberNetworkDependency` vs `externalNetworkDependency`
+
+## Dependency Types
+
+### Normal Dependency
+Wait for resource but don't prevent deletion:
+```go
+dependency.NewDependency[*orcv1alpha1.MyResourceList, *orcv1alpha1.DepResource](...)
+```
+
+### Deletion Guard Dependency
+Wait for resource AND prevent its deletion:
+```go
+dependency.NewDeletionGuardDependency[*orcv1alpha1.MyResourceList, *orcv1alpha1.DepResource](...)
+```
+
+**Use Deletion Guard when**: Deleting the dependency would cause your resource to fail or become invalid (e.g., Subnet depends on Network, Port depends on SecurityGroup).
+
+## Step 1: Add Reference Field to API
+
+In `api/v1alpha1/<kind>_types.go`, add the reference field:
+
+```go
+type MyResourceSpec struct {
+    // ...
+
+    // projectRef is a reference to a Project.
+    // +kubebuilder:validation:XValidation:rule="self == oldSelf",message="projectRef is immutable"
+    // +optional
+    ProjectRef *KubernetesNameRef `json:"projectRef,omitempty"`
+}
+```
+
+For import filters, add to the Filter struct as well:
+```go
+type MyResourceFilter struct {
+    // +optional
+    ProjectRef *KubernetesNameRef `json:"projectRef,omitempty"`
+}
+```
+
+## Step 2: Declare Dependency
+
+In `internal/controllers/<kind>/controller.go`, add package-scoped variable:
+
+```go
+var (
+    projectDependency = dependency.NewDeletionGuardDependency[*orcv1alpha1.MyResourceList, *orcv1alpha1.Project](
+        "spec.resource.projectRef",  // Field path for indexing
+        func(obj *orcv1alpha1.MyResource) []string {
+            resource := obj.Spec.Resource
+            if resource == nil || resource.ProjectRef == nil {
+                return nil
+            }
+            return []string{string(*resource.ProjectRef)}
+        },
+        finalizer, externalObjectFieldOwner,
+    )
+
+    // For import filter dependencies (no deletion guard needed)
+    projectImportDependency = dependency.NewDependency[*orcv1alpha1.MyResourceList, *orcv1alpha1.Project](
+        "spec.import.filter.projectRef",
+        func(obj *orcv1alpha1.MyResource) []string {
+            imp := obj.Spec.Import
+            if imp == nil || imp.Filter == nil || imp.Filter.ProjectRef == nil {
+                return nil
+            }
+            return []string{string(*imp.Filter.ProjectRef)}
+        },
+    )
+)
+```
+
+## Step 3: Setup Watches
+
+In `SetupWithManager()` in `controller.go`:
+
+```go
+func (c myReconcilerConstructor) SetupWithManager(ctx context.Context, mgr ctrl.Manager, options controller.Options) error {
+    log := ctrl.LoggerFrom(ctx)
+    k8sClient := mgr.GetClient()
+
+    // Create watch handlers
+    projectWatchHandler, err := projectDependency.WatchEventHandler(log, k8sClient)
+    if err != nil {
+        return err
+    }
+
+    builder := ctrl.NewControllerManagedBy(mgr).
+        WithOptions(options).
+        For(&orcv1alpha1.MyResource{}).
+        // Watch the dependency
+        Watches(&orcv1alpha1.Project{}, projectWatchHandler,
+            builder.WithPredicates(predicates.NewBecameAvailable(log, &orcv1alpha1.Project{})),
+        )
+
+    // Register dependencies with manager
+    if err := errors.Join(
+        projectDependency.AddToManager(ctx, mgr),
+        credentialsDependency.AddToManager(ctx, mgr),
+        credentials.AddCredentialsWatch(log, k8sClient, builder, credentialsDependency),
+    ); err != nil {
+        return err
+    }
+
+    r := reconciler.NewController(controllerName, k8sClient, c.scopeFactory, helperFactory{}, statusWriter{})
+    return builder.Complete(&r)
+}
+```
+
+## Step 4: Use Dependency in Actuator
+
+In `actuator.go`, resolve the dependency before using it:
+
+```go
+func (actuator myActuator) CreateResource(ctx context.Context, obj *orcv1alpha1.MyResource) (*osResourceT, progress.ReconcileStatus) {
+    resource := obj.Spec.Resource
+
+    var projectID string
+    if resource.ProjectRef != nil {
+        project, reconcileStatus := projectDependency.GetDependency(
+            ctx, actuator.k8sClient, obj,
+            func(dep *orcv1alpha1.Project) bool {
+                return orcv1alpha1.IsAvailable(dep) && dep.Status.ID != nil
+            },
+        )
+        if needsReschedule, _ := reconcileStatus.NeedsReschedule(); needsReschedule {
+            return nil, reconcileStatus
+        }
+        projectID = ptr.Deref(project.Status.ID, "")
+    }
+
+    createOpts := myresource.CreateOpts{
+        ProjectID: projectID,
+        // ...
+    }
+    // ...
+}
+```
+
+For import filter dependencies:
+```go
+func (actuator myActuator) ListOSResourcesForImport(ctx context.Context, obj orcObjectPT, filter filterT) (iter.Seq2[*osResourceT, error], progress.ReconcileStatus) {
+    var reconcileStatus progress.ReconcileStatus
+
+    project, rs := dependency.FetchDependency(
+        ctx, actuator.k8sClient, obj.Namespace, filter.ProjectRef, "Project",
+        func(dep *orcv1alpha1.Project) bool {
+            return orcv1alpha1.IsAvailable(dep) && dep.Status.ID != nil
+        },
+    )
+    reconcileStatus = reconcileStatus.WithReconcileStatus(rs)
+
+    if needsReschedule, _ := reconcileStatus.NeedsReschedule(); needsReschedule {
+        return nil, reconcileStatus
+    }
+
+    listOpts := myresource.ListOpts{
+        ProjectID: ptr.Deref(project.Status.ID, ""),
+    }
+    return actuator.osClient.ListMyResources(ctx, listOpts), nil
+}
+```
+
+## Step 5: Add k8sClient to Actuator
+
+If not already present, add `k8sClient` to the actuator struct:
+
+```go
+type myActuator struct {
+    osClient  osclients.MyResourceClient
+    k8sClient client.Client  // Add this
+}
+```
+
+Update `newActuator()`:
+```go
+func newActuator(ctx context.Context, orcObject orcObjectPT, controller interfaces.ResourceController) (myActuator, progress.ReconcileStatus) {
+    k8sClient := controller.GetK8sClient()  // Add this
+    // ...
+    return myActuator{
+        osClient:  osClient,
+        k8sClient: k8sClient,  // Add this
+    }, nil
+}
+```
+
+## Step 6: Add Tests
+
+Create dependency tests in `internal/controllers/<kind>/tests/<kind>-dependency/`:
+- Test that resource waits for dependency
+- Test that dependency deletion is blocked (if using DeletionGuard)
+
+Follow @.agents/skills/testing/SKILL.md for running unit tests, linting, and E2E tests.
+
+## Checklist
+
+- [ ] Reference field added to API types (with immutability validation)
+- [ ] Dependency declared in controller.go
+- [ ] Watch configured in SetupWithManager
+- [ ] Dependency registered with manager (AddToManager)
+- [ ] Dependency resolved in actuator before use
+- [ ] k8sClient added to actuator struct
+- [ ] `make generate` runs cleanly
+- [ ] `make lint` passes
+- [ ] Dependency tests added

--- a/.agents/skills/new-controller/SKILL.md
+++ b/.agents/skills/new-controller/SKILL.md
@@ -1,0 +1,248 @@
+---
+name: new-controller
+description: Create a new ORC controller for an OpenStack resource. Use when adding support for a new OpenStack resource type (e.g., LoadBalancer, FloatingIP).
+disable-model-invocation: true
+---
+
+# Create New Controller
+
+Create a new ORC controller for an OpenStack resource.
+
+**IMPORTANT**: Complete ALL steps in order. Do not stop after implementing TODOs - you must also write E2E tests and run them. Ask the user for `E2E_OSCLOUDS` path if needed to run tests.
+
+## Prerequisites
+
+Ask the user one by one about:
+1. What OpenStack resource to create (e.g., "VolumeBackup")
+2. Which service it belongs to (compute, network, blockstorage, identity, image)
+3. Does it need polling for availability or deletion? (i.e., does the resource have intermediate provisioning states like PENDING_CREATE, BUILD, etc.)
+4. Any dependencies on other ORC resources (required, optional, or import-only)?
+5. Is there a similar existing controller to use as reference? (e.g., Listener for LoadBalancer)
+6. Do they have `E2E_OSCLOUDS` path to a clouds.yaml for running E2E tests locally? (If not, local E2E testing will be skipped)
+7. Any additional requirements or constraints? (e.g., cascade delete support, special validation rules, immutability requirements)
+
+## Step 1: Research the OpenStack Resource
+
+**Before scaffolding**, research the resource to understand the exact field names:
+
+1. **Read the gophercloud struct** to get exact field names:
+```bash
+go doc <gophercloud-module>.<Type>
+go doc <gophercloud-module>.CreateOpts
+```
+
+2. **Look at a similar existing controller** for patterns (if user provided one):
+   - Check their `*_types.go` for API structure
+   - Check their `actuator.go` for implementation patterns
+
+3. **Note the exact field names** from gophercloud - use these when defining API types:
+   - If gophercloud has `VipSubnetID`, name the ORC field `VipSubnetRef` (not just `SubnetRef`)
+   - If gophercloud has `FlavorID`, name the ORC field `FlavorRef`
+   - Preserve prefixes like `Vip`, `Source`, `Destination` etc.
+
+## Step 2: Run Scaffolding Tool
+
+**IMPORTANT**: Build a single scaffolding command using the user's answers and the flags reference below. Run it exactly ONCE (user will be prompted to approve).
+
+Use the field names discovered in Step 1 to inform your implementation later.
+
+### Scaffolding Flags Reference
+
+**Required flags:**
+
+| Flag | Description | Example |
+|------|-------------|---------|
+| `-kind` | The Kind of the new resource (PascalCase) | `VolumeBackup`, `FloatingIP` |
+| `-gophercloud-client` | The gophercloud function to instantiate a client | `NewBlockStorageV3`, `NewNetworkV2` |
+| `-gophercloud-module` | Full gophercloud module import path | `github.com/gophercloud/gophercloud/v2/openstack/blockstorage/v3/backups` |
+
+**Optional flags:**
+
+| Flag | Description | Default |
+|------|-------------|---------|
+| `-gophercloud-type` | The gophercloud struct type name | Same as `-kind` |
+| `-openstack-json-object` | Object name in OpenStack JSON responses | snake_case of kind (e.g., `volume_backup`) |
+| `-available-polling-period` | Polling period in seconds while waiting for resource to become available | `0` (available immediately) |
+| `-deleting-polling-period` | Polling period in seconds while waiting for resource to be deleted | `0` (deleted immediately) |
+| `-required-create-dependency` | Required dependency for creation (can repeat flag for multiple) | none |
+| `-optional-create-dependency` | Optional dependency for creation (can repeat flag for multiple) | none |
+| `-import-dependency` | Dependency for import filter (can repeat flag for multiple) | none |
+| `-interactive` | Run in interactive mode | `true` (set to `false` for scripted use) |
+
+### Common Gophercloud Clients
+
+| Service | Client Function | Module Path Prefix |
+|---------|-----------------|-------------------|
+| Compute | `NewComputeV2` | `github.com/gophercloud/gophercloud/v2/openstack/compute/v2/...` |
+| Network | `NewNetworkV2` | `github.com/gophercloud/gophercloud/v2/openstack/networking/v2/...` |
+| Block Storage | `NewBlockStorageV3` | `github.com/gophercloud/gophercloud/v2/openstack/blockstorage/v3/...` |
+| Identity | `NewIdentityV3` | `github.com/gophercloud/gophercloud/v2/openstack/identity/v3/...` |
+| Image | `NewImageV2` | `github.com/gophercloud/gophercloud/v2/openstack/image/v2/...` |
+
+### Example Command (for reference only - build your own based on user input)
+
+```bash
+# Example with dependencies - adapt based on user's answers
+go run ./cmd/scaffold-controller -interactive=false \
+    -kind=Port \
+    -gophercloud-client=NewNetworkV2 \
+    -gophercloud-module=github.com/gophercloud/gophercloud/v2/openstack/networking/v2/ports \
+    -required-create-dependency=Network \
+    -optional-create-dependency=Subnet \
+    -optional-create-dependency=SecurityGroup \
+    -import-dependency=Network
+```
+
+After scaffolding completes, run code generation:
+
+```bash
+make generate
+```
+
+Commit the scaffolding with the command used:
+
+```bash
+git add .
+git commit -m "$(cat <<'EOF'
+Scaffolding for the VolumeBackup controller
+
+$ go run ./cmd/scaffold-controller -interactive=false \
+    -kind=VolumeBackup \
+    -gophercloud-client=NewBlockStorageV3 \
+    -gophercloud-module=github.com/gophercloud/gophercloud/v2/openstack/blockstorage/v3/backups
+EOF
+)"
+```
+
+## Step 3: Register with Resource Generator
+
+Add the new resource to `cmd/resource-generator/main.go` in the `resources` slice:
+
+```go
+var resources []templateFields = []templateFields{
+    // ... existing resources (keep alphabetically sorted) ...
+    {
+        Name: "VolumeBackup",
+    },
+}
+```
+
+Then regenerate to create the `zz_generated.*.go` files:
+
+```bash
+make generate
+```
+
+## Step 4: Add OpenStack Client to Scope
+
+Update these files in `internal/scope/`:
+
+### scope.go
+Add interface method:
+```go
+NewYourResourceClient() (osclients.YourResourceClient, error)
+```
+
+### provider.go
+Implement the constructor:
+```go
+func (s *providerScope) NewYourResourceClient() (osclients.YourResourceClient, error) {
+    return osclients.NewYourResourceClient(s.provider)
+}
+```
+
+### mock.go
+Add mock client field and implementation for testing.
+
+## Step 5: Register Controller
+
+Add to `cmd/manager/main.go`:
+
+```go
+import (
+    yourresourcecontroller "github.com/k-orc/openstack-resource-controller/v2/internal/controllers/yourresource"
+)
+
+// In controllers slice:
+controllers := []interfaces.Controller{
+    // ...
+    yourresourcecontroller.New(scopeFactory),
+}
+```
+
+## Step 6: Implement TODOs
+
+**Reference Documentation**: For detailed patterns and rationale, see:
+- `website/docs/development/controller-implementation.md` - Progressing condition, ReconcileStatus, error handling, dependencies
+- `website/docs/development/api-design.md` - Filter, ResourceSpec, ResourceStatus conventions
+- `website/docs/development/coding-standards.md` - Code organization, naming, logging
+
+Find all scaffolding TODOs:
+
+```bash
+grep -r "TODO(scaffolding)" api/v1alpha1/ internal/controllers/<kind>/
+```
+
+### API Types (api/v1alpha1/<kind>_types.go)
+
+Use the exact field names from gophercloud discovered in Step 1.
+
+Define:
+- `<Kind>ResourceSpec` - Creation parameters with validation markers
+- `<Kind>Filter` - Import filter with `MinProperties:=1`
+- `<Kind>ResourceStatus` - Observed state fields
+
+### Actuator (internal/controllers/<kind>/actuator.go)
+
+Implement:
+- `CreateResource()` - Build CreateOpts, call OpenStack API
+- `DeleteResource()` - Call delete API
+- `ListOSResourcesForImport()` - Apply filter to list results
+- `ListOSResourcesForAdoption()` - Match by spec fields
+- `GetResourceReconcilers()` - (if resource supports updates)
+
+### Implementation Patterns
+
+Follow the patterns in @.agents/skills/new-controller/patterns.md when implementing the actuator and API types.
+
+### Status Writer (internal/controllers/<kind>/status.go)
+
+Implement:
+- `ResourceAvailableStatus()` - When is resource available?
+- `ApplyResourceStatus()` - Map OpenStack fields to status
+
+## Step 7: Write and Run Tests
+
+**This step is required** - do not skip it.
+
+Complete the test stubs in `internal/controllers/<kind>/tests/` and run tests following @.agents/skills/testing/SKILL.md
+
+## Checklist
+
+- [ ] Gophercloud struct researched (field names noted)
+- [ ] Similar controller reviewed (if applicable)
+- [ ] Scaffolding complete
+- [ ] First `make generate` run
+- [ ] Scaffolding committed
+- [ ] Registered in resource-generator
+- [ ] Second `make generate` run (creates zz_generated files)
+- [ ] OpenStack client added to scope
+- [ ] Controller registered in main.go
+- [ ] API types implemented:
+  - [ ] Correct field names (matching OpenStack conventions)
+  - [ ] Stricter types where appropriate (IPvAny, custom tag types)
+  - [ ] Status constants in types.go (if resource has provisioning states)
+- [ ] Actuator methods implemented:
+  - [ ] DeleteResource: no cascade unless explicitly requested
+  - [ ] DeleteResource: handles pending states and 409 Conflict (if resource has intermediate states)
+  - [ ] CreateResource includes tags with sorting (if applicable)
+  - [ ] Proper error classification (Terminal vs retryable)
+  - [ ] Descriptive dependency variable names
+- [ ] Status writer implemented
+- [ ] Update reconciler includes tags update (if tags are mutable)
+- [ ] All TODOs resolved
+- [ ] `make generate` runs cleanly
+- [ ] `make lint` passes
+- [ ] `make test` passes
+- [ ] E2E tests written (including dependency tests if applicable)
+- [ ] E2E tests passing

--- a/.agents/skills/new-controller/patterns.md
+++ b/.agents/skills/new-controller/patterns.md
@@ -1,0 +1,168 @@
+# ORC Controller Implementation Patterns
+
+Follow these principles when implementing controllers. See `website/docs/development/` for detailed rationale.
+
+## 1. Defensive Operations
+
+Avoid destructive defaults - require explicit user intent for dangerous operations.
+
+**Examples:**
+- Never use cascade delete unless the user explicitly requests it (cascade removes all child resources)
+- Don't auto-correct invalid states that might cause data loss
+- Ask the user additional questions if required
+- Prefer failing safely over making assumptions
+
+## 2. Resource Lifecycle Management
+
+Handle all states a resource can be in throughout its lifecycle.
+
+**For resources with intermediate provisioning states** (PENDING_CREATE, BUILD, PENDING_DELETE, etc.):
+- Check the current state before attempting operations
+- Wait for stable states before making changes
+- Handle race conditions where state changes between check and action
+
+```go
+// Example: Handle all states before deletion
+switch resource.ProvisioningStatus {
+case ProvisioningStatusPendingDelete:
+    return progress.WaitingOnOpenStack(progress.WaitingOnReady, deletingPollingPeriod)
+case ProvisioningStatusPendingCreate, ProvisioningStatusPendingUpdate:
+    // Can't delete in pending state, wait for ACTIVE
+    return progress.WaitingOnOpenStack(progress.WaitingOnReady, availablePollingPeriod)
+}
+
+// Example: Handle 409 Conflict (state changed between check and API call)
+err := actuator.osClient.DeleteResource(ctx, resource.ID)
+if orcerrors.IsConflict(err) {
+    return progress.WaitingOnOpenStack(progress.WaitingOnReady, deletingPollingPeriod)
+}
+```
+
+**Note**: Resources without intermediate states (e.g., Flavor, Keypair) are created/deleted synchronously and don't need this handling.
+
+## 3. Deterministic State
+
+Ensure consistent, comparable state to enable reliable drift detection.
+
+**Principle**: Data should be normalized before storage and comparison so equivalent states produce identical representations.
+
+**Examples:**
+- Sort lists before creation and comparison (tags, security group rules, allowed address pairs)
+- Normalize strings (trim whitespace, consistent casing where appropriate)
+- Use canonical forms for complex types
+
+```go
+// Example: Sort tags for consistent comparison
+tags := make([]string, len(resource.Tags))
+for i := range resource.Tags {
+    tags[i] = string(resource.Tags[i])
+}
+slices.Sort(tags)
+createOpts.Tags = tags
+
+// Example: Compare with sorting (copy before sorting to avoid mutation)
+desiredTags := make([]string, len(resource.Tags))
+copy(desiredTags, resource.Tags)
+slices.Sort(desiredTags)
+
+currentTags := make([]string, len(osResource.Tags))
+copy(currentTags, osResource.Tags)
+slices.Sort(currentTags)
+
+if !slices.Equal(desiredTags, currentTags) {
+    updateOpts.Tags = &desiredTags
+}
+```
+
+**Note**: Import `"slices"` when using sorting/comparison functions.
+
+## 4. Error Classification
+
+Distinguish between errors that can be retried vs those requiring user action.
+
+| Error Type | When to Use | Behavior |
+|------------|-------------|----------|
+| **Retryable** (default) | Transient issues (network, API unavailable) | Automatic retry with backoff |
+| **Terminal** | Invalid configuration, bad input, permission denied | No retry until spec changes |
+
+```go
+// Terminal: User must fix the spec
+if !orcerrors.IsRetryable(err) {
+    err = orcerrors.Terminal(orcv1alpha1.ConditionReasonInvalidConfiguration,
+        "invalid configuration: "+err.Error(), err)
+}
+
+// Conflict on update: Treat as terminal (spec likely conflicts with existing state)
+// unless resource has intermediate states that could cause transient conflicts
+if orcerrors.IsConflict(err) {
+    err = orcerrors.Terminal(orcv1alpha1.ConditionReasonInvalidConfiguration,
+        "invalid configuration updating resource: "+err.Error(), err)
+}
+```
+
+## 5. Dependency Timing
+
+Resolve dependencies as late as possible, as close to the point of use as possible.
+
+**Rationale**: Avoid injecting dependency requirements where not strictly required. This reduces coupling and gives users greater flexibility when fixing failed deployments.
+
+**Examples:**
+- A Subnet depends on Network for creation, but not for import by ID or deletion
+- Don't require recreating a deleted Network just to delete a Subnet whose `status.ID` is already set
+- Add finalizers to dependencies only immediately before the OpenStack create/update call that references them
+
+```go
+// Good: Only fetch dependency when needed for creation
+if resource.VipSubnetRef != nil {
+    subnet, depRS := subnetDependency.GetDependency(ctx, ...)
+    reconcileStatus = reconcileStatus.WithReconcileStatus(depRS)
+}
+
+// Bad: Fetching dependency unconditionally even when not needed
+subnet, depRS := subnetDependency.GetDependency(ctx, ...)  // Wrong if subnet is optional
+```
+
+For detailed dependency implementation: @.agents/skills/add-dependency/SKILL.md
+
+## 6. Code Clarity
+
+Write self-documenting code through naming and organization.
+
+**Naming**: Use descriptive names that prevent ambiguity:
+- `vipSubnetDependency` not `subnetDependency` (when multiple subnet types possible)
+- `sourcePortDependency` vs `destinationPortDependency`
+- `memberNetworkDependency` vs `externalNetworkDependency`
+
+**Organization**: Define constants and types where they're most accessible:
+- Status constants: prefer using constants from gophercloud if available
+- Only define constants in ORC's `types.go` if gophercloud doesn't provide them
+- Internal helpers in `actuator.go`
+
+```go
+// Prefer gophercloud constants when available:
+import "github.com/gophercloud/gophercloud/v2/openstack/networking/v2/ports"
+if osResource.Status == ports.StatusActive { ... }
+
+// Only define in types.go if gophercloud doesn't have them:
+const (
+    <Kind>ProvisioningStatusActive        = "ACTIVE"
+    <Kind>ProvisioningStatusPendingCreate = "PENDING_CREATE"
+    <Kind>ProvisioningStatusError         = "ERROR"
+)
+```
+
+## 7. API Safety
+
+Design APIs that prevent invalid states through types and validation.
+
+**Use stricter types** where OpenStack provides specific formats:
+- `IPvAny` for IP addresses (validates format)
+- `OpenStackName` for resource names - but check the specific OpenStack project for exact limits (e.g., Keystone names max 64 chars, Neutron names max 255 chars)
+- Custom types with validation (e.g., tag types with length limits)
+
+**Note**: Always check how fields are defined in the related OpenStack project to determine correct validation constraints.
+
+**Add validation markers** to catch errors early:
+- `+kubebuilder:validation:MinLength`, `MaxLength`
+- `+kubebuilder:validation:Pattern` for format constraints
+- `+kubebuilder:validation:XValidation` for cross-field rules

--- a/.agents/skills/proposal/SKILL.md
+++ b/.agents/skills/proposal/SKILL.md
@@ -1,0 +1,251 @@
+---
+name: proposal
+description: Write an enhancement proposal for a new ORC feature. Use for significant new features, breaking changes, or cross-cutting architectural changes.
+disable-model-invocation: true
+---
+
+# Write Feature Proposal
+
+Guide for creating a proposal for a new feature or enhancement in ORC.
+
+## When to Write an Enhancement
+
+Write an enhancement proposal when you want to:
+- Add a significant new feature or capability
+- Make breaking changes to existing APIs
+- Deprecate or remove functionality
+- Make cross-cutting architectural changes
+- Change behavior that users depend on
+
+You do **not** need an enhancement for:
+- Bug fixes
+- Small improvements or refactoring
+- Documentation updates
+- Adding support for additional OpenStack resource fields
+- Test improvements
+
+When in doubt, suggest opening a GitHub issue first to discuss whether an enhancement proposal is needed.
+
+## Enhancement Lifecycle
+
+Enhancements move through the following statuses:
+
+| Status | Description |
+|--------|-------------|
+| `implementable` | The enhancement has been approved and is ready for implementation |
+| `implemented` | The enhancement has been fully implemented and merged |
+| `withdrawn` | The enhancement is no longer being pursued |
+
+## Template and File Location
+
+Use the enhancement template at `enhancements/TEMPLATE.md`.
+
+For full process details, see `enhancements/README.md`.
+
+### Creating the Proposal File
+
+Simple enhancement (single file):
+```bash
+cp enhancements/TEMPLATE.md enhancements/your-feature-name.md
+```
+
+Enhancement with supporting files (images, diagrams):
+```bash
+mkdir enhancements/your-feature-name
+cp enhancements/TEMPLATE.md enhancements/your-feature-name/your-feature-name.md
+```
+
+## Information to Gather from User
+
+Before writing a proposal, ask the user about:
+
+1. **Feature Overview**
+   - What OpenStack resource or capability does this involve?
+   - What problem does this solve for users?
+   - Is this a new controller, enhancement to existing controller, or infrastructure change?
+
+2. **Use Cases**
+   - Who will use this feature? (end users, operators, other controllers)
+   - What are the primary use cases?
+   - Are there edge cases to consider?
+
+3. **Dependencies**
+   - Does this depend on other ORC resources?
+   - Does this require new OpenStack API capabilities?
+   - Are there upstream dependencies (gophercloud, controller-runtime)?
+
+4. **Scope**
+   - Is this a minimal viable feature or full implementation?
+   - Are there phases or milestones to break this into?
+   - What's explicitly out of scope?
+
+5. **Testing**
+   - How is this going to be tested?
+   - Are there specific E2E test scenarios required?
+   - What OpenStack capabilities are needed for testing?
+
+6. **Existing Infrastructure** (for non-controller enhancements)
+   - What related functionality already exists in ORC?
+   - Are there existing endpoints, ports, or configurations to integrate with?
+   - What frameworks/libraries does ORC already use for this area?
+
+## Research Phase
+
+Before writing the proposal, research relevant areas based on the enhancement type:
+
+### For Controller Enhancements
+
+1. **OpenStack API**
+   - Read the OpenStack API documentation for the resource
+   - Identify required vs optional fields
+   - Understand resource lifecycle (creation, updates, deletion)
+   - Check for async operations (polling requirements)
+
+2. **Gophercloud Support**
+   - Check if gophercloud has client support for this resource
+   - Identify the module path and types
+   - Note any missing functionality that needs upstream work
+
+3. **Existing Patterns**
+   - Look at similar controllers in ORC for patterns to follow
+   - Identify if existing utilities can be reused
+   - Check if new generic functionality is needed
+
+4. **Dependencies**
+   - Map out all ORC resource dependencies
+   - Determine which are required vs optional
+   - Identify deletion guard requirements
+
+### For Infrastructure Enhancements (metrics, webhooks, etc.)
+
+1. **Current Implementation**
+   - Check existing code for related functionality (e.g., `cmd/manager/`, `internal/`)
+   - Identify current ports, endpoints, and configurations
+   - Verify technical details by reading the actual code
+
+2. **Framework Capabilities**
+   - Check controller-runtime documentation for built-in features
+   - Identify what's provided vs what needs custom implementation
+
+3. **Integration Points**
+   - How does this integrate with existing infrastructure?
+   - What configuration already exists that this should use?
+
+## Filling Out the Template
+
+Read the template at `enhancements/TEMPLATE.md` and fill in each section:
+
+| Section | What to Include |
+|---------|-----------------|
+| **Metadata table** | Status (`implementable`), author, dates, tracking issue (TBD initially) |
+| **Summary** | 1-2 paragraph overview of the enhancement |
+| **Motivation** | Why this is needed, who benefits, links to issues |
+| **Goals** | Specific, measurable objectives |
+| **Non-Goals** | What's explicitly out of scope |
+| **Proposal** | Detailed solution with API examples |
+| **Risks and Edge Cases** | What could go wrong, mitigations (see risk checklist below) |
+| **Alternatives Considered** | Other approaches and why rejected |
+| **Implementation History** | Timeline of major milestones |
+
+### For New Controller Proposals
+
+**Note**: New controllers following existing patterns typically don't need an enhancement proposal. Only write a proposal if the controller requires new patterns or architectural changes.
+
+If a proposal is needed, in the **Proposal** section, include:
+
+```yaml
+apiVersion: openstack.k-orc.cloud/v1alpha1
+kind: ResourceName
+metadata:
+  name: example
+spec:
+  cloudCredentialsRef:
+    secretName: openstack-credentials
+    cloudName: openstack
+  resource:
+    # Required fields with descriptions
+    # Optional fields with descriptions
+  import:
+    filter:
+      # Filter fields
+status:
+  id: "uuid"
+  conditions: [...]
+  resource:
+    # Observed state fields
+```
+
+Also describe:
+- Controller behavior (creation, updates, deletion)
+- Dependencies (required vs optional, deletion guards)
+- Mutable vs immutable fields
+
+### Risk Checklist
+
+Address each of these in the **Risks and Edge Cases** section:
+
+| Risk Category | Questions to Answer |
+|---------------|---------------------|
+| **API compatibility** | Will this break existing users? Are metric/label names stable? |
+| **Security** | Are there security implications? (Often N/A for read-only features) |
+| **Performance** | Could this impact controller performance at scale? |
+| **Error handling** | What happens when things fail? |
+| **Upgrade/downgrade** | How does this affect users upgrading or downgrading ORC? |
+| **OpenStack compatibility** | Does this work across different OpenStack versions? (N/A for K8s-only) |
+| **Interaction with existing features** | Could this conflict with existing behavior? |
+
+### Verification Before Submission
+
+Before finalizing the proposal:
+
+1. **Internal consistency**: Verify anything referenced in one section is defined elsewhere
+   - If you mention a metric/API/config in mitigations, ensure it's defined in Proposal
+   - If you reference a flag, show its usage
+
+2. **Technical accuracy**: Verify details against actual code
+   - Check ports, endpoints, paths in the codebase
+   - Verify framework capabilities match what you describe
+
+3. **Completeness**: Ensure examples are complete and correct
+   - Code examples should compile conceptually
+   - Config examples should be valid YAML/JSON
+
+## Tips for Writing Good Enhancements
+
+1. **Be concise but complete** - Include enough detail for reviewers to understand the proposal without unnecessary verbosity.
+
+2. **Focus on the "why"** - Motivation is often more important than implementation details.
+
+3. **Think about edge cases** - The Risks and Edge Cases section is where you demonstrate you've thought through the implications.
+
+4. **Consider alternatives** - Showing that you've evaluated other approaches strengthens your proposal.
+
+5. **Keep it updated** - As implementation progresses, update the Implementation History section.
+
+## Submission Process
+
+1. **Fill out the template** with proposal details
+2. **Open a pull request** with title: `Enhancement: Add support for feature X`
+3. **Iterate based on feedback** - Discussion happens on the PR
+4. **Create a tracking issue** once merged - Label with `enhancement` and link in metadata
+
+## Review Process
+
+- Any community member can propose an enhancement
+- Maintainers review proposals and provide feedback on the PR
+- Enhancements are approved using lazy consensus (typically one week review period)
+- The enhancement author is typically expected to drive implementation
+
+## Checklist
+
+- [ ] Confirmed enhancement proposal is needed (not just a bug fix or small improvement)
+- [ ] Gathered feature requirements from user
+- [ ] Researched relevant areas (OpenStack API, gophercloud, or existing infrastructure)
+- [ ] Reviewed similar implementations in ORC
+- [ ] Copied template to `enhancements/`
+- [ ] Filled in all template sections
+- [ ] Addressed all items in risk checklist
+- [ ] Documented alternatives considered
+- [ ] Verified internal consistency (references match definitions)
+- [ ] Verified technical accuracy against codebase
+- [ ] Opened PR for review

--- a/.agents/skills/testing/SKILL.md
+++ b/.agents/skills/testing/SKILL.md
@@ -1,0 +1,107 @@
+---
+name: testing
+description: Run ORC tests (unit tests, linting, and E2E tests). Use after making changes to verify correctness.
+disable-model-invocation: true
+---
+
+# ORC Testing Guide
+
+Run unit tests, linting, and E2E tests for ORC controllers.
+
+## Unit Tests and Linting
+
+Before running E2E tests, ensure code compiles and passes linting:
+
+```bash
+make generate
+make lint
+make test
+```
+
+## E2E Test Prerequisites
+
+E2E tests require `E2E_OSCLOUDS` environment variable pointing to a `clouds.yaml` file containing:
+- A cloud named `openstack` - regular user credentials
+- A cloud named `devstack-admin` - admin credentials
+
+If the user did not provide `E2E_OSCLOUDS`, tell them local E2E testing will be skipped and they should run it manually later or in CI.
+
+## Running E2E Tests
+
+If `E2E_OSCLOUDS` is provided, execute each step in order:
+
+**Step 1: Create kind cluster (if not already running)**
+```bash
+# Check if cluster exists
+kind get clusters
+
+# Create only if no cluster exists
+kind create cluster
+```
+If a cluster already exists, skip creation and proceed to Step 2.
+
+**Step 2: Verify cluster is ready**
+```bash
+kubectl get nodes
+```
+Ensure node shows `Ready` status.
+
+**Step 3: Install CRDs**
+```bash
+kubectl apply -k config/crd --server-side
+```
+
+**Step 4: Stop any existing manager, rebuild, and start**
+```bash
+# Stop any existing manager to ensure we're running latest code
+pkill -f orc-manager || true
+
+# Build and start fresh
+go build -o /tmp/orc-manager ./cmd/manager
+/tmp/orc-manager -zap-log-level 5 > /tmp/manager.log 2>&1 &
+```
+
+**Step 5: Wait for manager to start and verify it's running**
+```bash
+sleep 5
+ps aux | grep "[o]rc-manager"
+```
+If no process found, check `/tmp/manager.log` for errors.
+
+**Step 6: Run E2E tests**
+Replace `/path/to/clouds.yaml` with the actual path and `<kind>` with the controller name:
+```bash
+E2E_OSCLOUDS=/path/to/clouds.yaml E2E_KUTTL_DIR=internal/controllers/<kind>/tests make test-e2e
+```
+
+**Step 7: If tests fail, review manager logs**
+```bash
+# Search for errors first (logs are verbose at level 5)
+grep -i error /tmp/manager.log | tail -50
+
+# Or view more context
+tail -500 /tmp/manager.log
+```
+Use these logs to diagnose and fix issues, then re-run the tests.
+
+**Step 8: Cleanup**
+After tests pass (or when done debugging):
+```bash
+pkill -f "orc-manager" || true
+kind delete cluster
+rm -f /tmp/manager.log /tmp/orc-manager
+```
+
+## E2E Test Directory Structure
+
+Tests are located in `internal/controllers/<kind>/tests/`:
+
+| Directory | Purpose |
+|-----------|---------|
+| `<kind>-create-minimal/` | Create with minimum required fields |
+| `<kind>-create-full/` | Create with all fields |
+| `<kind>-import/` | Import existing resource |
+| `<kind>-import-error/` | Import with no matches |
+| `<kind>-dependency/` | Test dependency waiting and deletion guards |
+| `<kind>-import-dependency/` | Test import with dependency references |
+| `<kind>-update/` | Test mutable field updates |

--- a/.agents/skills/update-controller/SKILL.md
+++ b/.agents/skills/update-controller/SKILL.md
@@ -1,0 +1,249 @@
+---
+name: update-controller
+description: Update an existing ORC controller. Use when adding fields, making fields mutable, adding tag support, or improving error handling.
+disable-model-invocation: true
+---
+
+# Update Existing Controller
+
+Guide for modifying an existing ORC controller.
+
+**Reference**: See `website/docs/development/` for detailed patterns and rationale.
+
+## Before Making Changes
+
+Research the resource before implementing changes:
+
+1. **Check gophercloud** for the resource's API:
+   ```bash
+   go doc <gophercloud-module>.UpdateOpts
+   go doc <gophercloud-module>.CreateOpts
+   ```
+
+2. **Check existing controller** patterns:
+   - How are similar fields handled?
+   - Does the resource have intermediate provisioning states?
+   - How are tags updated (standard Update API or separate tags API)?
+
+3. **Check OpenStack API documentation** for:
+   - Field constraints (max lengths, allowed values)
+   - Mutability (can the field be updated after creation?)
+
+## Key Principles
+
+When updating controllers, follow the patterns in @.agents/skills/new-controller/patterns.md
+
+## Common Update Scenarios
+
+### Adding a New Field to Spec
+
+1. **Update API types** in `api/v1alpha1/<kind>_types.go`:
+   - Add field to `<Kind>ResourceSpec`
+   - Add corresponding field to `<Kind>ResourceStatus`
+   - Add validation markers (`+kubebuilder:validation:*`)
+
+2. **Update actuator** in `internal/controllers/<kind>/actuator.go`:
+   - Add field to `CreateOpts` in `CreateResource()`
+   - If mutable, add update logic in reconciler
+
+3. **Update status writer** in `internal/controllers/<kind>/status.go`:
+   - Add field mapping in `ApplyResourceStatus()`
+
+4. **Regenerate**:
+   ```bash
+   make generate
+   ```
+
+5. **Update tests** to cover the new field (add only what's relevant to your change):
+   - Unit tests in `internal/controllers/<kind>/actuator_test.go` (if complex logic)
+   - E2E tests in `internal/controllers/<kind>/tests/`:
+     - `create-full`: Set new field to non-default value and verify
+     - `create-minimal`: Verify default value behavior (if field has defaults)
+     - `update`: Test setting and unsetting the field (only if field is mutable)
+     - `*-dependency`: Test dependency behavior (only if adding a new dependency)
+     - `*import*`: Test import filtering (only if adding a new filter field)
+
+### Adding a New Filter Field
+
+1. Add field to `<Kind>Filter` in `api/v1alpha1/<kind>_types.go`
+
+2. Update `ListOSResourcesForImport()` in actuator to apply the filter
+
+3. Add import test case
+
+### Making a Field Mutable
+
+1. Remove immutability validation from the field:
+   ```go
+   // Remove or update this validation
+   // +kubebuilder:validation:XValidation:rule="self == oldSelf"
+   ```
+
+2. Implement `GetResourceReconcilers()` if not already present
+
+3. Add update handling to the `updateResource()` reconciler (or create it if not present):
+   ```go
+   func (actuator myActuator) updateResource(...) progress.ReconcileStatus {
+       var updateOpts resources.UpdateOpts
+       // Add a handleXXXUpdate() call for each mutable field
+       handleMyFieldUpdate(&updateOpts, resource, osResource)
+       // Call API only if something changed
+       if updateOpts != (resources.UpdateOpts{}) {
+           _, err := actuator.osClient.UpdateResource(ctx, *obj.Status.ID, updateOpts)
+           // ...
+       }
+   }
+
+   func handleMyFieldUpdate(updateOpts *resources.UpdateOpts, resource *resourceSpecT, osResource *osResourceT) {
+       if resource.MyField != nil && *resource.MyField != osResource.MyField {
+           updateOpts.MyField = resource.MyField
+       }
+   }
+   ```
+
+   **Note**: Only create a separate reconciler method if the field requires a different API call (e.g., tags on networking resources use a separate tags API).
+
+4. Register in `GetResourceReconcilers()`:
+   ```go
+   return []resourceReconciler{
+       actuator.updateResource,
+   }, nil
+   ```
+
+### Adding a Dependency
+
+See @.agents/skills/add-dependency/SKILL.md for detailed steps.
+
+### Improving DeleteResource
+
+For resources with intermediate provisioning states, ensure robust deletion:
+
+```go
+func (actuator myActuator) DeleteResource(ctx context.Context, _ orcObjectPT, resource *osResourceT) progress.ReconcileStatus {
+    // Handle intermediate states
+    switch resource.ProvisioningStatus {
+    case ProvisioningStatusPendingDelete:
+        return progress.WaitingOnOpenStack(progress.WaitingOnReady, deletingPollingPeriod)
+    case ProvisioningStatusPendingCreate, ProvisioningStatusPendingUpdate:
+        // Can't delete in pending state, wait for ACTIVE
+        return progress.WaitingOnOpenStack(progress.WaitingOnReady, availablePollingPeriod)
+    }
+
+    err := actuator.osClient.DeleteResource(ctx, resource.ID)
+    // Handle 409 (state changed between check and API call)
+    if orcerrors.IsConflict(err) {
+        return progress.WaitingOnOpenStack(progress.WaitingOnReady, deletingPollingPeriod)
+    }
+    return progress.WrapError(err)
+}
+```
+
+**Important**: Never use cascade delete unless explicitly requested by the user.
+
+### Adding Tag Support
+
+**Note**: Tag handling varies by OpenStack service. Some services (e.g., block storage) include tags in the standard Update API, while others (e.g., networking) require a separate tags API and a dedicated reconciler. Check gophercloud for the specific resource.
+
+1. Add `Tags` field to spec and status:
+   ```go
+   // In ResourceSpec
+   // +kubebuilder:validation:MaxItems:=64
+   // +listType=set
+   Tags []NeutronTag `json:"tags,omitempty"`
+
+   // In ResourceStatus
+   // +listType=atomic
+   Tags []string `json:"tags,omitempty"`
+   ```
+
+2. Sort tags before creation (deterministic state):
+   ```go
+   tags := make([]string, len(resource.Tags))
+   for i := range resource.Tags {
+       tags[i] = string(resource.Tags[i])
+   }
+   slices.Sort(tags)
+   createOpts.Tags = tags
+   ```
+
+3. Add tag update handler with sorting:
+   ```go
+   func handleTagsUpdate(updateOpts *resources.UpdateOpts, resource *resourceSpecT, osResource *osResourceT) {
+       desiredTags := make([]string, len(resource.Tags))
+       for i := range resource.Tags {
+           desiredTags[i] = string(resource.Tags[i])
+       }
+       slices.Sort(desiredTags)
+
+       currentTags := make([]string, len(osResource.Tags))
+       copy(currentTags, osResource.Tags)  // Don't mutate original
+       slices.Sort(currentTags)
+
+       if !slices.Equal(desiredTags, currentTags) {
+           updateOpts.Tags = &desiredTags
+       }
+   }
+   ```
+
+4. Register in `GetResourceReconcilers()`:
+   ```go
+   return []resourceReconciler{
+       actuator.updateResource,  // includes handleTagsUpdate
+   }, nil
+   ```
+
+**Note**: Import `"slices"` for sorting/comparison functions.
+
+### Adding Status Constants
+
+For resources with provisioning states, prefer using constants from gophercloud when available. Only define constants in ORC's `types.go` if gophercloud doesn't provide them.
+
+```go
+// Prefer gophercloud constants when available:
+import "github.com/gophercloud/gophercloud/v2/openstack/loadbalancer/v2/loadbalancers"
+if osResource.ProvisioningStatus == loadbalancers.ProvisioningStatusActive { ... }
+
+// Only define in types.go if gophercloud doesn't have them:
+const (
+    MyResourceProvisioningStatusActive        = "ACTIVE"
+    MyResourceProvisioningStatusPendingCreate = "PENDING_CREATE"
+    MyResourceProvisioningStatusError         = "ERROR"
+)
+```
+
+See also `@.agents/skills/new-controller/patterns.md` for more details on this pattern.
+
+### Improving Error Handling
+
+Ensure proper error classification:
+
+```go
+// Terminal: Invalid configuration - user must fix spec
+if !orcerrors.IsRetryable(err) {
+    err = orcerrors.Terminal(orcv1alpha1.ConditionReasonInvalidConfiguration,
+        "invalid configuration: "+err.Error(), err)
+}
+return nil, progress.WrapError(err)
+
+// Conflict on update: Treat as terminal
+if orcerrors.IsConflict(err) {
+    err = orcerrors.Terminal(orcv1alpha1.ConditionReasonInvalidConfiguration,
+        "invalid configuration updating resource: "+err.Error(), err)
+}
+```
+
+## Testing Changes
+
+Follow @.agents/skills/testing/SKILL.md for running unit tests, linting, and E2E tests.
+
+## Checklist
+
+- [ ] API types updated with proper validation
+- [ ] Actuator updated (create/update logic)
+- [ ] Status writer updated
+- [ ] `make generate` runs cleanly
+- [ ] `make lint` passes
+- [ ] `make test` passes
+- [ ] E2E tests updated/added
+- [ ] E2E tests passing
+- [ ] Unit tests added (if complex logic)

--- a/.claude/settings.local.json
+++ b/.claude/settings.local.json
@@ -1,0 +1,14 @@
+{
+  "permissions": {
+    "allow": [
+      "Bash(go mod tidy:*)",
+      "Bash(make generate:*)",
+      "Bash(go build:*)",
+      "Bash(go fmt:*)",
+      "Bash(go doc:*)",
+      "Bash(make test:*)"
+    ],
+    "deny": [],
+    "ask": []
+  }
+}

--- a/.claude/skills
+++ b/.claude/skills
@@ -1,0 +1,1 @@
+../.agents/skills

--- a/AGENTS.md
+++ b/AGENTS.md
@@ -1,0 +1,264 @@
+# OpenStack Resource Controller (ORC) - Development Guide
+
+This document provides instructions for AI agents to develop controllers in the ORC project.
+
+## Project Overview
+
+ORC is a Kubernetes operator that manages OpenStack resources declaratively. Each OpenStack resource (Flavor, Server, Network, etc.) has a corresponding Kubernetes Custom Resource and controller.
+
+**Key Principle**: ORC objects only reference other ORC objects, never OpenStack resources directly. OpenStack resource IDs appear only in status fields.
+
+## Project Structure
+
+```
+openstack-resource-controller/
+├── api/v1alpha1/              # CRD type definitions (*_types.go)
+├── internal/
+│   ├── controllers/           # Controller implementations
+│   │   └── <resource>/        # Each controller in its own package
+│   │       ├── controller.go  # Setup, dependencies, SetupWithManager
+│   │       ├── actuator.go    # OpenStack CRUD operations
+│   │       ├── status.go      # Status writer implementation
+│   │       ├── zz_generated.*.go  # Generated code (DO NOT EDIT)
+│   │       └── tests/         # KUTTL E2E tests
+│   ├── osclients/             # OpenStack API client wrappers
+│   ├── scope/                 # Cloud credentials & client factory
+│   └── util/                  # Utilities (errors, dependency, tags)
+├── cmd/
+│   ├── manager/               # Main entry point
+│   ├── resource-generator/    # Code generation
+│   └── scaffold-controller/   # New controller scaffolding
+└── website/docs/development/  # Detailed documentation
+```
+
+## Architecture
+
+### Generic Reconciler Framework
+
+All controllers use a generic reconciler that handles the reconciliation loop. Controllers implement interfaces:
+
+- **CreateResourceActuator**: Create and import operations
+- **DeleteResourceActuator**: Delete operations
+- **ReconcileResourceActuator**: Post-creation updates (optional)
+- **ResourceStatusWriter**: Status and condition management
+
+### Key Interfaces
+
+Controllers implement these methods (see `internal/controllers/flavor/` for a simple example):
+
+```go
+// Required by all actuators
+GetResourceID(osResource) string
+GetOSResourceByID(ctx, id) (*osResource, ReconcileStatus)
+ListOSResourcesForAdoption(ctx, obj) (iterator, bool)
+
+// For creation/import
+ListOSResourcesForImport(ctx, obj, filter) (iterator, ReconcileStatus)
+CreateResource(ctx, orcObject) (*osResource, ReconcileStatus)
+
+// For deletion
+DeleteResource(ctx, orcObject, osResource) ReconcileStatus
+
+// Optional - for updates after creation
+GetResourceReconcilers(ctx, obj, osResource) ([]ResourceReconciler, error)
+```
+
+### Two Critical Conditions
+
+Every ORC object has these conditions:
+
+1. **Progressing**
+   - `True`: Spec doesn't match status; controller expects more reconciles
+   - `False`: Either available OR terminal error (no more reconciles until spec changes)
+
+2. **Available**
+   - `True`: Resource is ready for use
+   - Determined by `ResourceStatusWriter.ResourceAvailableStatus()`
+
+### ReconcileStatus Pattern
+
+Methods return `ReconcileStatus` instead of `error`:
+
+```go
+nil                                    // Success, no reschedule
+progress.WrapError(err)                // Wrap error for handling
+reconcileStatus.WithRequeue(5*time.Second)  // Schedule reconcile after delay
+reconcileStatus.WithProgressMessage("waiting...") // Add progress message
+```
+
+### Error Classification
+
+- **Transient errors** (5xx, API unavailable): Default handling with exponential backoff
+- **Terminal errors** (400, invalid config): Wrap with `orcerrors.Terminal()` - no retry
+
+```go
+// Terminal error example
+if !orcerrors.IsRetryable(err) {
+    err = orcerrors.Terminal(orcv1alpha1.ConditionReasonInvalidConfiguration,
+        "invalid configuration: "+err.Error(), err)
+}
+return nil, progress.WrapError(err)
+```
+
+## Dependencies
+
+Dependencies are core to ORC - they ensure resources are created in order.
+
+### Types of Dependencies
+
+1. **Normal Dependency**: Wait for object to exist and be available
+2. **Deletion Guard Dependency**: Normal + prevents deletion of dependency while in use
+
+### Declaring Dependencies (in controller.go)
+
+```go
+var projectDependency = dependency.NewDeletionGuardDependency[*orcv1alpha1.SecurityGroupList, *orcv1alpha1.Project](
+    "spec.resource.projectRef",           // Field path for indexing
+    func(sg *orcv1alpha1.SecurityGroup) []string {
+        if sg.Spec.Resource != nil && sg.Spec.Resource.ProjectRef != nil {
+            return []string{string(*sg.Spec.Resource.ProjectRef)}
+        }
+        return nil
+    },
+    finalizer, externalObjectFieldOwner,
+)
+```
+
+### Using Dependencies (in actuator.go)
+
+```go
+project, reconcileStatus := projectDependency.GetDependency(
+    ctx, actuator.k8sClient, orcObject,
+    func(dep *orcv1alpha1.Project) bool {
+        return orcv1alpha1.IsAvailable(dep) && dep.Status.ID != nil
+    },
+)
+if needsReschedule, _ := reconcileStatus.NeedsReschedule(); needsReschedule {
+    return nil, reconcileStatus
+}
+// project is now guaranteed available
+projectID := ptr.Deref(project.Status.ID, "")
+```
+
+## Common Patterns
+
+### Resource Name Helper
+
+```go
+func getResourceName(orcObject *orcv1alpha1.Flavor) string {
+    if orcObject.Spec.Resource.Name != nil {
+        return *orcObject.Spec.Resource.Name
+    }
+    return orcObject.Name
+}
+```
+
+### Type Aliases (top of actuator.go)
+
+```go
+type (
+    osResourceT = flavors.Flavor
+    createResourceActuator = interfaces.CreateResourceActuator[orcObjectPT, orcObjectT, filterT, osResourceT]
+    deleteResourceActuator = interfaces.DeleteResourceActuator[orcObjectPT, orcObjectT, osResourceT]
+    helperFactory = interfaces.ResourceHelperFactory[orcObjectPT, orcObjectT, resourceSpecT, filterT, osResourceT]
+)
+```
+
+### Interface Assertions
+
+```go
+var _ createResourceActuator = flavorActuator{}
+var _ deleteResourceActuator = flavorActuator{}
+```
+
+### Pointer Handling
+
+```go
+import "k8s.io/utils/ptr"
+
+ptr.Deref(optionalPtr, defaultValue)  // Dereference with default
+ptr.To(value)                          // Create pointer
+```
+
+## API Types Structure
+
+### ResourceSpec (creation parameters)
+
+```go
+// Most resources have a mix of immutable and mutable fields.
+// Immutability is typically applied per-field, not on the whole struct.
+type ServerResourceSpec struct {
+    // +optional
+    Name *OpenStackName `json:"name,omitempty"`
+
+    // +required
+    // +kubebuilder:validation:XValidation:rule="self == oldSelf",message="imageRef is immutable"
+    ImageRef KubernetesNameRef `json:"imageRef,omitempty"`
+
+    // tags is mutable (no immutability validation)
+    // +optional
+    Tags []ServerTag `json:"tags,omitempty"`
+}
+
+// Some resources are fully immutable (rare - e.g., Flavor, ServerGroup)
+// +kubebuilder:validation:XValidation:rule="self == oldSelf",message="FlavorResourceSpec is immutable"
+type FlavorResourceSpec struct {
+    // ...
+}
+```
+
+### Filter (import parameters)
+
+```go
+// +kubebuilder:validation:MinProperties:=1
+type FlavorFilter struct {
+    Name *OpenStackName `json:"name,omitempty"`
+    RAM  *int32         `json:"ram,omitempty"`
+}
+```
+
+### ResourceStatus (observed state)
+
+```go
+type FlavorResourceStatus struct {
+    Name string `json:"name,omitempty"`
+    RAM  *int32 `json:"ram,omitempty"`
+}
+```
+
+## Logging Levels
+
+```go
+import "github.com/k-orc/openstack-resource-controller/v2/internal/logging"
+
+log.V(logging.Status).Info("...")   // Always shown: startup, shutdown
+log.V(logging.Info).Info("...")     // Default: creation/deletion, reconcile complete
+log.V(logging.Verbose).Info("...")  // Admin: fires every reconcile
+log.V(logging.Debug).Info("...")    // Development: detailed debugging
+```
+
+## Key Make Targets
+
+```bash
+make generate      # Generate all code (run after API type changes)
+make build         # Build manager binary
+make lint          # Run linters
+make test          # Run unit tests
+make test-e2e      # Run KUTTL E2E tests (requires E2E_OSCLOUDS)
+make fmt           # Format code
+```
+
+## Reference Controllers
+
+- **Simple**: `internal/controllers/flavor/` - No dependencies, immutable
+- **With dependencies**: `internal/controllers/securitygroup/` - Project dependency, rules reconciliation
+- **Complex**: `internal/controllers/server/` - Multiple dependencies, reconcilers
+
+## Documentation
+
+Detailed documentation in `website/docs/development/`:
+- `scaffolding.md` - Creating new controllers
+- `controller-implementation.md` - Progressing condition, ReconcileStatus
+- `interfaces.md` - Detailed interface descriptions
+- `coding-standards.md` - Code style and conventions
+- `writing-tests.md` - Testing patterns

--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -1,0 +1,1 @@
+AGENTS.md


### PR DESCRIPTION
Add AGENTS.md with project-specific instructions for AI-assisted
development of ORC controllers, including project structure, key
patterns, and references to detailed documentation.

Add skills for common development workflows:
- /new-controller: Scaffold and implement new ORC controllers
- /update-controller: Modify existing controllers (add fields, tags, etc.)
- /add-dependency: Add resource dependencies to controllers
- /proposal: Write enhancement proposals following the template
- /testing: Run unit tests, linting, and E2E tests

## Open Standards

Following review feedback, this PR uses generic naming conventions:

- **AGENTS.md** is the main instruction file (open standard)
- **CLAUDE.md** is a symlink for Claude Code compatibility
- **.agents/skills/** contains the skills (Agent Skills open standard)
- **.claude/skills/** symlinks to .agents/skills/ for Claude Code

This ensures compatibility with multiple AI coding assistants while
avoiding vendor lock-in.

Skills follow the [Agent Skills](https://agentskills.io/specification) open standard with SKILL.md format.

Tested locally and compared with already proposed controller (loadbalancer), did a great job mostly similar to what I did with some possible improvements!