### PR TITLE
Neutron: add filtering trunk resources by status

### DIFF
--- a/api/v1alpha1/trunk_types.go
+++ b/api/v1alpha1/trunk_types.go
@@ -113,8 +113,10 @@ type TrunkFilter struct {
 	// +optional
 	ProjectRef *KubernetesNameRef `json:"projectRef,omitempty"`
 
-	// Contrary to what the neutron doc say, we can't filter by status
-	// https://github.com/gophercloud/gophercloud/issues/3626
+	// status indicates the trunk state to use as a filter.
+	// +kubebuilder:validation:MaxLength=64
+	// +optional
+	Status string `json:"status,omitempty"`
 
 	// adminStateUp is the administrative state of the trunk.
 	// +optional

--- a/cmd/models-schema/zz_generated.openapi.go
+++ b/cmd/models-schema/zz_generated.openapi.go
@@ -10643,6 +10643,13 @@ func schema_openstack_resource_controller_v2_api_v1alpha1_TrunkFilter(ref common
 							Format:      "",
 						},
 					},
+					"status": {
+						SchemaProps: spec.SchemaProps{
+							Description: "status indicates the trunk state to use as a filter.",
+							Type:        []string{"string"},
+							Format:      "",
+						},
+					},
 					"adminStateUp": {
 						SchemaProps: spec.SchemaProps{
 							Description: "adminStateUp is the administrative state of the trunk.",

--- a/cmd/models-schema/zz_generated.openapi.go
+++ b/cmd/models-schema/zz_generated.openapi.go
@@ -12573,6 +12573,13 @@ func schema_openstack_resource_controller_v2_api_v1alpha1_TrunkFilter(ref common
 							Format:      "",
 						},
 					},
+					"status": {
+						SchemaProps: spec.SchemaProps{
+							Description: "status indicates the trunk state to use as a filter.",
+							Type:        []string{"string"},
+							Format:      "",
+						},
+					},
 					"adminStateUp": {
 						SchemaProps: spec.SchemaProps{
 							Description: "adminStateUp is the administrative state of the trunk.",

--- a/config/crd/bases/openstack.k-orc.cloud_trunks.yaml
+++ b/config/crd/bases/openstack.k-orc.cloud_trunks.yaml
@@ -146,6 +146,11 @@ spec:
                         maxLength: 253
                         minLength: 1
                         type: string
+                      status:
+                        description: status indicates the trunk state to use as a
+                          filter.
+                        maxLength: 64
+                        type: string
                       tags:
                         description: |-
                           tags is a list of tags to filter by. If specified, the resource must

--- a/internal/controllers/trunk/actuator.go
+++ b/internal/controllers/trunk/actuator.go
@@ -137,6 +137,7 @@ func (actuator trunkActuator) ListOSResourcesForImport(ctx context.Context, obj 
 		PortID:       ptr.Deref(port.Status.ID, ""),
 		ProjectID:    ptr.Deref(project.Status.ID, ""),
 		AdminStateUp: filter.AdminStateUp,
+		Status:       filter.Status,
 		Tags:         tags.Join(filter.Tags),
 		TagsAny:      tags.Join(filter.TagsAny),
 		NotTags:      tags.Join(filter.NotTags),

--- a/internal/controllers/trunk/actuator.go
+++ b/internal/controllers/trunk/actuator.go
@@ -108,6 +108,7 @@ func (actuator trunkActuator) ListOSResourcesForImport(ctx context.Context, obj 
 		PortID:       ptr.Deref(port.Status.ID, ""),
 		ProjectID:    ptr.Deref(project.Status.ID, ""),
 		AdminStateUp: filter.AdminStateUp,
+		Status:       filter.Status,
 		Tags:         tags.Join(filter.Tags),
 		TagsAny:      tags.Join(filter.TagsAny),
 		NotTags:      tags.Join(filter.NotTags),

--- a/internal/controllers/trunk/tests/trunk-import/00-import-resource.yaml
+++ b/internal/controllers/trunk/tests/trunk-import/00-import-resource.yaml
@@ -12,6 +12,7 @@ spec:
     filter:
       name: trunk-import-external
       description: Trunk trunk-import-external from "trunk-import" test
+      status: ACTIVE
       adminStateUp: true
       tags:
         - trunk-import-tag

--- a/pkg/clients/applyconfiguration/api/v1alpha1/trunkfilter.go
+++ b/pkg/clients/applyconfiguration/api/v1alpha1/trunkfilter.go
@@ -29,6 +29,7 @@ type TrunkFilterApplyConfiguration struct {
 	Description                           *apiv1alpha1.NeutronDescription `json:"description,omitempty"`
 	PortRef                               *apiv1alpha1.KubernetesNameRef  `json:"portRef,omitempty"`
 	ProjectRef                            *apiv1alpha1.KubernetesNameRef  `json:"projectRef,omitempty"`
+	Status                                *string                         `json:"status,omitempty"`
 	AdminStateUp                          *bool                           `json:"adminStateUp,omitempty"`
 	FilterByNeutronTagsApplyConfiguration `json:",inline"`
 }
@@ -68,6 +69,14 @@ func (b *TrunkFilterApplyConfiguration) WithPortRef(value apiv1alpha1.Kubernetes
 // If called multiple times, the ProjectRef field is set to the value of the last call.
 func (b *TrunkFilterApplyConfiguration) WithProjectRef(value apiv1alpha1.KubernetesNameRef) *TrunkFilterApplyConfiguration {
 	b.ProjectRef = &value
+	return b
+}
+
+// WithStatus sets the Status field in the declarative configuration to the given value
+// and returns the receiver, so that objects can be built by chaining "With" function invocations.
+// If called multiple times, the Status field is set to the value of the last call.
+func (b *TrunkFilterApplyConfiguration) WithStatus(value string) *TrunkFilterApplyConfiguration {
+	b.Status = &value
 	return b
 }
 

--- a/pkg/clients/applyconfiguration/internal/internal.go
+++ b/pkg/clients/applyconfiguration/internal/internal.go
@@ -3199,6 +3199,9 @@ var schemaYAML = typed.YAMLObject(`types:
     - name: projectRef
       type:
         scalar: string
+    - name: status
+      type:
+        scalar: string
     - name: tags
       type:
         list:

--- a/pkg/clients/applyconfiguration/internal/internal.go
+++ b/pkg/clients/applyconfiguration/internal/internal.go
@@ -3865,6 +3865,9 @@ var schemaYAML = typed.YAMLObject(`types:
     - name: projectRef
       type:
         scalar: string
+    - name: status
+      type:
+        scalar: string
     - name: tags
       type:
         list:

--- a/website/docs/crd-reference.md
+++ b/website/docs/crd-reference.md
@@ -4194,6 +4194,7 @@ _Appears in:_
 | `description` _[NeutronDescription](#neutrondescription)_ | description of the existing resource |  | MaxLength: 255 <br />MinLength: 1 <br />Optional: \{\} <br /> |
 | `portRef` _[KubernetesNameRef](#kubernetesnameref)_ | portRef is a reference to the ORC Port which this resource is associated with. |  | MaxLength: 253 <br />MinLength: 1 <br />Optional: \{\} <br /> |
 | `projectRef` _[KubernetesNameRef](#kubernetesnameref)_ | projectRef is a reference to the ORC Project which this resource is associated with. |  | MaxLength: 253 <br />MinLength: 1 <br />Optional: \{\} <br /> |
+| `status` _string_ | status indicates the trunk state to use as a filter. |  | MaxLength: 64 <br />Optional: \{\} <br /> |
 | `adminStateUp` _boolean_ | adminStateUp is the administrative state of the trunk. |  | Optional: \{\} <br /> |
 | `tags` _[NeutronTag](#neutrontag) array_ | tags is a list of tags to filter by. If specified, the resource must<br />have all of the tags specified to be included in the result. |  | MaxItems: 64 <br />MaxLength: 255 <br />MinLength: 1 <br />Optional: \{\} <br /> |
 | `tagsAny` _[NeutronTag](#neutrontag) array_ | tagsAny is a list of tags to filter by. If specified, the resource<br />must have at least one of the tags specified to be included in the<br />result. |  | MaxItems: 64 <br />MaxLength: 255 <br />MinLength: 1 <br />Optional: \{\} <br /> |

--- a/website/docs/crd-reference.md
+++ b/website/docs/crd-reference.md
@@ -4865,6 +4865,7 @@ _Appears in:_
 | `description` _[NeutronDescription](#neutrondescription)_ | description of the existing resource |  | MaxLength: 255 <br />MinLength: 1 <br />Optional: \{\} <br /> |
 | `portRef` _[KubernetesNameRef](#kubernetesnameref)_ | portRef is a reference to the ORC Port which this resource is associated with. |  | MaxLength: 253 <br />MinLength: 1 <br />Optional: \{\} <br /> |
 | `projectRef` _[KubernetesNameRef](#kubernetesnameref)_ | projectRef is a reference to the ORC Project which this resource is associated with. |  | MaxLength: 253 <br />MinLength: 1 <br />Optional: \{\} <br /> |
+| `status` _string_ | status indicates the trunk state to use as a filter. |  | MaxLength: 64 <br />Optional: \{\} <br /> |
 | `adminStateUp` _boolean_ | adminStateUp is the administrative state of the trunk. |  | Optional: \{\} <br /> |
 | `tags` _[NeutronTag](#neutrontag) array_ | tags is a list of tags to filter by. If specified, the resource must<br />have all of the tags specified to be included in the result. |  | MaxItems: 64 <br />MaxLength: 255 <br />MinLength: 1 <br />Optional: \{\} <br /> |
 | `tagsAny` _[NeutronTag](#neutrontag) array_ | tagsAny is a list of tags to filter by. If specified, the resource<br />must have at least one of the tags specified to be included in the<br />result. |  | MaxItems: 64 <br />MaxLength: 255 <br />MinLength: 1 <br />Optional: \{\} <br /> |


### PR DESCRIPTION
This PR adds support for filtering Trunk ports by their status. 

Fixes: #746 