### PR TITLE
Fix port status not updating to ACTIVE after server interface attachment

### DIFF
--- a/internal/controllers/port/controller.go
+++ b/internal/controllers/port/controller.go
@@ -208,6 +208,12 @@ func serverToPortMapFunc(ctx context.Context, k8sClient client.Client) handler.M
 					log.V(logging.Verbose).Info("port needs reconciliation: listed in server status but deviceID not set",
 						"port", client.ObjectKeyFromObject(port),
 						"server", client.ObjectKeyFromObject(server))
+				} else if portStatus.Status == PortStatusDown {
+					shouldReconcile = true
+					reason = "Port attached to server but status is still DOWN"
+					log.V(logging.Verbose).Info("port needs reconciliation: attached to server but status is DOWN",
+						"port", client.ObjectKeyFromObject(port),
+						"server", client.ObjectKeyFromObject(server))
 				}
 			}
 

--- a/internal/controllers/volume/controller.go
+++ b/internal/controllers/volume/controller.go
@@ -162,6 +162,12 @@ func serverToVolumeMapFunc(ctx context.Context, k8sClient client.Client) handler
 					log.V(logging.Verbose).Info("volume needs reconciliation: listed in server status but no attachment info",
 						"volume", client.ObjectKeyFromObject(volume),
 						"server", client.ObjectKeyFromObject(server))
+				} else if volumeStatus.Status != VolumeStatusInUse {
+					shouldReconcile = true
+					reason = "Volume attached to server but status is not in-use"
+					log.V(logging.Verbose).Info("volume needs reconciliation: attached to server but status is not in-use",
+						"volume", client.ObjectKeyFromObject(volume),
+						"server", client.ObjectKeyFromObject(server))
 				}
 			}
 


### PR DESCRIPTION
When the server controller attaches a port via Nova os-interface, the port's Neutron status transitions asynchronously from DOWN to ACTIVE as OVN binds the port. The port controller may reconcile after device_id is set but before the status becomes ACTIVE, writing DOWN to the port's status and setting Progressing: False.

The existing serverToPortMapFunc watch handler only triggers port re-reconciliation when DeviceID disagrees with the server's interface list. When the port controller already picked up the device_id but not the ACTIVE status, DeviceID matches and no re-reconciliation is triggered, leaving the port status permanently stale at DOWN.

Add a check for ports that are listed in the server's interfaces and have the correct DeviceID but still show status DOWN, triggering a re-reconciliation to pick up the current Neutron status.

Fixes https://github.com/k-orc/openstack-resource-controller/issues/764