### PR TITLE
dependabot: drop pins due to older version of go

### DIFF
--- a/.github/dependabot.yml
+++ b/.github/dependabot.yml
@@ -75,7 +75,4 @@ updates:
   # Ignore k8s major and minor bumps and its transitives modules
   - dependency-name: "k8s.io/*"
     update-types: ["version-update:semver-major", "version-update:semver-minor"]
-  # Below dependencies require a newer version of go:
-  - dependency-name: "github.com/onsi/gomega"
-  - dependency-name: "golang.org/x/text"
 ## release-1.0 branch config ends here


### PR DESCRIPTION
We're now on go 1.25 in the release-1.0 branch.