### PR TITLE
Fix typos in endpoint controller tests' README

### DIFF
--- a/internal/controllers/endpoint/tests/endpoint-create-full/README.md
+++ b/internal/controllers/endpoint/tests/endpoint-create-full/README.md
@@ -1,8 +1,8 @@
-# Create a Endpoint with all the options
+# Create an Endpoint with all the options
 
 ## Step 00
 
-Create a Endpoint using all available fields, and verify that the observed state corresponds to the spec.
+Create an Endpoint using all available fields, and verify that the observed state corresponds to the spec.
 
 Also validate that the OpenStack resource uses the name from the spec when it is specified.
 

--- a/internal/controllers/endpoint/tests/endpoint-create-minimal/README.md
+++ b/internal/controllers/endpoint/tests/endpoint-create-minimal/README.md
@@ -1,4 +1,4 @@
-# Create a Endpoint with the minimum options
+# Create an Endpoint with the minimum options
 
 ## Step 00
 

--- a/internal/controllers/endpoint/tests/endpoint-import-dependency/README.md
+++ b/internal/controllers/endpoint/tests/endpoint-import-dependency/README.md
@@ -2,16 +2,16 @@
 
 ## Step 00
 
-Import a Endpoint that references other imported resources. The referenced imported resources have no matching resources yet.
+Import an Endpoint that references other imported resources. The referenced imported resources have no matching resources yet.
 Verify the Endpoint is waiting for the dependency to be ready.
 
 ## Step 01
 
-Create a Endpoint matching the import filter, except for referenced resources, and verify that it's not being imported.
+Create an Endpoint matching the import filter, except for referenced resources, and verify that it's not being imported.
 
 ## Step 02
 
-Create the referenced resources and a Endpoint matching the import filters.
+Create the referenced resources and an Endpoint matching the import filters.
 
 Verify that the observed status on the imported Endpoint corresponds to the spec of the created Endpoint.
 

--- a/internal/controllers/endpoint/tests/endpoint-import/README.md
+++ b/internal/controllers/endpoint/tests/endpoint-import/README.md
@@ -2,15 +2,15 @@
 
 ## Step 00
 
-Import a endpoint that matches all fields in the filter, and verify it is waiting for the external resource to be created.
+Import an endpoint that matches all fields in the filter, and verify it is waiting for the external resource to be created.
 
 ## Step 01
 
-Create a endpoint whose name is a superstring of the one specified in the import filter, otherwise matching the filter, and verify that it's not being imported.
+Create an endpoint whose name is a superstring of the one specified in the import filter, otherwise matching the filter, and verify that it's not being imported.
 
 ## Step 02
 
-Create a endpoint matching the filter and verify that the observed status on the imported endpoint corresponds to the spec of the created endpoint.
+Create an endpoint matching the filter and verify that the observed status on the imported endpoint corresponds to the spec of the created endpoint.
 Also, confirm that it does not adopt any endpoint whose name is a superstring of its own.
 
 ## Reference

--- a/internal/controllers/endpoint/tests/endpoint-update/README.md
+++ b/internal/controllers/endpoint/tests/endpoint-update/README.md
@@ -2,7 +2,7 @@
 
 ## Step 00
 
-Create a Endpoint using only mandatory fields.
+Create an Endpoint using only mandatory fields.
 
 ## Step 01
 


### PR DESCRIPTION
There are some spelling errors in the Endpoint controller, as @dlaw4608 has noticed in #693. This PR fixes them.

Maybe worth adding some guidance on AGENTS.md to fix this type of spell detail (I think this is a good case for AI automation :)).