### PR TITLE
Project: Add ability to specify domainRef

### DIFF
--- a/api/v1alpha1/project_types.go
+++ b/api/v1alpha1/project_types.go
@@ -64,6 +64,11 @@ type ProjectResourceSpec struct {
 	// +optional
 	Description *string `json:"description,omitempty"`
 
+	// domainRef is a reference to the ORC Domain which this resource is associated with.
+	// +optional
+	// +kubebuilder:validation:XValidation:rule="self == oldSelf",message="domainRef is immutable"
+	DomainRef *KubernetesNameRef `json:"domainRef,omitempty"`
+
 	// enabled defines whether a project is enabled or not. Default is true.
 	// +optional
 	Enabled *bool `json:"enabled,omitempty"`
@@ -83,6 +88,10 @@ type ProjectFilter struct {
 	// +optional
 	Name *KeystoneName `json:"name,omitempty"`
 
+	// domainRef is a reference to the ORC Domain which this resource is associated with.
+	// +optional
+	DomainRef *KubernetesNameRef `json:"domainRef,omitempty"`
+
 	FilterByKeystoneTags `json:",inline"`
 }
 
@@ -97,6 +106,11 @@ type ProjectResourceStatus struct {
 	// +kubebuilder:validation:MaxLength:=65535
 	// +optional
 	Description string `json:"description,omitempty"`
+
+	// domainID is the ID of the Domain to which the resource is associated.
+	// +kubebuilder:validation:MaxLength=1024
+	// +optional
+	DomainID string `json:"domainID,omitempty"`
 
 	// enabled represents whether a project is enabled or not.
 	// +optional

--- a/api/v1alpha1/zz_generated.deepcopy.go
+++ b/api/v1alpha1/zz_generated.deepcopy.go
@@ -3149,6 +3149,11 @@ func (in *ProjectFilter) DeepCopyInto(out *ProjectFilter) {
 		*out = new(KeystoneName)
 		**out = **in
 	}
+	if in.DomainRef != nil {
+		in, out := &in.DomainRef, &out.DomainRef
+		*out = new(KubernetesNameRef)
+		**out = **in
+	}
 	in.FilterByKeystoneTags.DeepCopyInto(&out.FilterByKeystoneTags)
 }
 
@@ -3230,6 +3235,11 @@ func (in *ProjectResourceSpec) DeepCopyInto(out *ProjectResourceSpec) {
 	if in.Description != nil {
 		in, out := &in.Description, &out.Description
 		*out = new(string)
+		**out = **in
+	}
+	if in.DomainRef != nil {
+		in, out := &in.DomainRef, &out.DomainRef
+		*out = new(KubernetesNameRef)
 		**out = **in
 	}
 	if in.Enabled != nil {

--- a/cmd/models-schema/zz_generated.openapi.go
+++ b/cmd/models-schema/zz_generated.openapi.go
@@ -6080,6 +6080,13 @@ func schema_openstack_resource_controller_v2_api_v1alpha1_ProjectFilter(ref comm
 							Format:      "",
 						},
 					},
+					"domainRef": {
+						SchemaProps: spec.SchemaProps{
+							Description: "domainRef is a reference to the ORC Domain which this resource is associated with.",
+							Type:        []string{"string"},
+							Format:      "",
+						},
+					},
 					"tags": {
 						VendorExtensible: spec.VendorExtensible{
 							Extensions: spec.Extensions{
@@ -6266,6 +6273,13 @@ func schema_openstack_resource_controller_v2_api_v1alpha1_ProjectResourceSpec(re
 							Format:      "",
 						},
 					},
+					"domainRef": {
+						SchemaProps: spec.SchemaProps{
+							Description: "domainRef is a reference to the ORC Domain which this resource is associated with.",
+							Type:        []string{"string"},
+							Format:      "",
+						},
+					},
 					"enabled": {
 						SchemaProps: spec.SchemaProps{
 							Description: "enabled defines whether a project is enabled or not. Default is true.",
@@ -6316,6 +6330,13 @@ func schema_openstack_resource_controller_v2_api_v1alpha1_ProjectResourceStatus(
 					"description": {
 						SchemaProps: spec.SchemaProps{
 							Description: "description is a human-readable description for the resource.",
+							Type:        []string{"string"},
+							Format:      "",
+						},
+					},
+					"domainID": {
+						SchemaProps: spec.SchemaProps{
+							Description: "domainID is the ID of the Domain to which the resource is associated.",
 							Type:        []string{"string"},
 							Format:      "",
 						},

--- a/config/crd/bases/openstack.k-orc.cloud_projects.yaml
+++ b/config/crd/bases/openstack.k-orc.cloud_projects.yaml
@@ -91,6 +91,12 @@ spec:
                       error state and will not continue to retry.
                     minProperties: 1
                     properties:
+                      domainRef:
+                        description: domainRef is a reference to the ORC Domain which
+                          this resource is associated with.
+                        maxLength: 253
+                        minLength: 1
+                        type: string
                       name:
                         description: name of the existing resource
                         maxLength: 64
@@ -195,6 +201,15 @@ spec:
                     maxLength: 65535
                     minLength: 1
                     type: string
+                  domainRef:
+                    description: domainRef is a reference to the ORC Domain which
+                      this resource is associated with.
+                    maxLength: 253
+                    minLength: 1
+                    type: string
+                    x-kubernetes-validations:
+                    - message: domainRef is immutable
+                      rule: self == oldSelf
                   enabled:
                     description: enabled defines whether a project is enabled or not.
                       Default is true.
@@ -325,6 +340,11 @@ spec:
                     description: description is a human-readable description for the
                       resource.
                     maxLength: 65535
+                    type: string
+                  domainID:
+                    description: domainID is the ID of the Domain to which the resource
+                      is associated.
+                    maxLength: 1024
                     type: string
                   enabled:
                     description: enabled represents whether a project is enabled or

--- a/internal/controllers/project/actuator.go
+++ b/internal/controllers/project/actuator.go
@@ -25,11 +25,13 @@ import (
 	corev1 "k8s.io/api/core/v1"
 	"k8s.io/utils/ptr"
 	ctrl "sigs.k8s.io/controller-runtime"
+	"sigs.k8s.io/controller-runtime/pkg/client"
 
 	orcv1alpha1 "github.com/k-orc/openstack-resource-controller/v2/api/v1alpha1"
 	generic "github.com/k-orc/openstack-resource-controller/v2/internal/controllers/generic/interfaces"
 	"github.com/k-orc/openstack-resource-controller/v2/internal/controllers/generic/progress"
 	"github.com/k-orc/openstack-resource-controller/v2/internal/logging"
+	"github.com/k-orc/openstack-resource-controller/v2/internal/util/dependency"
 	orcerrors "github.com/k-orc/openstack-resource-controller/v2/internal/util/errors"
 	"github.com/k-orc/openstack-resource-controller/v2/internal/util/tags"
 )
@@ -53,7 +55,8 @@ type projectClient interface {
 }
 
 type projectActuator struct {
-	osClient projectClient
+	osClient  projectClient
+	k8sClient client.Client
 }
 
 var _ createResourceActuator = projectActuator{}
@@ -85,8 +88,23 @@ func (actuator projectActuator) ListOSResourcesForAdoption(ctx context.Context, 
 }
 
 func (actuator projectActuator) ListOSResourcesForImport(ctx context.Context, orcObject orcObjectPT, filter filterT) (iter.Seq2[*osResourceT, error], progress.ReconcileStatus) {
+	var reconcileStatus progress.ReconcileStatus
+
+	domain, rs := dependency.FetchDependency(
+		ctx, actuator.k8sClient, orcObject.Namespace, filter.DomainRef, "Domain",
+		func(dep *orcv1alpha1.Domain) bool {
+			return orcv1alpha1.IsAvailable(dep) && dep.Status.ID != nil
+		},
+	)
+	reconcileStatus = reconcileStatus.WithReconcileStatus(rs)
+
+	if needsReschedule, _ := reconcileStatus.NeedsReschedule(); needsReschedule {
+		return nil, reconcileStatus
+	}
+
 	listOpts := projects.ListOpts{
 		Name:       string(ptr.Deref(filter.Name, "")),
+		DomainID:   ptr.Deref(domain.Status.ID, ""),
 		Tags:       tags.Join(filter.Tags),
 		TagsAny:    tags.Join(filter.TagsAny),
 		NotTags:    tags.Join(filter.NotTags),
@@ -104,6 +122,23 @@ func (actuator projectActuator) CreateResource(ctx context.Context, obj orcObjec
 		return nil, progress.WrapError(
 			orcerrors.Terminal(orcv1alpha1.ConditionReasonInvalidConfiguration, "Creation requested, but spec.resource is not set"))
 	}
+	var reconcileStatus progress.ReconcileStatus
+
+	var domainID string
+	if resource.DomainRef != nil {
+		domain, domainDepRS := domainDependency.GetDependency(
+			ctx, actuator.k8sClient, obj, func(dep *orcv1alpha1.Domain) bool {
+				return orcv1alpha1.IsAvailable(dep) && dep.Status.ID != nil
+			},
+		)
+		reconcileStatus = reconcileStatus.WithReconcileStatus(domainDepRS)
+		if domain != nil {
+			domainID = ptr.Deref(domain.Status.ID, "")
+		}
+	}
+	if needsReschedule, _ := reconcileStatus.NeedsReschedule(); needsReschedule {
+		return nil, reconcileStatus
+	}
 
 	tags := make([]string, len(resource.Tags))
 	for i := range resource.Tags {
@@ -115,6 +150,7 @@ func (actuator projectActuator) CreateResource(ctx context.Context, obj orcObjec
 	createOpts := projects.CreateOpts{
 		Name:        getResourceName(obj),
 		Description: ptr.Deref(resource.Description, ""),
+		DomainID:    domainID,
 		Enabled:     resource.Enabled,
 		Tags:        tags,
 	}
@@ -251,7 +287,8 @@ func newActuator(ctx context.Context, orcObject *orcv1alpha1.Project, controller
 	}
 
 	return projectActuator{
-		osClient: osClient,
+		osClient:  osClient,
+		k8sClient: controller.GetK8sClient(),
 	}, nil
 }
 

--- a/internal/controllers/project/controller.go
+++ b/internal/controllers/project/controller.go
@@ -21,6 +21,7 @@ import (
 	"errors"
 
 	ctrl "sigs.k8s.io/controller-runtime"
+	"sigs.k8s.io/controller-runtime/pkg/builder"
 	"sigs.k8s.io/controller-runtime/pkg/controller"
 
 	orcv1alpha1 "github.com/k-orc/openstack-resource-controller/v2/api/v1alpha1"
@@ -29,6 +30,8 @@ import (
 	"github.com/k-orc/openstack-resource-controller/v2/internal/controllers/generic/reconciler"
 	"github.com/k-orc/openstack-resource-controller/v2/internal/scope"
 	"github.com/k-orc/openstack-resource-controller/v2/internal/util/credentials"
+	"github.com/k-orc/openstack-resource-controller/v2/internal/util/dependency"
+	"github.com/k-orc/openstack-resource-controller/v2/pkg/predicates"
 )
 
 const controllerName = "project"
@@ -48,15 +51,58 @@ func (projectReconcilerConstructor) GetName() string {
 	return controllerName
 }
 
+var domainDependency = dependency.NewDeletionGuardDependency[*orcv1alpha1.ProjectList, *orcv1alpha1.Domain](
+	"spec.resource.domainRef",
+	func(project *orcv1alpha1.Project) []string {
+		resource := project.Spec.Resource
+		if resource == nil || resource.DomainRef == nil {
+			return nil
+		}
+		return []string{string(*resource.DomainRef)}
+	},
+	finalizer, externalObjectFieldOwner,
+)
+
+var domainImportDependency = dependency.NewDependency[*orcv1alpha1.ProjectList, *orcv1alpha1.Domain](
+	"spec.import.filter.domainRef",
+	func(project *orcv1alpha1.Project) []string {
+		resource := project.Spec.Import
+		if resource == nil || resource.Filter == nil || resource.Filter.DomainRef == nil {
+			return nil
+		}
+		return []string{string(*resource.Filter.DomainRef)}
+	},
+)
+
 // SetupWithManager sets up the controller with the Manager.
 func (c projectReconcilerConstructor) SetupWithManager(ctx context.Context, mgr ctrl.Manager, options controller.Options) error {
 	log := ctrl.LoggerFrom(ctx)
+	k8sClient := mgr.GetClient()
+
+	domainWatchEventHandler, err := domainDependency.WatchEventHandler(log, k8sClient)
+	if err != nil {
+		return err
+	}
+
+	domainImportWatchEventHandler, err := domainImportDependency.WatchEventHandler(log, k8sClient)
+	if err != nil {
+		return err
+	}
 
 	builder := ctrl.NewControllerManagedBy(mgr).
 		WithOptions(options).
+		Watches(&orcv1alpha1.Domain{}, domainWatchEventHandler,
+			builder.WithPredicates(predicates.NewBecameAvailable(log, &orcv1alpha1.Domain{})),
+		).
+		// A second watch is necessary because we need a different handler that omits deletion guards
+		Watches(&orcv1alpha1.Domain{}, domainImportWatchEventHandler,
+			builder.WithPredicates(predicates.NewBecameAvailable(log, &orcv1alpha1.Domain{})),
+		).
 		For(&orcv1alpha1.Project{})
 
 	if err := errors.Join(
+		domainDependency.AddToManager(ctx, mgr),
+		domainImportDependency.AddToManager(ctx, mgr),
 		credentialsDependency.AddToManager(ctx, mgr),
 		credentials.AddCredentialsWatch(log, mgr.GetClient(), builder, credentialsDependency),
 	); err != nil {

--- a/internal/controllers/project/status.go
+++ b/internal/controllers/project/status.go
@@ -54,6 +54,7 @@ func (projectStatusWriter) ResourceAvailableStatus(orcObject *orcv1alpha1.Projec
 func (projectStatusWriter) ApplyResourceStatus(_ logr.Logger, osResource *projects.Project, statusApply *statusApplyT) {
 	resourceStatus := orcapplyconfigv1alpha1.ProjectResourceStatus().
 		WithName(osResource.Name).
+		WithDomainID(osResource.DomainID).
 		WithEnabled(osResource.Enabled).
 		WithTags(osResource.Tags...)
 	if osResource.Description != "" {

--- a/internal/controllers/project/tests/project-create-full/00-assert.yaml
+++ b/internal/controllers/project/tests/project-create-full/00-assert.yaml
@@ -11,3 +11,25 @@ status:
     tags:
       - tag1
       - tag2
+  conditions:
+  - type: Available
+    status: "True"
+    reason: Success
+  - type: Progressing
+    status: "False"
+    reason: Success
+---
+apiVersion: kuttl.dev/v1beta1
+kind: TestAssert
+resourceRefs:
+    - apiVersion: openstack.k-orc.cloud/v1alpha1
+      kind: Project
+      name: project-create-full
+      ref: project
+    - apiVersion: openstack.k-orc.cloud/v1alpha1
+      kind: Domain
+      name: project-create-full
+      ref: domain
+assertAll:
+    - celExpr: "project.status.id != ''"
+    - celExpr: "project.status.resource.domainID == domain.status.id"

--- a/internal/controllers/project/tests/project-create-full/01-assert.yaml
+++ b/internal/controllers/project/tests/project-create-full/01-assert.yaml
@@ -4,7 +4,7 @@ kind: TestAssert
 resourceRefs:
     - apiVersion: openstack.k-orc.cloud/v1alpha1
       kind: Domain
-      name: project-dependency
+      name: project-create-full
       ref: domain
 assertAll:
     - celExpr: "domain.status.resource.enabled == false"

--- a/internal/controllers/project/tests/project-create-full/01-disable-domain.yaml
+++ b/internal/controllers/project/tests/project-create-full/01-disable-domain.yaml
@@ -1,0 +1,7 @@
+apiVersion: openstack.k-orc.cloud/v1alpha1
+kind: Domain
+metadata:
+  name: project-create-full
+spec:
+  resource:
+    enabled: false

--- a/internal/controllers/project/tests/project-create-full/README.md
+++ b/internal/controllers/project/tests/project-create-full/README.md
@@ -6,6 +6,12 @@ Create a project using all available fields, and verify that the observed state 
 
 Also validate that the OpenStack resource uses the name from the spec when it is specified.
 
+## Step 01
+
+By default the enabled field is set to true, the enabled field needs to be disabled.
+
+Disabling the Domain is required before deletion in Openstack.
+
 ## Reference
 
 https://k-orc.cloud/development/writing-tests/#create-full

--- a/internal/controllers/project/tests/project-dependency/00-assert.yaml
+++ b/internal/controllers/project/tests/project-dependency/00-assert.yaml
@@ -13,3 +13,18 @@ status:
       message: Waiting for Secret/project-dependency to be created
       status: "True"
       reason: Progressing
+---
+apiVersion: openstack.k-orc.cloud/v1alpha1
+kind: Project
+metadata:
+  name: project-dependency-no-domain
+status:
+  conditions:
+    - type: Available
+      message: Waiting for Domain/project-dependency to be created
+      status: "False"
+      reason: Progressing
+    - type: Progressing
+      message: Waiting for Domain/project-dependency to be created
+      status: "True"
+      reason: Progressing

--- a/internal/controllers/project/tests/project-dependency/00-create-resources-missing-deps.yaml
+++ b/internal/controllers/project/tests/project-dependency/00-create-resources-missing-deps.yaml
@@ -2,6 +2,18 @@
 apiVersion: openstack.k-orc.cloud/v1alpha1
 kind: Project
 metadata:
+  name: project-dependency-no-domain
+spec:
+  cloudCredentialsRef:
+    cloudName: openstack-admin
+    secretName: openstack-clouds
+  managementPolicy: managed
+  resource:
+    domainRef: project-dependency
+---
+apiVersion: openstack.k-orc.cloud/v1alpha1
+kind: Project
+metadata:
   name: project-dependency-no-secret
 spec:
   cloudCredentialsRef:

--- a/internal/controllers/project/tests/project-dependency/00-secret.yaml
+++ b/internal/controllers/project/tests/project-dependency/00-secret.yaml
@@ -1,0 +1,6 @@
+---
+apiVersion: kuttl.dev/v1beta1
+kind: TestStep
+commands:
+  - command: kubectl create secret generic openstack-clouds --from-file=clouds.yaml=${E2E_KUTTL_OSCLOUDS} ${E2E_KUTTL_CACERT_OPT}
+    namespaced: true

--- a/internal/controllers/project/tests/project-dependency/01-assert.yaml
+++ b/internal/controllers/project/tests/project-dependency/01-assert.yaml
@@ -13,3 +13,32 @@ status:
       message: OpenStack resource is up to date
       status: "False"
       reason: Success
+---
+apiVersion: openstack.k-orc.cloud/v1alpha1
+kind: Project
+metadata:
+  name: project-dependency-no-domain
+status:
+  conditions:
+    - type: Available
+      message: OpenStack resource is available
+      status: "True"
+      reason: Success
+    - type: Progressing
+      message: OpenStack resource is up to date
+      status: "False"
+      reason: Success
+---
+apiVersion: kuttl.dev/v1beta1
+kind: TestAssert
+resourceRefs:
+    - apiVersion: openstack.k-orc.cloud/v1alpha1
+      kind: Project
+      name: project-dependency-no-domain
+      ref: project
+    - apiVersion: openstack.k-orc.cloud/v1alpha1
+      kind: Domain
+      name: project-dependency
+      ref: domain
+assertAll:
+    - celExpr: "project.status.resource.domainID == domain.status.id"

--- a/internal/controllers/project/tests/project-dependency/01-create-dependencies.yaml
+++ b/internal/controllers/project/tests/project-dependency/01-create-dependencies.yaml
@@ -1,5 +1,17 @@
+---
 apiVersion: kuttl.dev/v1beta1
 kind: TestStep
 commands:
   - command: kubectl create secret generic project-dependency --from-file=clouds.yaml=${E2E_KUTTL_OSCLOUDS} ${E2E_KUTTL_CACERT_OPT}
     namespaced: true
+---
+apiVersion: openstack.k-orc.cloud/v1alpha1
+kind: Domain
+metadata:
+  name: project-dependency
+spec:
+  cloudCredentialsRef:
+    cloudName: openstack-admin
+    secretName: openstack-clouds
+  managementPolicy: managed
+  resource: {}

--- a/internal/controllers/project/tests/project-dependency/02-disable-domain.yaml
+++ b/internal/controllers/project/tests/project-dependency/02-disable-domain.yaml
@@ -1,0 +1,8 @@
+---
+apiVersion: openstack.k-orc.cloud/v1alpha1
+kind: Domain
+metadata:
+  name: project-dependency
+spec:
+  resource:
+    enabled: false

--- a/internal/controllers/project/tests/project-dependency/03-assert.yaml
+++ b/internal/controllers/project/tests/project-dependency/03-assert.yaml
@@ -1,6 +1,17 @@
+---
 apiVersion: kuttl.dev/v1beta1
 kind: TestAssert
-commands:
-# Dependencies that were prevented deletion before should now be gone
-- script: "! kubectl get secret project-dependency --namespace $NAMESPACE"
-  skipLogOutput: true
+resourceRefs:
+    - apiVersion: openstack.k-orc.cloud/v1alpha1
+      kind: Domain
+      name: project-dependency
+      ref: domain
+    - apiVersion: v1
+      kind: Secret
+      name: project-dependency
+      ref: secret
+assertAll:
+    - celExpr: "domain.metadata.deletionTimestamp != 0"
+    - celExpr: "'openstack.k-orc.cloud/project' in domain.metadata.finalizers"
+    - celExpr: "secret.metadata.deletionTimestamp != 0"
+    - celExpr: "'openstack.k-orc.cloud/project' in secret.metadata.finalizers"

--- a/internal/controllers/project/tests/project-dependency/03-delete-dependencies.yaml
+++ b/internal/controllers/project/tests/project-dependency/03-delete-dependencies.yaml
@@ -1,6 +1,9 @@
+---
 apiVersion: kuttl.dev/v1beta1
 kind: TestStep
 commands:
   # We expect the deletion to hang due to the finalizer, so use --wait=false
+  - command: kubectl delete domain project-dependency --wait=false
+    namespaced: true
   - command: kubectl delete secret project-dependency --wait=false
     namespaced: true

--- a/internal/controllers/project/tests/project-dependency/04-assert.yaml
+++ b/internal/controllers/project/tests/project-dependency/04-assert.yaml
@@ -1,0 +1,9 @@
+---
+apiVersion: kuttl.dev/v1beta1
+kind: TestAssert
+commands:
+# Dependencies that were prevented deletion before should now be gone
+- script: "! kubectl get domain project-dependency --namespace $NAMESPACE"
+  skipLogOutput: true
+- script: "! kubectl get secret project-dependency --namespace $NAMESPACE"
+  skipLogOutput: true

--- a/internal/controllers/project/tests/project-dependency/04-delete-resources.yaml
+++ b/internal/controllers/project/tests/project-dependency/04-delete-resources.yaml
@@ -1,6 +1,10 @@
+---
 apiVersion: kuttl.dev/v1beta1
 kind: TestStep
 delete:
 - apiVersion: openstack.k-orc.cloud/v1alpha1
   kind: Project
   name: project-dependency-no-secret
+- apiVersion: openstack.k-orc.cloud/v1alpha1
+  kind: Project
+  name: project-dependency-no-domain

--- a/internal/controllers/project/tests/project-dependency/README.md
+++ b/internal/controllers/project/tests/project-dependency/README.md
@@ -10,9 +10,13 @@ Create the missing dependencies and make and verify all the projects are availab
 
 ## Step 02
 
-Delete all the dependencies and check that ORC prevents deletion since there is still a resource that depends on them.
+Disable the domain dependency to allow KUTTL to cleanup resources without any issues.
 
 ## Step 03
+
+Delete all the dependencies and check that ORC prevents deletion since there is still a resource that depends on them.
+
+## Step 04
 
 Delete the projects and validate that all resources are gone.
 

--- a/internal/controllers/project/tests/project-import-dependency/00-assert.yaml
+++ b/internal/controllers/project/tests/project-import-dependency/00-assert.yaml
@@ -1,0 +1,17 @@
+---
+apiVersion: openstack.k-orc.cloud/v1alpha1
+kind: Project
+metadata:
+  name: project-import-dependency
+status:
+  conditions:
+    - type: Available
+      message: |-
+        Waiting for Domain/project-import-dependency to be ready
+      status: "False"
+      reason: Progressing
+    - type: Progressing
+      message: |-
+        Waiting for Domain/project-import-dependency to be ready
+      status: "True"
+      reason: Progressing

--- a/internal/controllers/project/tests/project-import-dependency/00-import-resource.yaml
+++ b/internal/controllers/project/tests/project-import-dependency/00-import-resource.yaml
@@ -2,28 +2,25 @@
 apiVersion: openstack.k-orc.cloud/v1alpha1
 kind: Domain
 metadata:
-  name: project-create-full
+  name: project-import-dependency
 spec:
   cloudCredentialsRef:
     cloudName: openstack-admin
     secretName: openstack-clouds
-  managementPolicy: managed
-  resource: {}
+  managementPolicy: unmanaged
+  import:
+    filter:
+      name: project-import-dependency-external
 ---
 apiVersion: openstack.k-orc.cloud/v1alpha1
 kind: Project
 metadata:
-  name: project-create-full
+  name: project-import-dependency
 spec:
   cloudCredentialsRef:
     cloudName: openstack-admin
     secretName: openstack-clouds
-  managementPolicy: managed
-  resource:
-    name: project-create-full-override
-    description: Project from "create full" test
-    domainRef: project-create-full
-    enabled: false
-    tags:
-      - tag1
-      - tag2
+  managementPolicy: unmanaged
+  import:
+    filter:
+      domainRef: project-import-dependency

--- a/internal/controllers/project/tests/project-import-dependency/00-secret.yaml
+++ b/internal/controllers/project/tests/project-import-dependency/00-secret.yaml
@@ -1,0 +1,6 @@
+---
+apiVersion: kuttl.dev/v1beta1
+kind: TestStep
+commands:
+  - command: kubectl create secret generic openstack-clouds --from-file=clouds.yaml=${E2E_KUTTL_OSCLOUDS} ${E2E_KUTTL_CACERT_OPT}
+    namespaced: true

--- a/internal/controllers/project/tests/project-import-dependency/01-assert.yaml
+++ b/internal/controllers/project/tests/project-import-dependency/01-assert.yaml
@@ -1,0 +1,32 @@
+---
+apiVersion: openstack.k-orc.cloud/v1alpha1
+kind: Project
+metadata:
+  name: project-import-dependency-not-this-one
+status:
+  conditions:
+    - type: Available
+      message: OpenStack resource is available
+      status: "True"
+      reason: Success
+    - type: Progressing
+      message: OpenStack resource is up to date
+      status: "False"
+      reason: Success
+---
+apiVersion: openstack.k-orc.cloud/v1alpha1
+kind: Project
+metadata:
+  name: project-import-dependency
+status:
+  conditions:
+    - type: Available
+      message: |-
+        Waiting for Domain/project-import-dependency to be ready
+      status: "False"
+      reason: Progressing
+    - type: Progressing
+      message: |-
+        Waiting for Domain/project-import-dependency to be ready
+      status: "True"
+      reason: Progressing

--- a/internal/controllers/project/tests/project-import-dependency/01-create-trap-resource.yaml
+++ b/internal/controllers/project/tests/project-import-dependency/01-create-trap-resource.yaml
@@ -2,7 +2,7 @@
 apiVersion: openstack.k-orc.cloud/v1alpha1
 kind: Domain
 metadata:
-  name: project-create-full
+  name: project-import-dependency-not-this-one
 spec:
   cloudCredentialsRef:
     cloudName: openstack-admin
@@ -10,20 +10,15 @@ spec:
   managementPolicy: managed
   resource: {}
 ---
+# This `project-import-dependency-not-this-one` should not be picked by the import filter
 apiVersion: openstack.k-orc.cloud/v1alpha1
 kind: Project
 metadata:
-  name: project-create-full
+  name: project-import-dependency-not-this-one
 spec:
   cloudCredentialsRef:
     cloudName: openstack-admin
     secretName: openstack-clouds
   managementPolicy: managed
   resource:
-    name: project-create-full-override
-    description: Project from "create full" test
-    domainRef: project-create-full
-    enabled: false
-    tags:
-      - tag1
-      - tag2
+    domainRef: project-import-dependency-not-this-one

--- a/internal/controllers/project/tests/project-import-dependency/02-assert.yaml
+++ b/internal/controllers/project/tests/project-import-dependency/02-assert.yaml
@@ -1,0 +1,34 @@
+---
+apiVersion: kuttl.dev/v1beta1
+kind: TestAssert
+resourceRefs:
+    - apiVersion: openstack.k-orc.cloud/v1alpha1
+      kind: Project
+      name: project-import-dependency
+      ref: project1
+    - apiVersion: openstack.k-orc.cloud/v1alpha1
+      kind: Project
+      name: project-import-dependency-not-this-one
+      ref: project2
+    - apiVersion: openstack.k-orc.cloud/v1alpha1
+      kind: Domain
+      name: project-import-dependency
+      ref: domain
+assertAll:
+    - celExpr: "project1.status.id != project2.status.id"
+    - celExpr: "project1.status.resource.domainID == domain.status.id"
+---
+apiVersion: openstack.k-orc.cloud/v1alpha1
+kind: Project
+metadata:
+  name: project-import-dependency
+status:
+  conditions:
+    - type: Available
+      message: OpenStack resource is available
+      status: "True"
+      reason: Success
+    - type: Progressing
+      message: OpenStack resource is up to date
+      status: "False"
+      reason: Success

--- a/internal/controllers/project/tests/project-import-dependency/02-create-resource.yaml
+++ b/internal/controllers/project/tests/project-import-dependency/02-create-resource.yaml
@@ -2,7 +2,7 @@
 apiVersion: openstack.k-orc.cloud/v1alpha1
 kind: Domain
 metadata:
-  name: project-create-full
+  name: project-import-dependency-external
 spec:
   cloudCredentialsRef:
     cloudName: openstack-admin
@@ -13,17 +13,11 @@ spec:
 apiVersion: openstack.k-orc.cloud/v1alpha1
 kind: Project
 metadata:
-  name: project-create-full
+  name: project-import-dependency-external
 spec:
   cloudCredentialsRef:
     cloudName: openstack-admin
     secretName: openstack-clouds
   managementPolicy: managed
   resource:
-    name: project-create-full-override
-    description: Project from "create full" test
-    domainRef: project-create-full
-    enabled: false
-    tags:
-      - tag1
-      - tag2
+    domainRef: project-import-dependency-external

--- a/internal/controllers/project/tests/project-import-dependency/03-assert.yaml
+++ b/internal/controllers/project/tests/project-import-dependency/03-assert.yaml
@@ -1,0 +1,15 @@
+---
+apiVersion: kuttl.dev/v1beta1
+kind: TestAssert
+resourceRefs:
+    - apiVersion: openstack.k-orc.cloud/v1alpha1
+      kind: Domain
+      name: project-import-dependency-external
+      ref: domain1
+    - apiVersion: openstack.k-orc.cloud/v1alpha1
+      kind: Domain
+      name: project-import-dependency-not-this-one
+      ref: domain2
+assertAll:
+    - celExpr: "domain1.status.resource.enabled == false"
+    - celExpr: "domain2.status.resource.enabled == false"

--- a/internal/controllers/project/tests/project-import-dependency/03-disable-domain.yaml
+++ b/internal/controllers/project/tests/project-import-dependency/03-disable-domain.yaml
@@ -1,0 +1,16 @@
+---
+apiVersion: openstack.k-orc.cloud/v1alpha1
+kind: Domain
+metadata:
+  name: project-import-dependency-external
+spec:
+  resource:
+    enabled: false
+---
+apiVersion: openstack.k-orc.cloud/v1alpha1
+kind: Domain
+metadata:
+  name: project-import-dependency-not-this-one
+spec:
+  resource:
+    enabled: false

--- a/internal/controllers/project/tests/project-import-dependency/04-assert.yaml
+++ b/internal/controllers/project/tests/project-import-dependency/04-assert.yaml
@@ -1,0 +1,6 @@
+---
+apiVersion: kuttl.dev/v1beta1
+kind: TestAssert
+commands:
+- script: "! kubectl get domain project-import-dependency --namespace $NAMESPACE"
+  skipLogOutput: true

--- a/internal/controllers/project/tests/project-import-dependency/04-delete-import-dependencies.yaml
+++ b/internal/controllers/project/tests/project-import-dependency/04-delete-import-dependencies.yaml
@@ -1,0 +1,7 @@
+---
+apiVersion: kuttl.dev/v1beta1
+kind: TestStep
+commands:
+  # We should be able to delete the import dependencies
+  - command: kubectl delete domain project-import-dependency
+    namespaced: true

--- a/internal/controllers/project/tests/project-import-dependency/05-assert.yaml
+++ b/internal/controllers/project/tests/project-import-dependency/05-assert.yaml
@@ -1,0 +1,6 @@
+---
+apiVersion: kuttl.dev/v1beta1
+kind: TestAssert
+commands:
+- script: "! kubectl get project project-import-dependency --namespace $NAMESPACE"
+  skipLogOutput: true

--- a/internal/controllers/project/tests/project-import-dependency/05-delete-resource.yaml
+++ b/internal/controllers/project/tests/project-import-dependency/05-delete-resource.yaml
@@ -1,0 +1,7 @@
+---
+apiVersion: kuttl.dev/v1beta1
+kind: TestStep
+delete:
+  - apiVersion: openstack.k-orc.cloud/v1alpha1
+    kind: Project
+    name: project-import-dependency

--- a/internal/controllers/project/tests/project-import-dependency/README.md
+++ b/internal/controllers/project/tests/project-import-dependency/README.md
@@ -1,0 +1,33 @@
+# Check dependency handling for imported Project
+
+## Step 00
+
+Import a Project that references other imported resources. The referenced imported resources have no matching resources yet.
+Verify the Project is waiting for the dependency to be ready.
+
+## Step 01
+
+Create a Project matching the import filter, except for referenced resources, and verify that it's not being imported.
+
+## Step 02
+
+Create the referenced resources and a Project matching the import filters.
+
+Verify that the observed status on the imported Project corresponds to the spec of the created Project.
+
+## Step 03
+
+Delete the referenced resources and check that ORC does not prevent deletion. The OpenStack resources still exist because they
+were imported resources and we only deleted the ORC representation of it.
+
+## Step 04
+
+Delete the Project and validate that all resources are gone.
+
+## Step 05
+
+Disable the domain dependencies so KUTTL can clean the resources without failing.
+
+## Reference
+
+https://k-orc.cloud/development/writing-tests/#import-dependency

--- a/pkg/clients/applyconfiguration/api/v1alpha1/projectfilter.go
+++ b/pkg/clients/applyconfiguration/api/v1alpha1/projectfilter.go
@@ -25,7 +25,8 @@ import (
 // ProjectFilterApplyConfiguration represents a declarative configuration of the ProjectFilter type for use
 // with apply.
 type ProjectFilterApplyConfiguration struct {
-	Name                                   *apiv1alpha1.KeystoneName `json:"name,omitempty"`
+	Name                                   *apiv1alpha1.KeystoneName      `json:"name,omitempty"`
+	DomainRef                              *apiv1alpha1.KubernetesNameRef `json:"domainRef,omitempty"`
 	FilterByKeystoneTagsApplyConfiguration `json:",inline"`
 }
 
@@ -40,6 +41,14 @@ func ProjectFilter() *ProjectFilterApplyConfiguration {
 // If called multiple times, the Name field is set to the value of the last call.
 func (b *ProjectFilterApplyConfiguration) WithName(value apiv1alpha1.KeystoneName) *ProjectFilterApplyConfiguration {
 	b.Name = &value
+	return b
+}
+
+// WithDomainRef sets the DomainRef field in the declarative configuration to the given value
+// and returns the receiver, so that objects can be built by chaining "With" function invocations.
+// If called multiple times, the DomainRef field is set to the value of the last call.
+func (b *ProjectFilterApplyConfiguration) WithDomainRef(value apiv1alpha1.KubernetesNameRef) *ProjectFilterApplyConfiguration {
+	b.DomainRef = &value
 	return b
 }
 

--- a/pkg/clients/applyconfiguration/api/v1alpha1/projectresourcespec.go
+++ b/pkg/clients/applyconfiguration/api/v1alpha1/projectresourcespec.go
@@ -25,10 +25,11 @@ import (
 // ProjectResourceSpecApplyConfiguration represents a declarative configuration of the ProjectResourceSpec type for use
 // with apply.
 type ProjectResourceSpecApplyConfiguration struct {
-	Name        *apiv1alpha1.KeystoneName `json:"name,omitempty"`
-	Description *string                   `json:"description,omitempty"`
-	Enabled     *bool                     `json:"enabled,omitempty"`
-	Tags        []apiv1alpha1.KeystoneTag `json:"tags,omitempty"`
+	Name        *apiv1alpha1.KeystoneName      `json:"name,omitempty"`
+	Description *string                        `json:"description,omitempty"`
+	DomainRef   *apiv1alpha1.KubernetesNameRef `json:"domainRef,omitempty"`
+	Enabled     *bool                          `json:"enabled,omitempty"`
+	Tags        []apiv1alpha1.KeystoneTag      `json:"tags,omitempty"`
 }
 
 // ProjectResourceSpecApplyConfiguration constructs a declarative configuration of the ProjectResourceSpec type for use with
@@ -50,6 +51,14 @@ func (b *ProjectResourceSpecApplyConfiguration) WithName(value apiv1alpha1.Keyst
 // If called multiple times, the Description field is set to the value of the last call.
 func (b *ProjectResourceSpecApplyConfiguration) WithDescription(value string) *ProjectResourceSpecApplyConfiguration {
 	b.Description = &value
+	return b
+}
+
+// WithDomainRef sets the DomainRef field in the declarative configuration to the given value
+// and returns the receiver, so that objects can be built by chaining "With" function invocations.
+// If called multiple times, the DomainRef field is set to the value of the last call.
+func (b *ProjectResourceSpecApplyConfiguration) WithDomainRef(value apiv1alpha1.KubernetesNameRef) *ProjectResourceSpecApplyConfiguration {
+	b.DomainRef = &value
 	return b
 }
 

--- a/pkg/clients/applyconfiguration/api/v1alpha1/projectresourcestatus.go
+++ b/pkg/clients/applyconfiguration/api/v1alpha1/projectresourcestatus.go
@@ -23,6 +23,7 @@ package v1alpha1
 type ProjectResourceStatusApplyConfiguration struct {
 	Name        *string  `json:"name,omitempty"`
 	Description *string  `json:"description,omitempty"`
+	DomainID    *string  `json:"domainID,omitempty"`
 	Enabled     *bool    `json:"enabled,omitempty"`
 	Tags        []string `json:"tags,omitempty"`
 }
@@ -46,6 +47,14 @@ func (b *ProjectResourceStatusApplyConfiguration) WithName(value string) *Projec
 // If called multiple times, the Description field is set to the value of the last call.
 func (b *ProjectResourceStatusApplyConfiguration) WithDescription(value string) *ProjectResourceStatusApplyConfiguration {
 	b.Description = &value
+	return b
+}
+
+// WithDomainID sets the DomainID field in the declarative configuration to the given value
+// and returns the receiver, so that objects can be built by chaining "With" function invocations.
+// If called multiple times, the DomainID field is set to the value of the last call.
+func (b *ProjectResourceStatusApplyConfiguration) WithDomainID(value string) *ProjectResourceStatusApplyConfiguration {
+	b.DomainID = &value
 	return b
 }
 

--- a/pkg/clients/applyconfiguration/internal/internal.go
+++ b/pkg/clients/applyconfiguration/internal/internal.go
@@ -1737,6 +1737,9 @@ var schemaYAML = typed.YAMLObject(`types:
 - name: com.github.k-orc.openstack-resource-controller.v2.api.v1alpha1.ProjectFilter
   map:
     fields:
+    - name: domainRef
+      type:
+        scalar: string
     - name: name
       type:
         scalar: string
@@ -1779,6 +1782,9 @@ var schemaYAML = typed.YAMLObject(`types:
     - name: description
       type:
         scalar: string
+    - name: domainRef
+      type:
+        scalar: string
     - name: enabled
       type:
         scalar: boolean
@@ -1795,6 +1801,9 @@ var schemaYAML = typed.YAMLObject(`types:
   map:
     fields:
     - name: description
+      type:
+        scalar: string
+    - name: domainID
       type:
         scalar: string
     - name: enabled

--- a/test/apivalidations/project_test.go
+++ b/test/apivalidations/project_test.go
@@ -106,4 +106,16 @@ var _ = Describe("ORC Project API validations", func() {
 			WithTags("foo", "bar"))
 		Expect(applyObj(ctx, project, patch)).To(Succeed())
 	})
+
+	It("should have immutable domainRef", func(ctx context.Context) {
+		project := projectStub(namespace)
+		patch := baseProjectPatch(project)
+		patch.Spec.WithResource(applyconfigv1alpha1.ProjectResourceSpec().
+			WithDomainRef("domain-a"))
+		Expect(applyObj(ctx, project, patch)).To(Succeed())
+
+		patch.Spec.WithResource(applyconfigv1alpha1.ProjectResourceSpec().
+			WithDomainRef("domain-b"))
+		Expect(applyObj(ctx, project, patch)).To(MatchError(ContainSubstring("domainRef is immutable")))
+	})
 })

--- a/website/docs/crd-reference.md
+++ b/website/docs/crd-reference.md
@@ -1927,6 +1927,8 @@ _Appears in:_
 - [NetworkResourceSpec](#networkresourcespec)
 - [PortFilter](#portfilter)
 - [PortResourceSpec](#portresourcespec)
+- [ProjectFilter](#projectfilter)
+- [ProjectResourceSpec](#projectresourcespec)
 - [RoleFilter](#rolefilter)
 - [RoleResourceSpec](#roleresourcespec)
 - [RouterFilter](#routerfilter)
@@ -2631,6 +2633,7 @@ _Appears in:_
 | Field | Description | Default | Validation |
 | --- | --- | --- | --- |
 | `name` _[KeystoneName](#keystonename)_ | name of the existing resource |  | MaxLength: 64 <br />MinLength: 1 <br />Optional: \{\} <br /> |
+| `domainRef` _[KubernetesNameRef](#kubernetesnameref)_ | domainRef is a reference to the ORC Domain which this resource is associated with. |  | MaxLength: 253 <br />MinLength: 1 <br />Optional: \{\} <br /> |
 | `tags` _[KeystoneTag](#keystonetag) array_ | tags is a list of tags to filter by. If specified, the resource must<br />have all of the tags specified to be included in the result. |  | MaxItems: 80 <br />MaxLength: 255 <br />MinLength: 1 <br />Optional: \{\} <br /> |
 | `tagsAny` _[KeystoneTag](#keystonetag) array_ | tagsAny is a list of tags to filter by. If specified, the resource<br />must have at least one of the tags specified to be included in the<br />result. |  | MaxItems: 80 <br />MaxLength: 255 <br />MinLength: 1 <br />Optional: \{\} <br /> |
 | `notTags` _[KeystoneTag](#keystonetag) array_ | notTags is a list of tags to filter by. If specified, resources which<br />contain all of the given tags will be excluded from the result. |  | MaxItems: 80 <br />MaxLength: 255 <br />MinLength: 1 <br />Optional: \{\} <br /> |
@@ -2672,6 +2675,7 @@ _Appears in:_
 | --- | --- | --- | --- |
 | `name` _[KeystoneName](#keystonename)_ | name will be the name of the created resource. If not specified, the<br />name of the ORC object will be used. |  | MaxLength: 64 <br />MinLength: 1 <br />Optional: \{\} <br /> |
 | `description` _string_ | description contains a free form description of the project. |  | MaxLength: 65535 <br />MinLength: 1 <br />Optional: \{\} <br /> |
+| `domainRef` _[KubernetesNameRef](#kubernetesnameref)_ | domainRef is a reference to the ORC Domain which this resource is associated with. |  | MaxLength: 253 <br />MinLength: 1 <br />Optional: \{\} <br /> |
 | `enabled` _boolean_ | enabled defines whether a project is enabled or not. Default is true. |  | Optional: \{\} <br /> |
 | `tags` _[KeystoneTag](#keystonetag) array_ | tags is list of simple strings assigned to a project.<br />Tags can be used to classify projects into groups. |  | MaxItems: 80 <br />MaxLength: 255 <br />MinLength: 1 <br />Optional: \{\} <br /> |
 
@@ -2691,6 +2695,7 @@ _Appears in:_
 | --- | --- | --- | --- |
 | `name` _string_ | name is a Human-readable name for the project. Might not be unique. |  | MaxLength: 1024 <br />Optional: \{\} <br /> |
 | `description` _string_ | description is a human-readable description for the resource. |  | MaxLength: 65535 <br />Optional: \{\} <br /> |
+| `domainID` _string_ | domainID is the ID of the Domain to which the resource is associated. |  | MaxLength: 1024 <br />Optional: \{\} <br /> |
 | `enabled` _boolean_ | enabled represents whether a project is enabled or not. |  | Optional: \{\} <br /> |
 | `tags` _string array_ | tags is the list of tags on the resource. |  | MaxItems: 80 <br />items:MaxLength: 1024 <br />Optional: \{\} <br /> |
 


### PR DESCRIPTION
Allow users to specify which Keystone domain a Project should be created under by adding a `domainRef` field to the spec and filter. The domain is is now returned in the project status as well.

Fixes https://github.com/k-orc/openstack-resource-controller/issues/739.