### PR TITLE
Add CI and GitHub configuration for release-2.0 branch

### DIFF
--- a/.github/dependabot.yml
+++ b/.github/dependabot.yml
@@ -84,3 +84,44 @@ updates:
   - dependency-name: "k8s.io/*"
     update-types: ["version-update:semver-major", "version-update:semver-minor"]
 ## release-1.0 branch config ends here
+## release-2.0 branch config starts here
+# github-actions
+- directory: "/"
+  package-ecosystem: "github-actions"
+  schedule:
+    interval: "weekly"
+    day: "monday"
+  cooldown:
+    default-days: 7
+  target-branch: release-2.0
+  groups:
+    all-github-actions:
+      patterns: [ "*" ]
+  commit-message:
+    prefix: ":seedling:"
+    include: scope
+# Go directories
+- directories:
+  - "/"
+  package-ecosystem: "gomod"
+  schedule:
+    interval: "weekly"
+    day: "monday"
+  cooldown:
+    default-days: 7
+  target-branch: release-2.0
+  groups:
+    all-go-mod-patch-and-minor:
+      patterns: [ "*" ]
+      update-types: [ "patch", "minor" ]
+  commit-message:
+    prefix: ":seedling:"
+    include: scope
+  ignore:
+  # Ignore controller-runtime major and minor bumps as its upgraded manually.
+  - dependency-name: "sigs.k8s.io/controller-runtime"
+    update-types: ["version-update:semver-major", "version-update:semver-minor"]
+  # Ignore k8s major and minor bumps and its transitives modules
+  - dependency-name: "k8s.io/*"
+    update-types: ["version-update:semver-major", "version-update:semver-minor"]
+## release-2.0 branch config ends here

--- a/.github/labeler.yml
+++ b/.github/labeler.yml
@@ -1,2 +1,4 @@
 v1.0:
 - base-branch: 'release-1.0'
+v2.0:
+- base-branch: 'release-2.0'

--- a/.github/labels.yaml
+++ b/.github/labels.yaml
@@ -4,6 +4,12 @@
 - color: '30ABB9'
   description: This PR targets v1.0
   name: v1.0
+- color: 'D97706'
+  description: This PR will be backported to v2.0
+  name: backport-v2.0
+- color: 'D97706'
+  description: This PR targets v2.0
+  name: v2.0
 
 - color: 'BCF611'
   description: A good issue for first-time contributors

--- a/.github/workflows/backport.yaml
+++ b/.github/workflows/backport.yaml
@@ -69,3 +69,62 @@ jobs:
           NUMBER: ${{ github.event.pull_request.number }}
           BODY: >
             Labels `semver:major` and `semver:minor` block backports to the branch `release-1.0`.
+
+  backport_v2_0:
+    name: "Backport to v2.0"
+    # Only react to merged PRs for security reasons.
+    # See https://docs.github.com/en/actions/using-workflows/events-that-trigger-workflows#pull_request_target.
+    if: >
+      github.event.pull_request.merged
+      && (
+        github.event.action == 'closed'
+          && contains(github.event.pull_request.labels.*.name, 'backport-v2.0')
+        || (
+          github.event.action == 'labeled'
+          && contains(github.event.label.name, 'backport-v2.0')
+        )
+      )
+    runs-on: ubuntu-latest
+    steps:
+      - name: Generate a token from the orc-backport-bot github-app
+        id: generate_token
+        uses: getsentry/action-github-app-token@5c1e90706fe007857338ac1bfbd7a4177db2f789 # tag=v4.0.0
+        with:
+          app_id: ${{ secrets.BACKPORT_APP_ID }} # zizmor: ignore[secrets-outside-env]
+          private_key: ${{ secrets.BACKPORT_APP_PRIVATE_KEY }} # zizmor: ignore[secrets-outside-env]
+
+      - name: Backporting
+        if: >
+          contains(github.event.pull_request.labels.*.name, 'semver:patch')
+          || contains(github.event.pull_request.labels.*.name, 'semver:minor')
+          || contains(github.event.label.name, 'semver:patch')
+          || contains(github.event.label.name, 'semver:minor')
+        uses: kiegroup/git-backporting@08da0b07ef2330d189f6074ec8db736b3aa9f465 # tag=v4.9.1
+        with:
+          target-branch: release-2.0
+          pull-request: ${{ github.event.pull_request.url }}
+          auth: ${{ steps.generate_token.outputs.token }}
+          no-squash: true
+          strategy-option: find-renames
+
+      - name: Report failure
+        if: failure()
+        run: gh issue comment "$NUMBER" --body "$BODY"
+        env:
+          GH_TOKEN: ${{ secrets.GITHUB_TOKEN }}
+          GH_REPO: ${{ github.repository }}
+          NUMBER: ${{ github.event.pull_request.number }}
+          BODY: >
+            Failed to backport PR to `release-2.0` branch. See [logs](${{ github.server_url }}/${{ github.repository }}/actions/runs/${{ github.run_id }}) for details.
+
+      - name: Report an error if backport unsupported labels
+        if: >
+          contains(github.event.pull_request.labels.*.name, 'semver:major')
+          || contains(github.event.label.name, 'semver:major')
+        run: gh pr comment "$NUMBER" --body "$BODY"
+        env:
+          GH_TOKEN: ${{ secrets.GITHUB_TOKEN }}
+          GH_REPO: ${{ github.repository }}
+          NUMBER: ${{ github.event.pull_request.number }}
+          BODY: >
+            Label `semver:major` blocks backports to the branch `release-2.0`.

--- a/.github/workflows/weekly-security-scan.yaml
+++ b/.github/workflows/weekly-security-scan.yaml
@@ -13,7 +13,7 @@ jobs:
     strategy:
       fail-fast: false
       matrix:
-        branch: [main, release-1.0]
+        branch: [main, release-1.0, release-2.0]
     name: Trivy
     runs-on: ubuntu-latest
     steps:


### PR DESCRIPTION
Add backport workflow job, dependabot config, labels, auto-labeling rules, and weekly security scans for the new release-2.0 branch.