### PR TITLE
CI: Fix floating version tag comments in GitHub Actions workflows

### DIFF
--- a/.github/workflows/container_image.yaml
+++ b/.github/workflows/container_image.yaml
@@ -25,7 +25,7 @@ jobs:
         fetch-tags: true
         persist-credentials: false
     - name: Set up Docker Buildx
-      uses: docker/setup-buildx-action@4d04d5d9486b7bd6fa91e7baf45bbb4f8b9deedd # tag=v4
+      uses: docker/setup-buildx-action@4d04d5d9486b7bd6fa91e7baf45bbb4f8b9deedd # tag=v4.0.0
 
     - name: Build and push images
       run: |

--- a/.github/workflows/e2e.yaml
+++ b/.github/workflows/e2e.yaml
@@ -68,7 +68,7 @@ jobs:
 
     - name: Upload logs artifacts on failure
       if: failure()
-      uses: actions/upload-artifact@bbbca2ddaa5d8feaa63e36b76fdaad77386f024f # tag=v7
+      uses: actions/upload-artifact@bbbca2ddaa5d8feaa63e36b76fdaad77386f024f # tag=v7.0.0
       with:
         name: e2e-${{ matrix.name }}-${{ github.run_id }}
         path: /tmp/artifacts/*

--- a/.github/workflows/ensure-labels.yaml
+++ b/.github/workflows/ensure-labels.yaml
@@ -16,7 +16,7 @@ jobs:
       - uses: actions/checkout@de0fac2e4500dabe0009e67214ff5f5447ce83dd # tag=v6.0.2
         with:
           persist-credentials: false
-      - uses: micnncim/action-label-syncer@3abd5ab72fda571e69fffd97bd4e0033dd5f495c # tag=v1
+      - uses: micnncim/action-label-syncer@3abd5ab72fda571e69fffd97bd4e0033dd5f495c # tag=v1.3.0
         env:
           GITHUB_TOKEN: ${{ secrets.GITHUB_TOKEN }}
         with:

--- a/.github/workflows/label-pr.yaml
+++ b/.github/workflows/label-pr.yaml
@@ -81,4 +81,4 @@ jobs:
       contents: read
       pull-requests: write
     steps:
-    - uses: actions/labeler@634933edcd8ababfe52f92936142cc22ac488b1b # tag=v6
+    - uses: actions/labeler@634933edcd8ababfe52f92936142cc22ac488b1b # tag=v6.0.1

--- a/.github/workflows/release_image.yaml
+++ b/.github/workflows/release_image.yaml
@@ -25,7 +25,7 @@ jobs:
         fetch-tags: true
         persist-credentials: false
     - name: Set up Docker Buildx
-      uses: docker/setup-buildx-action@4d04d5d9486b7bd6fa91e7baf45bbb4f8b9deedd # tag=v4
+      uses: docker/setup-buildx-action@4d04d5d9486b7bd6fa91e7baf45bbb4f8b9deedd # tag=v4.0.0
     - name: Install build dependencies
       run: sudo apt-get install -y libgpgme-dev
 

--- a/.github/workflows/semver.yaml
+++ b/.github/workflows/semver.yaml
@@ -62,7 +62,7 @@ jobs:
 
     - name: Upload semver results
       if: always()
-      uses: actions/upload-artifact@bbbca2ddaa5d8feaa63e36b76fdaad77386f024f # tag=v7
+      uses: actions/upload-artifact@bbbca2ddaa5d8feaa63e36b76fdaad77386f024f # tag=v7.0.0
       with:
         name: semver-results
         path: semver-results/

--- a/.github/workflows/website.yaml
+++ b/.github/workflows/website.yaml
@@ -28,7 +28,7 @@ jobs:
       run: mkdocs build --verbose --strict --config-file website/mkdocs.yml --site-dir rendered
 
     - name: Publish to Cloudflare Pages
-      uses: cloudflare/pages-action@f0a1cd58cd66095dee69bfa18fa5efd1dde93bca # tag=v1
+      uses: cloudflare/pages-action@f0a1cd58cd66095dee69bfa18fa5efd1dde93bca # tag=v1.5.0
       with:
         apiToken: ${{ secrets.CLOUDFLARE_API_TOKEN }} # zizmor: ignore[secrets-outside-env]
         accountId: ${{ secrets.CLOUDFLARE_ACCOUNT_ID }} # zizmor: ignore[secrets-outside-env]


### PR DESCRIPTION
Consistently use precise version tags instead of floating major version tags.