### PR TITLE
scaffolding: change default cloudName on dependency test

### DIFF
--- a/cmd/scaffold-controller/data/tests/import-dependency/02-create-resource.yaml.template
+++ b/cmd/scaffold-controller/data/tests/import-dependency/02-create-resource.yaml.template
@@ -22,7 +22,7 @@ metadata:
 spec:
   cloudCredentialsRef:
     # TODO(scaffolding): Use openstack-admin if the resource needs admin credentials to be created
-    cloudName: openstack-admin
+    cloudName: openstack
     secretName: openstack-clouds
   managementPolicy: managed
   resource:


### PR DESCRIPTION
The scaffolding tool is generating the import-dependency test using admin credentials for the resource that will be created. We avoid using admin credentials whenever it is not needed, so I believe it is better to generate a less privileged cloudName and let the user change it if needed.