### PR TITLE
Tighten adoption filters

### DIFF
--- a/internal/controllers/addressscope/actuator.go
+++ b/internal/controllers/addressscope/actuator.go
@@ -71,8 +71,25 @@ func (actuator addressscopeActuator) ListOSResourcesForAdoption(ctx context.Cont
 		return nil, false
 	}
 
+	// Resolve the project ID from ProjectRef if set.
+	var projectID string
+	if resourceSpec.ProjectRef != nil {
+		project, rs := dependency.FetchDependency(
+			ctx, actuator.k8sClient, orcObject.Namespace, resourceSpec.ProjectRef, "Project",
+			func(dep *orcv1alpha1.Project) bool {
+				return orcv1alpha1.IsAvailable(dep) && dep.Status.ID != nil
+			},
+		)
+		if needsReschedule, _ := rs.NeedsReschedule(); needsReschedule {
+			return nil, false
+		}
+		projectID = ptr.Deref(project.Status.ID, "")
+	}
+
 	listOpts := addressscopes.ListOpts{
-		Name: getResourceName(orcObject),
+		Name:      getResourceName(orcObject),
+		IPVersion: int(resourceSpec.IPVersion),
+		ProjectID: projectID,
 	}
 
 	return actuator.osClient.ListAddressScopes(ctx, listOpts), true

--- a/internal/controllers/floatingip/actuator.go
+++ b/internal/controllers/floatingip/actuator.go
@@ -46,15 +46,11 @@ type (
 )
 
 type floatingipActuator struct {
-	osClient osclients.NetworkClient
-}
-
-type floatingipCreateActuator struct {
-	floatingipActuator
+	osClient  osclients.NetworkClient
 	k8sClient client.Client
 }
 
-var _ createResourceActuator = floatingipCreateActuator{}
+var _ createResourceActuator = floatingipActuator{}
 var _ deleteResourceActuator = floatingipActuator{}
 
 func (floatingipActuator) GetResourceID(osResource *osResourceT) string {
@@ -70,22 +66,69 @@ func (actuator floatingipActuator) GetOSResourceByID(ctx context.Context, id str
 }
 
 func (actuator floatingipActuator) ListOSResourcesForAdoption(ctx context.Context, obj *orcv1alpha1.FloatingIP) (floatingipIterator, bool) {
-	if obj.Spec.Resource == nil {
+	resource := obj.Spec.Resource
+	if resource == nil {
 		return nil, false
 	}
 	// we only support adoption of floatingips by IP as they don't have name
-	if obj.Spec.Resource.FloatingIP == nil {
+	if resource.FloatingIP == nil {
 		return nil, false
 	}
 
+	// Resolve the floating network ID from either FloatingNetworkRef or
+	// FloatingSubnetRef. Exactly one of these must be set per API
+	// validation. Without the network ID, adoption could match a floating
+	// IP on the wrong network.
+	var floatingNetworkID string
+	if resource.FloatingNetworkRef != nil {
+		network, rs := dependency.FetchDependency(
+			ctx, actuator.k8sClient, obj.Namespace, resource.FloatingNetworkRef, "Network",
+			func(dep *orcv1alpha1.Network) bool {
+				return orcv1alpha1.IsAvailable(dep) && dep.Status.ID != nil
+			},
+		)
+		if needsReschedule, _ := rs.NeedsReschedule(); needsReschedule {
+			return nil, false
+		}
+		floatingNetworkID = ptr.Deref(network.Status.ID, "")
+	} else if resource.FloatingSubnetRef != nil {
+		subnet, rs := dependency.FetchDependency(
+			ctx, actuator.k8sClient, obj.Namespace, resource.FloatingSubnetRef, "Subnet",
+			func(dep *orcv1alpha1.Subnet) bool {
+				return orcv1alpha1.IsAvailable(dep) && dep.Status.ID != nil && dep.Status.Resource != nil
+			},
+		)
+		if needsReschedule, _ := rs.NeedsReschedule(); needsReschedule {
+			return nil, false
+		}
+		floatingNetworkID = subnet.Status.Resource.NetworkID
+	}
+
+	// Resolve the project ID from ProjectRef if set.
+	var projectID string
+	if resource.ProjectRef != nil {
+		project, rs := dependency.FetchDependency(
+			ctx, actuator.k8sClient, obj.Namespace, resource.ProjectRef, "Project",
+			func(dep *orcv1alpha1.Project) bool {
+				return orcv1alpha1.IsAvailable(dep) && dep.Status.ID != nil
+			},
+		)
+		if needsReschedule, _ := rs.NeedsReschedule(); needsReschedule {
+			return nil, false
+		}
+		projectID = ptr.Deref(project.Status.ID, "")
+	}
+
 	listOpts := floatingips.ListOpts{
-		FloatingIP: string(ptr.Deref(obj.Spec.Resource.FloatingIP, "")),
-		Tags:       tags.Join(obj.Spec.Resource.Tags),
+		FloatingIP:        string(ptr.Deref(resource.FloatingIP, "")),
+		FloatingNetworkID: floatingNetworkID,
+		ProjectID:         projectID,
+		Tags:              tags.Join(resource.Tags),
 	}
 	return actuator.osClient.ListFloatingIP(ctx, listOpts), true
 }
 
-func (actuator floatingipCreateActuator) ListOSResourcesForImport(ctx context.Context, obj orcObjectPT, filter filterT) (iter.Seq2[*osResourceT, error], progress.ReconcileStatus) {
+func (actuator floatingipActuator) ListOSResourcesForImport(ctx context.Context, obj orcObjectPT, filter filterT) (iter.Seq2[*osResourceT, error], progress.ReconcileStatus) {
 	var reconcileStatus progress.ReconcileStatus
 
 	network, rs := dependency.FetchDependency(
@@ -132,7 +175,7 @@ func (actuator floatingipCreateActuator) ListOSResourcesForImport(ctx context.Co
 	return actuator.osClient.ListFloatingIP(ctx, listOpts), nil
 }
 
-func (actuator floatingipCreateActuator) CreateResource(ctx context.Context, obj *orcv1alpha1.FloatingIP) (*osResourceT, progress.ReconcileStatus) {
+func (actuator floatingipActuator) CreateResource(ctx context.Context, obj *orcv1alpha1.FloatingIP) (*osResourceT, progress.ReconcileStatus) {
 	resource := obj.Spec.Resource
 	if resource == nil {
 		// Should have been caught by API validation
@@ -304,7 +347,7 @@ func (floatingipHelperFactory) NewAPIObjectAdapter(obj orcObjectPT) adapterI {
 }
 
 func (floatingipHelperFactory) NewCreateActuator(ctx context.Context, orcObject orcObjectPT, controller interfaces.ResourceController) (createResourceActuator, progress.ReconcileStatus) {
-	return newCreateActuator(ctx, orcObject, controller)
+	return newActuator(ctx, orcObject, controller)
 }
 
 func (floatingipHelperFactory) NewDeleteActuator(ctx context.Context, orcObject orcObjectPT, controller interfaces.ResourceController) (deleteResourceActuator, progress.ReconcileStatus) {
@@ -330,18 +373,7 @@ func newActuator(ctx context.Context, orcObject *orcv1alpha1.FloatingIP, control
 	}
 
 	return floatingipActuator{
-		osClient: osClient,
-	}, nil
-}
-
-func newCreateActuator(ctx context.Context, orcObject *orcv1alpha1.FloatingIP, controller interfaces.ResourceController) (floatingipCreateActuator, progress.ReconcileStatus) {
-	floatingipActuator, reconcileStatus := newActuator(ctx, orcObject, controller)
-	if needsReschedule, _ := reconcileStatus.NeedsReschedule(); needsReschedule {
-		return floatingipCreateActuator{}, reconcileStatus
-	}
-
-	return floatingipCreateActuator{
-		floatingipActuator: floatingipActuator,
-		k8sClient:          controller.GetK8sClient(),
+		osClient:  osClient,
+		k8sClient: controller.GetK8sClient(),
 	}, nil
 }

--- a/internal/controllers/group/actuator.go
+++ b/internal/controllers/group/actuator.go
@@ -71,8 +71,25 @@ func (actuator groupActuator) ListOSResourcesForAdoption(ctx context.Context, or
 		return nil, false
 	}
 
+	// Resolve the domain ID from DomainRef if set. Without the domain
+	// ID, adoption could match a group in the wrong domain.
+	var domainID string
+	if resourceSpec.DomainRef != nil {
+		domain, rs := dependency.FetchDependency(
+			ctx, actuator.k8sClient, orcObject.Namespace, resourceSpec.DomainRef, "Domain",
+			func(dep *orcv1alpha1.Domain) bool {
+				return orcv1alpha1.IsAvailable(dep) && dep.Status.ID != nil
+			},
+		)
+		if needsReschedule, _ := rs.NeedsReschedule(); needsReschedule {
+			return nil, false
+		}
+		domainID = ptr.Deref(domain.Status.ID, "")
+	}
+
 	listOpts := groups.ListOpts{
-		Name: getResourceName(orcObject),
+		Name:     getResourceName(orcObject),
+		DomainID: domainID,
 	}
 
 	return actuator.osClient.ListGroups(ctx, listOpts), true

--- a/internal/controllers/network/actuator.go
+++ b/internal/controllers/network/actuator.go
@@ -72,11 +72,32 @@ func (actuator networkActuator) GetOSResourceByID(ctx context.Context, id string
 }
 
 func (actuator networkActuator) ListOSResourcesForAdoption(ctx context.Context, obj orcObjectPT) (iter.Seq2[*osResourceT, error], bool) {
-	if obj.Spec.Resource == nil {
+	resource := obj.Spec.Resource
+	if resource == nil {
 		return nil, false
 	}
 
-	listOpts := networks.ListOpts{Name: getResourceName(obj)}
+	// Resolve the project ID from ProjectRef if set. Without the project
+	// ID, adoption with admin-scoped credentials could match a network
+	// in the wrong project.
+	var projectID string
+	if resource.ProjectRef != nil {
+		project, rs := dependency.FetchDependency(
+			ctx, actuator.k8sClient, obj.Namespace, resource.ProjectRef, "Project",
+			func(dep *orcv1alpha1.Project) bool {
+				return orcv1alpha1.IsAvailable(dep) && dep.Status.ID != nil
+			},
+		)
+		if needsReschedule, _ := rs.NeedsReschedule(); needsReschedule {
+			return nil, false
+		}
+		projectID = ptr.Deref(project.Status.ID, "")
+	}
+
+	listOpts := networks.ListOpts{
+		Name:      getResourceName(obj),
+		ProjectID: projectID,
+	}
 	return actuator.osClient.ListNetwork(ctx, listOpts), true
 }
 

--- a/internal/controllers/port/actuator.go
+++ b/internal/controllers/port/actuator.go
@@ -117,11 +117,44 @@ func (actuator portActuator) GetOSResourceByID(ctx context.Context, id string) (
 }
 
 func (actuator portActuator) ListOSResourcesForAdoption(ctx context.Context, obj *orcv1alpha1.Port) (portIterator, bool) {
-	if obj.Spec.Resource == nil {
+	resource := obj.Spec.Resource
+	if resource == nil {
 		return nil, false
 	}
 
-	listOpts := ports.ListOpts{Name: getResourceName(obj)}
+	// Resolve the network ID from NetworkRef. Without the network ID,
+	// adoption could match a port on the wrong network.
+	network, rs := dependency.FetchDependency(
+		ctx, actuator.k8sClient, obj.Namespace, &resource.NetworkRef, "Network",
+		func(dep *orcv1alpha1.Network) bool {
+			return orcv1alpha1.IsAvailable(dep) && dep.Status.ID != nil
+		},
+	)
+	if needsReschedule, _ := rs.NeedsReschedule(); needsReschedule {
+		return nil, false
+	}
+
+	// Resolve the project ID from ProjectRef if set.
+	var projectID string
+	if resource.ProjectRef != nil {
+		project, rs := dependency.FetchDependency(
+			ctx, actuator.k8sClient, obj.Namespace, resource.ProjectRef, "Project",
+			func(dep *orcv1alpha1.Project) bool {
+				return orcv1alpha1.IsAvailable(dep) && dep.Status.ID != nil
+			},
+		)
+		if needsReschedule, _ := rs.NeedsReschedule(); needsReschedule {
+			return nil, false
+		}
+		projectID = ptr.Deref(project.Status.ID, "")
+	}
+
+	listOpts := ports.ListOpts{
+		Name:       getResourceName(obj),
+		NetworkID:  ptr.Deref(network.Status.ID, ""),
+		MACAddress: resource.MACAddress,
+		ProjectID:  projectID,
+	}
 	return actuator.osClient.ListPort(ctx, listOpts), true
 }
 

--- a/internal/controllers/project/actuator.go
+++ b/internal/controllers/project/actuator.go
@@ -75,13 +75,31 @@ func (actuator projectActuator) GetOSResourceByID(ctx context.Context, id string
 }
 
 func (actuator projectActuator) ListOSResourcesForAdoption(ctx context.Context, obj orcObjectPT) (iter.Seq2[*osResourceT, error], bool) {
-	if obj.Spec.Resource == nil {
+	resource := obj.Spec.Resource
+	if resource == nil {
 		return nil, false
 	}
 
+	// Resolve the domain ID from DomainRef if set. Without the domain
+	// ID, adoption could match a project in the wrong domain.
+	var domainID string
+	if resource.DomainRef != nil {
+		domain, rs := dependency.FetchDependency(
+			ctx, actuator.k8sClient, obj.Namespace, resource.DomainRef, "Domain",
+			func(dep *orcv1alpha1.Domain) bool {
+				return orcv1alpha1.IsAvailable(dep) && dep.Status.ID != nil
+			},
+		)
+		if needsReschedule, _ := rs.NeedsReschedule(); needsReschedule {
+			return nil, false
+		}
+		domainID = ptr.Deref(domain.Status.ID, "")
+	}
+
 	listOpts := projects.ListOpts{
-		Name: getResourceName(obj),
-		Tags: tags.Join(obj.Spec.Resource.Tags),
+		Name:     getResourceName(obj),
+		DomainID: domainID,
+		Tags:     tags.Join(resource.Tags),
 	}
 
 	return actuator.osClient.ListProjects(ctx, listOpts), true

--- a/internal/controllers/router/actuator.go
+++ b/internal/controllers/router/actuator.go
@@ -48,15 +48,11 @@ type (
 )
 
 type routerActuator struct {
-	osClient osclients.NetworkClient
-}
-
-type routerCreateActuator struct {
-	routerActuator
+	osClient  osclients.NetworkClient
 	k8sClient client.Client
 }
 
-var _ createResourceActuator = routerCreateActuator{}
+var _ createResourceActuator = routerActuator{}
 var _ deleteResourceActuator = routerActuator{}
 
 func (routerActuator) GetResourceID(osResource *osResourceT) string {
@@ -72,15 +68,37 @@ func (actuator routerActuator) GetOSResourceByID(ctx context.Context, id string)
 }
 
 func (actuator routerActuator) ListOSResourcesForAdoption(ctx context.Context, obj *orcv1alpha1.Router) (routerIterator, bool) {
-	if obj.Spec.Resource == nil {
+	resource := obj.Spec.Resource
+	if resource == nil {
 		return nil, false
 	}
 
-	listOpts := routers.ListOpts{Name: getResourceName(obj)}
+	// Resolve the project ID from ProjectRef if set. Without the project
+	// ID, adoption with admin-scoped credentials could match a router
+	// in the wrong project.
+	var projectID string
+	if resource.ProjectRef != nil {
+		project, rs := dependency.FetchDependency(
+			ctx, actuator.k8sClient, obj.Namespace, resource.ProjectRef, "Project",
+			func(dep *orcv1alpha1.Project) bool {
+				return orcv1alpha1.IsAvailable(dep) && dep.Status.ID != nil
+			},
+		)
+		if needsReschedule, _ := rs.NeedsReschedule(); needsReschedule {
+			return nil, false
+		}
+		projectID = ptr.Deref(project.Status.ID, "")
+	}
+
+	listOpts := routers.ListOpts{
+		Name:        getResourceName(obj),
+		ProjectID:   projectID,
+		Distributed: resource.Distributed,
+	}
 	return actuator.osClient.ListRouter(ctx, listOpts), true
 }
 
-func (actuator routerCreateActuator) ListOSResourcesForImport(ctx context.Context, obj orcObjectPT, filter filterT) (iter.Seq2[*osResourceT, error], progress.ReconcileStatus) {
+func (actuator routerActuator) ListOSResourcesForImport(ctx context.Context, obj orcObjectPT, filter filterT) (iter.Seq2[*osResourceT, error], progress.ReconcileStatus) {
 	var reconcileStatus progress.ReconcileStatus
 
 	project, rs := dependency.FetchDependency(
@@ -108,7 +126,7 @@ func (actuator routerCreateActuator) ListOSResourcesForImport(ctx context.Contex
 	return actuator.osClient.ListRouter(ctx, listOpts), nil
 }
 
-func (actuator routerCreateActuator) CreateResource(ctx context.Context, obj *orcv1alpha1.Router) (*osResourceT, progress.ReconcileStatus) {
+func (actuator routerActuator) CreateResource(ctx context.Context, obj *orcv1alpha1.Router) (*osResourceT, progress.ReconcileStatus) {
 	resource := obj.Spec.Resource
 	if resource == nil {
 		// Should have been caught by API validation
@@ -274,7 +292,7 @@ func (routerHelperFactory) NewAPIObjectAdapter(obj orcObjectPT) adapterI {
 }
 
 func (routerHelperFactory) NewCreateActuator(ctx context.Context, orcObject orcObjectPT, controller interfaces.ResourceController) (createResourceActuator, progress.ReconcileStatus) {
-	return newCreateActuator(ctx, orcObject, controller)
+	return newActuator(ctx, orcObject, controller)
 }
 
 func (routerHelperFactory) NewDeleteActuator(ctx context.Context, orcObject orcObjectPT, controller interfaces.ResourceController) (deleteResourceActuator, progress.ReconcileStatus) {
@@ -300,18 +318,7 @@ func newActuator(ctx context.Context, orcObject *orcv1alpha1.Router, controller 
 	}
 
 	return routerActuator{
-		osClient: osClient,
-	}, nil
-}
-
-func newCreateActuator(ctx context.Context, orcObject *orcv1alpha1.Router, controller interfaces.ResourceController) (routerCreateActuator, progress.ReconcileStatus) {
-	routerActuator, reconcileStatus := newActuator(ctx, orcObject, controller)
-	if needsReschedule, _ := reconcileStatus.NeedsReschedule(); needsReschedule {
-		return routerCreateActuator{}, reconcileStatus
-	}
-
-	return routerCreateActuator{
-		routerActuator: routerActuator,
-		k8sClient:      controller.GetK8sClient(),
+		osClient:  osClient,
+		k8sClient: controller.GetK8sClient(),
 	}, nil
 }

--- a/internal/controllers/securitygroup/actuator.go
+++ b/internal/controllers/securitygroup/actuator.go
@@ -77,11 +77,33 @@ func (actuator securityGroupActuator) GetOSResourceByID(ctx context.Context, id 
 }
 
 func (actuator securityGroupActuator) ListOSResourcesForAdoption(ctx context.Context, obj *orcv1alpha1.SecurityGroup) (securityGroupIterator, bool) {
-	if obj.Spec.Resource == nil {
+	resource := obj.Spec.Resource
+	if resource == nil {
 		return nil, false
 	}
 
-	listOpts := groups.ListOpts{Name: getResourceName(obj)}
+	// Resolve the project ID from ProjectRef if set. Without the project
+	// ID, adoption with admin-scoped credentials could match a security
+	// group in the wrong project.
+	var projectID string
+	if resource.ProjectRef != nil {
+		project, rs := dependency.FetchDependency(
+			ctx, actuator.k8sClient, obj.Namespace, resource.ProjectRef, "Project",
+			func(dep *orcv1alpha1.Project) bool {
+				return orcv1alpha1.IsAvailable(dep) && dep.Status.ID != nil
+			},
+		)
+		if needsReschedule, _ := rs.NeedsReschedule(); needsReschedule {
+			return nil, false
+		}
+		projectID = ptr.Deref(project.Status.ID, "")
+	}
+
+	listOpts := groups.ListOpts{
+		Name:      getResourceName(obj),
+		ProjectID: projectID,
+		Stateful:  resource.Stateful,
+	}
 	return actuator.osClient.ListSecGroup(ctx, listOpts), true
 }
 

--- a/internal/controllers/servergroup/actuator.go
+++ b/internal/controllers/servergroup/actuator.go
@@ -22,6 +22,7 @@ import (
 
 	"github.com/gophercloud/gophercloud/v2/openstack/compute/v2/servergroups"
 	corev1 "k8s.io/api/core/v1"
+	"k8s.io/utils/ptr"
 	ctrl "sigs.k8s.io/controller-runtime"
 
 	orcv1alpha1 "github.com/k-orc/openstack-resource-controller/v2/api/v1alpha1"
@@ -75,7 +76,7 @@ func (actuator servergroupActuator) ListOSResourcesForAdoption(ctx context.Conte
 	filters := []osclients.ResourceFilter[osResourceT]{
 		func(f *servergroups.ServerGroup) bool {
 			name := getResourceName(orcObject)
-			return f.Name == name
+			return f.Name == name && ptr.Deref(f.Policy, "") == string(resourceSpec.Policy)
 		},
 	}
 	listOpts := servergroups.ListOpts{}

--- a/internal/controllers/subnet/actuator.go
+++ b/internal/controllers/subnet/actuator.go
@@ -77,10 +77,45 @@ func (actuator subnetActuator) GetOSResourceByID(ctx context.Context, id string)
 }
 
 func (actuator subnetActuator) ListOSResourcesForAdoption(ctx context.Context, obj orcObjectPT) (iter.Seq2[*osResourceT, error], bool) {
-	if obj.Spec.Resource == nil {
+	resource := obj.Spec.Resource
+	if resource == nil {
 		return nil, false
 	}
-	listOpts := subnets.ListOpts{Name: getResourceName(obj)}
+
+	// Resolve the network ID from NetworkRef. Without the network ID,
+	// adoption could match a subnet on the wrong network.
+	network, rs := dependency.FetchDependency(
+		ctx, actuator.k8sClient, obj.Namespace, &resource.NetworkRef, "Network",
+		func(dep *orcv1alpha1.Network) bool {
+			return orcv1alpha1.IsAvailable(dep) && dep.Status.ID != nil
+		},
+	)
+	if needsReschedule, _ := rs.NeedsReschedule(); needsReschedule {
+		return nil, false
+	}
+
+	// Resolve the project ID from ProjectRef if set.
+	var projectID string
+	if resource.ProjectRef != nil {
+		project, rs := dependency.FetchDependency(
+			ctx, actuator.k8sClient, obj.Namespace, resource.ProjectRef, "Project",
+			func(dep *orcv1alpha1.Project) bool {
+				return orcv1alpha1.IsAvailable(dep) && dep.Status.ID != nil
+			},
+		)
+		if needsReschedule, _ := rs.NeedsReschedule(); needsReschedule {
+			return nil, false
+		}
+		projectID = ptr.Deref(project.Status.ID, "")
+	}
+
+	listOpts := subnets.ListOpts{
+		Name:      getResourceName(obj),
+		NetworkID: ptr.Deref(network.Status.ID, ""),
+		CIDR:      string(resource.CIDR),
+		IPVersion: int(resource.IPVersion),
+		ProjectID: projectID,
+	}
 	return actuator.osClient.ListSubnet(ctx, listOpts), true
 }
 

--- a/internal/controllers/trunk/actuator.go
+++ b/internal/controllers/trunk/actuator.go
@@ -73,9 +73,38 @@ func (actuator trunkActuator) ListOSResourcesForAdoption(ctx context.Context, or
 		return nil, false
 	}
 
+	// Resolve the port ID from PortRef. Without the port ID, adoption
+	// could match a trunk associated with the wrong parent port.
+	port, rs := dependency.FetchDependency(
+		ctx, actuator.k8sClient, orcObject.Namespace, &resourceSpec.PortRef, "Port",
+		func(dep *orcv1alpha1.Port) bool {
+			return orcv1alpha1.IsAvailable(dep) && dep.Status.ID != nil
+		},
+	)
+	if needsReschedule, _ := rs.NeedsReschedule(); needsReschedule {
+		return nil, false
+	}
+
+	// Resolve the project ID from ProjectRef if set.
+	var projectID string
+	if resourceSpec.ProjectRef != nil {
+		project, rs := dependency.FetchDependency(
+			ctx, actuator.k8sClient, orcObject.Namespace, resourceSpec.ProjectRef, "Project",
+			func(dep *orcv1alpha1.Project) bool {
+				return orcv1alpha1.IsAvailable(dep) && dep.Status.ID != nil
+			},
+		)
+		if needsReschedule, _ := rs.NeedsReschedule(); needsReschedule {
+			return nil, false
+		}
+		projectID = ptr.Deref(project.Status.ID, "")
+	}
+
 	listOpts := trunks.ListOpts{
 		Name:        getResourceName(orcObject),
 		Description: string(ptr.Deref(resourceSpec.Description, "")),
+		PortID:      ptr.Deref(port.Status.ID, ""),
+		ProjectID:   projectID,
 	}
 
 	return actuator.osClient.ListTrunks(ctx, listOpts), true

--- a/internal/controllers/user/actuator.go
+++ b/internal/controllers/user/actuator.go
@@ -74,8 +74,25 @@ func (actuator userActuator) ListOSResourcesForAdoption(ctx context.Context, orc
 		return nil, false
 	}
 
+	// Resolve the domain ID from DomainRef if set. Without the domain
+	// ID, adoption could match a user in the wrong domain.
+	var domainID string
+	if resourceSpec.DomainRef != nil {
+		domain, rs := dependency.FetchDependency(
+			ctx, actuator.k8sClient, orcObject.Namespace, resourceSpec.DomainRef, "Domain",
+			func(dep *orcv1alpha1.Domain) bool {
+				return orcv1alpha1.IsAvailable(dep) && dep.Status.ID != nil
+			},
+		)
+		if needsReschedule, _ := rs.NeedsReschedule(); needsReschedule {
+			return nil, false
+		}
+		domainID = ptr.Deref(domain.Status.ID, "")
+	}
+
 	listOpts := users.ListOpts{
-		Name: getResourceName(orcObject),
+		Name:     getResourceName(orcObject),
+		DomainID: domainID,
 	}
 
 	return actuator.osClient.ListUsers(ctx, listOpts), true


### PR DESCRIPTION
Tighten `ListOSResourcesForAdoption` across all controllers to include parent resource IDs, immutable identifying fields, and project/domain scoping in the adoption filter.

Fixes https://github.com/k-orc/openstack-resource-controller/issues/757