### PR TITLE
Use IsRetryable instead of IsConflict for terminal errors

### DIFF
--- a/.agents/skills/new-controller/patterns.md
+++ b/.agents/skills/new-controller/patterns.md
@@ -86,17 +86,22 @@ Distinguish between errors that can be retried vs those requiring user action.
 | **Terminal** | Invalid configuration, bad input, permission denied | No retry until spec changes |
 
 ```go
-// Terminal: User must fix the spec
-if !orcerrors.IsRetryable(err) {
-    err = orcerrors.Terminal(orcv1alpha1.ConditionReasonInvalidConfiguration,
-        "invalid configuration: "+err.Error(), err)
+// Terminal on create: User must fix the spec
+if err != nil {
+    if !orcerrors.IsRetryable(err) {
+        err = orcerrors.Terminal(orcv1alpha1.ConditionReasonInvalidConfiguration,
+            "invalid configuration creating resource: "+err.Error(), err)
+    }
+    return nil, progress.WrapError(err)
 }
 
-// Conflict on update: Treat as terminal (spec likely conflicts with existing state)
-// unless resource has intermediate states that could cause transient conflicts
-if orcerrors.IsConflict(err) {
-    err = orcerrors.Terminal(orcv1alpha1.ConditionReasonInvalidConfiguration,
-        "invalid configuration updating resource: "+err.Error(), err)
+// Terminal on update: Treat as terminal (spec likely conflicts with existing state)
+if err != nil {
+    if !orcerrors.IsRetryable(err) {
+        err = orcerrors.Terminal(orcv1alpha1.ConditionReasonInvalidConfiguration,
+            "invalid configuration updating resource: "+err.Error(), err)
+    }
+    return progress.WrapError(err)
 }
 ```
 

--- a/.agents/skills/update-controller/SKILL.md
+++ b/.agents/skills/update-controller/SKILL.md
@@ -218,17 +218,22 @@ See also `@.agents/skills/new-controller/patterns.md` for more details on this p
 Ensure proper error classification:
 
 ```go
-// Terminal: Invalid configuration - user must fix spec
-if !orcerrors.IsRetryable(err) {
-    err = orcerrors.Terminal(orcv1alpha1.ConditionReasonInvalidConfiguration,
-        "invalid configuration: "+err.Error(), err)
+// Terminal on create: Invalid configuration - user must fix spec
+if err != nil {
+    if !orcerrors.IsRetryable(err) {
+        err = orcerrors.Terminal(orcv1alpha1.ConditionReasonInvalidConfiguration,
+            "invalid configuration creating resource: "+err.Error(), err)
+    }
+    return nil, progress.WrapError(err)
 }
-return nil, progress.WrapError(err)
 
-// Conflict on update: Treat as terminal
-if orcerrors.IsConflict(err) {
-    err = orcerrors.Terminal(orcv1alpha1.ConditionReasonInvalidConfiguration,
-        "invalid configuration updating resource: "+err.Error(), err)
+// Terminal on update:
+if err != nil {
+    if !orcerrors.IsRetryable(err) {
+        err = orcerrors.Terminal(orcv1alpha1.ConditionReasonInvalidConfiguration,
+            "invalid configuration updating resource: "+err.Error(), err)
+    }
+    return progress.WrapError(err)
 }
 ```
 

--- a/AGENTS.md
+++ b/AGENTS.md
@@ -89,15 +89,17 @@ reconcileStatus.WithProgressMessage("waiting...") // Add progress message
 ### Error Classification
 
 - **Transient errors** (5xx, API unavailable): Default handling with exponential backoff
-- **Terminal errors** (400, invalid config): Wrap with `orcerrors.Terminal()` - no retry
+- **Non-recoverable errors** (409 Conflict, non-HTTP gophercloud errors): Wrap with `orcerrors.Terminal()` - no retry
 
 ```go
-// Terminal error example
-if !orcerrors.IsRetryable(err) {
-    err = orcerrors.Terminal(orcv1alpha1.ConditionReasonInvalidConfiguration,
-        "invalid configuration: "+err.Error(), err)
+// Non-recoverable error example
+if err != nil {
+    if !orcerrors.IsRetryable(err) {
+        err = orcerrors.Terminal(orcv1alpha1.ConditionReasonInvalidConfiguration,
+            "invalid configuration: "+err.Error(), err)
+    }
+    return nil, progress.WrapError(err)
 }
-return nil, progress.WrapError(err)
 ```
 
 ## Dependencies

--- a/cmd/scaffold-controller/data/controller/actuator.go.template
+++ b/cmd/scaffold-controller/data/controller/actuator.go.template
@@ -184,7 +184,6 @@ func (actuator {{ .PackageName }}Actuator) CreateResource(ctx context.Context, o
 
 	osResource, err := actuator.osClient.Create{{ .Kind }}(ctx, createOpts)
 	if err != nil {
-		// We should require the spec to be updated before retrying a create which returned a conflict
 		if !orcerrors.IsRetryable(err) {
 			err = orcerrors.Terminal(orcv1alpha1.ConditionReasonInvalidConfiguration, "invalid configuration creating resource: "+err.Error(), err)
 		}
@@ -232,12 +231,10 @@ func (actuator {{ .PackageName }}Actuator) updateResource(ctx context.Context, o
 
 	_, err = actuator.osClient.Update{{ .Kind }}(ctx, osResource.ID, updateOpts)
 
-	// We should require the spec to be updated before retrying an update which returned a conflict
-	if orcerrors.IsConflict(err) {
-		err = orcerrors.Terminal(orcv1alpha1.ConditionReasonInvalidConfiguration, "invalid configuration updating resource: "+err.Error(), err)
-	}
-
 	if err != nil {
+		if !orcerrors.IsRetryable(err) {
+			err = orcerrors.Terminal(orcv1alpha1.ConditionReasonInvalidConfiguration, "invalid configuration updating resource: "+err.Error(), err)
+		}
 		return progress.WrapError(err)
 	}
 

--- a/internal/controllers/addressscope/actuator.go
+++ b/internal/controllers/addressscope/actuator.go
@@ -195,12 +195,10 @@ func (actuator addressscopeActuator) updateResource(ctx context.Context, obj orc
 
 	_, err = actuator.osClient.UpdateAddressScope(ctx, osResource.ID, updateOpts)
 
-	// We should require the spec to be updated before retrying an update which returned a conflict
-	if orcerrors.IsConflict(err) {
-		err = orcerrors.Terminal(orcv1alpha1.ConditionReasonInvalidConfiguration, "invalid configuration updating resource: "+err.Error(), err)
-	}
-
 	if err != nil {
+		if !orcerrors.IsRetryable(err) {
+			err = orcerrors.Terminal(orcv1alpha1.ConditionReasonInvalidConfiguration, "invalid configuration updating resource: "+err.Error(), err)
+		}
 		return progress.WrapError(err)
 	}
 

--- a/internal/controllers/domain/actuator.go
+++ b/internal/controllers/domain/actuator.go
@@ -144,12 +144,10 @@ func (actuator domainActuator) updateResource(ctx context.Context, obj orcObject
 
 	_, err = actuator.osClient.UpdateDomain(ctx, osResource.ID, updateOpts)
 
-	// We should require the spec to be updated before retrying an update which returned a conflict
-	if orcerrors.IsConflict(err) {
-		err = orcerrors.Terminal(orcv1alpha1.ConditionReasonInvalidConfiguration, "invalid configuration updating resource: "+err.Error(), err)
-	}
-
 	if err != nil {
+		if !orcerrors.IsRetryable(err) {
+			err = orcerrors.Terminal(orcv1alpha1.ConditionReasonInvalidConfiguration, "invalid configuration updating resource: "+err.Error(), err)
+		}
 		return progress.WrapError(err)
 	}
 

--- a/internal/controllers/endpoint/actuator.go
+++ b/internal/controllers/endpoint/actuator.go
@@ -201,12 +201,10 @@ func (actuator endpointActuator) updateResource(ctx context.Context, obj orcObje
 
 	_, err = actuator.osClient.UpdateEndpoint(ctx, osResource.ID, updateOpts)
 
-	// We should require the spec to be updated before retrying an update which returned a conflict
-	if orcerrors.IsConflict(err) {
-		err = orcerrors.Terminal(orcv1alpha1.ConditionReasonInvalidConfiguration, "invalid configuration updating resource: "+err.Error(), err)
-	}
-
 	if err != nil {
+		if !orcerrors.IsRetryable(err) {
+			err = orcerrors.Terminal(orcv1alpha1.ConditionReasonInvalidConfiguration, "invalid configuration updating resource: "+err.Error(), err)
+		}
 		return progress.WrapError(err)
 	}
 

--- a/internal/controllers/floatingip/actuator.go
+++ b/internal/controllers/floatingip/actuator.go
@@ -243,12 +243,10 @@ func (actuator floatingipActuator) CreateResource(ctx context.Context, obj *orcv
 
 	osResource, err := actuator.osClient.CreateFloatingIP(ctx, &createOpts)
 
-	// We should require the spec to be updated before retrying a create which returned a conflict
-	if orcerrors.IsConflict(err) {
-		err = orcerrors.Terminal(orcv1alpha1.ConditionReasonInvalidConfiguration, "invalid configuration creating resource: "+err.Error(), err)
-	}
-
 	if err != nil {
+		if !orcerrors.IsRetryable(err) {
+			err = orcerrors.Terminal(orcv1alpha1.ConditionReasonInvalidConfiguration, "invalid configuration creating resource: "+err.Error(), err)
+		}
 		return nil, progress.WrapError(err)
 	}
 	return osResource, nil
@@ -284,10 +282,10 @@ func (actuator floatingipActuator) updateResource(ctx context.Context, obj orcOb
 
 	_, err = actuator.osClient.UpdateFloatingIP(ctx, osResource.ID, updateOpts)
 
-	if orcerrors.IsConflict(err) {
-		err = orcerrors.Terminal(orcv1alpha1.ConditionReasonInvalidConfiguration, "invalid configuration updating resource: "+err.Error(), err)
-	}
 	if err != nil {
+		if !orcerrors.IsRetryable(err) {
+			err = orcerrors.Terminal(orcv1alpha1.ConditionReasonInvalidConfiguration, "invalid configuration updating resource: "+err.Error(), err)
+		}
 		return progress.WrapError(err)
 	}
 

--- a/internal/controllers/group/actuator.go
+++ b/internal/controllers/group/actuator.go
@@ -188,12 +188,10 @@ func (actuator groupActuator) updateResource(ctx context.Context, obj orcObjectP
 
 	_, err = actuator.osClient.UpdateGroup(ctx, osResource.ID, updateOpts)
 
-	// We should require the spec to be updated before retrying an update which returned a conflict
-	if orcerrors.IsConflict(err) {
-		err = orcerrors.Terminal(orcv1alpha1.ConditionReasonInvalidConfiguration, "invalid configuration updating resource: "+err.Error(), err)
-	}
-
 	if err != nil {
+		if !orcerrors.IsRetryable(err) {
+			err = orcerrors.Terminal(orcv1alpha1.ConditionReasonInvalidConfiguration, "invalid configuration updating resource: "+err.Error(), err)
+		}
 		return progress.WrapError(err)
 	}
 

--- a/internal/controllers/image/actuator.go
+++ b/internal/controllers/image/actuator.go
@@ -171,9 +171,11 @@ func (actuator imageActuator) CreateResource(ctx context.Context, obj *orcv1alph
 		Properties:      additionalProperties,
 	})
 
-	// We should require the spec to be updated before retrying a create which returned a conflict
-	if orcerrors.IsConflict(err) {
-		err = orcerrors.Terminal(orcv1alpha1.ConditionReasonInvalidConfiguration, "invalid configuration creating image: "+err.Error(), err)
+	if err != nil {
+		if !orcerrors.IsRetryable(err) {
+			err = orcerrors.Terminal(orcv1alpha1.ConditionReasonInvalidConfiguration, "invalid configuration creating image: "+err.Error(), err)
+		}
+		return nil, progress.WrapError(err)
 	}
 
 	if err != nil {
@@ -208,10 +210,10 @@ func (actuator imageActuator) UpdateResource(ctx context.Context, obj orcObjectP
 
 	_, err := actuator.osClient.UpdateImage(ctx, osResource.ID, updateOpts)
 
-	if orcerrors.IsConflict(err) {
-		err = orcerrors.Terminal(orcv1alpha1.ConditionReasonInvalidConfiguration, "invalid configuration updating resource: "+err.Error(), err)
-	}
 	if err != nil {
+		if !orcerrors.IsRetryable(err) {
+			err = orcerrors.Terminal(orcv1alpha1.ConditionReasonInvalidConfiguration, "invalid configuration updating resource: "+err.Error(), err)
+		}
 		return progress.WrapError(err)
 	}
 

--- a/internal/controllers/network/actuator.go
+++ b/internal/controllers/network/actuator.go
@@ -194,8 +194,8 @@ func (actuator networkActuator) CreateResource(ctx context.Context, obj orcObjec
 
 	osResource, err := actuator.osClient.CreateNetwork(ctx, createOpts)
 	if err != nil {
-		// We should require the spec to be updated before retrying a create which returned a conflict
-		if orcerrors.IsConflict(err) {
+		// We should require the spec to be updated before retrying a create which returned a non-retryable error
+		if !orcerrors.IsRetryable(err) {
 			err = orcerrors.Terminal(orcv1alpha1.ConditionReasonInvalidConfiguration, "invalid configuration creating resource: "+err.Error(), err)
 		}
 		return nil, progress.WrapError(err)
@@ -251,10 +251,10 @@ func (actuator networkActuator) updateResource(ctx context.Context, obj orcObjec
 
 	_, err = actuator.osClient.UpdateNetwork(ctx, osResource.ID, updateOpts)
 
-	if orcerrors.IsConflict(err) {
-		err = orcerrors.Terminal(orcv1alpha1.ConditionReasonInvalidConfiguration, "invalid configuration updating resource: "+err.Error(), err)
-	}
 	if err != nil {
+		if !orcerrors.IsRetryable(err) {
+			err = orcerrors.Terminal(orcv1alpha1.ConditionReasonInvalidConfiguration, "invalid configuration updating resource: "+err.Error(), err)
+		}
 		return progress.WrapError(err)
 	}
 

--- a/internal/controllers/port/actuator.go
+++ b/internal/controllers/port/actuator.go
@@ -328,8 +328,8 @@ func (actuator portActuator) CreateResource(ctx context.Context, obj *orcv1alpha
 
 	osResource, err := actuator.osClient.CreatePort(ctx, &portTrustedOpts)
 	if err != nil {
-		// We should require the spec to be updated before retrying a create which returned a conflict
-		if orcerrors.IsConflict(err) {
+		// We should require the spec to be updated before retrying a create which returned a non-retryable error
+		if !orcerrors.IsRetryable(err) {
 			err = orcerrors.Terminal(orcv1alpha1.ConditionReasonInvalidConfiguration, "invalid configuration creating resource: "+err.Error(), err)
 		}
 		return nil, progress.WrapError(err)
@@ -438,12 +438,10 @@ func (actuator portActuator) updateResource(ctx context.Context, obj orcObjectPT
 
 	_, err = actuator.osClient.UpdatePort(ctx, osResource.ID, updateOpts)
 
-	// We should require the spec to be updated before retrying an update which returned a conflict
-	if orcerrors.IsConflict(err) {
-		err = orcerrors.Terminal(orcv1alpha1.ConditionReasonInvalidConfiguration, "invalid configuration updating resource: "+err.Error(), err)
-	}
-
 	if err != nil {
+		if !orcerrors.IsRetryable(err) {
+			err = orcerrors.Terminal(orcv1alpha1.ConditionReasonInvalidConfiguration, "invalid configuration updating resource: "+err.Error(), err)
+		}
 		return progress.WrapError(err)
 	}
 

--- a/internal/controllers/project/actuator.go
+++ b/internal/controllers/project/actuator.go
@@ -218,8 +218,11 @@ func (actuator projectActuator) updateResource(ctx context.Context, obj orcObjec
 
 	_, err = actuator.osClient.UpdateProject(ctx, osResource.ID, updateOpts)
 
-	if orcerrors.IsConflict(err) {
-		err = orcerrors.Terminal(orcv1alpha1.ConditionReasonInvalidConfiguration, "invalid configuration updating resource: "+err.Error(), err)
+	if err != nil {
+		if !orcerrors.IsRetryable(err) {
+			err = orcerrors.Terminal(orcv1alpha1.ConditionReasonInvalidConfiguration, "invalid configuration updating resource: "+err.Error(), err)
+		}
+		return progress.WrapError(err)
 	}
 	if err != nil {
 		return progress.WrapError(err)

--- a/internal/controllers/role/actuator.go
+++ b/internal/controllers/role/actuator.go
@@ -182,12 +182,10 @@ func (actuator roleActuator) updateResource(ctx context.Context, obj orcObjectPT
 
 	_, err = actuator.osClient.UpdateRole(ctx, osResource.ID, updateOpts)
 
-	// We should require the spec to be updated before retrying an update which returned a conflict
-	if orcerrors.IsConflict(err) {
-		err = orcerrors.Terminal(orcv1alpha1.ConditionReasonInvalidConfiguration, "invalid configuration updating resource: "+err.Error(), err)
-	}
-
 	if err != nil {
+		if !orcerrors.IsRetryable(err) {
+			err = orcerrors.Terminal(orcv1alpha1.ConditionReasonInvalidConfiguration, "invalid configuration updating resource: "+err.Error(), err)
+		}
 		return progress.WrapError(err)
 	}
 

--- a/internal/controllers/router/actuator.go
+++ b/internal/controllers/router/actuator.go
@@ -179,12 +179,10 @@ func (actuator routerActuator) CreateResource(ctx context.Context, obj *orcv1alp
 
 	osResource, err := actuator.osClient.CreateRouter(ctx, &createOpts)
 
-	// We should require the spec to be updated before retrying a create which returned a conflict
-	if orcerrors.IsConflict(err) {
-		err = orcerrors.Terminal(orcv1alpha1.ConditionReasonInvalidConfiguration, "invalid configuration creating resource: "+err.Error(), err)
-	}
-
 	if err != nil {
+		if !orcerrors.IsRetryable(err) {
+			err = orcerrors.Terminal(orcv1alpha1.ConditionReasonInvalidConfiguration, "invalid configuration creating resource: "+err.Error(), err)
+		}
 		return nil, progress.WrapError(err)
 	}
 	return osResource, nil
@@ -222,10 +220,10 @@ func (actuator routerActuator) updateResource(ctx context.Context, obj orcObject
 
 	_, err = actuator.osClient.UpdateRouter(ctx, osResource.ID, updateOpts)
 
-	if orcerrors.IsConflict(err) {
-		err = orcerrors.Terminal(orcv1alpha1.ConditionReasonInvalidConfiguration, "invalid configuration updating resource: "+err.Error(), err)
-	}
 	if err != nil {
+		if !orcerrors.IsRetryable(err) {
+			err = orcerrors.Terminal(orcv1alpha1.ConditionReasonInvalidConfiguration, "invalid configuration updating resource: "+err.Error(), err)
+		}
 		return progress.WrapError(err)
 	}
 

--- a/internal/controllers/securitygroup/actuator.go
+++ b/internal/controllers/securitygroup/actuator.go
@@ -160,8 +160,8 @@ func (actuator securityGroupActuator) CreateResource(ctx context.Context, obj *o
 
 	osResource, err := actuator.osClient.CreateSecGroup(ctx, &createOpts)
 	if err != nil {
-		// We should require the spec to be updated before retrying a create which returned a conflict
-		if orcerrors.IsConflict(err) {
+		// We should require the spec to be updated before retrying a create which returned a non-retryable error
+		if !orcerrors.IsRetryable(err) {
 			err = orcerrors.Terminal(orcv1alpha1.ConditionReasonInvalidConfiguration, "invalid configuration creating resource: "+err.Error(), err)
 		}
 		return nil, progress.WrapError(err)
@@ -209,10 +209,10 @@ func (actuator securityGroupActuator) updateResource(ctx context.Context, obj or
 
 	_, err = actuator.osClient.UpdateSecGroup(ctx, osResource.ID, updateOpts)
 
-	if orcerrors.IsConflict(err) {
-		err = orcerrors.Terminal(orcv1alpha1.ConditionReasonInvalidConfiguration, "invalid configuration updating resource: "+err.Error(), err)
-	}
 	if err != nil {
+		if !orcerrors.IsRetryable(err) {
+			err = orcerrors.Terminal(orcv1alpha1.ConditionReasonInvalidConfiguration, "invalid configuration updating resource: "+err.Error(), err)
+		}
 		return progress.WrapError(err)
 	}
 

--- a/internal/controllers/server/actuator.go
+++ b/internal/controllers/server/actuator.go
@@ -454,10 +454,10 @@ func (actuator serverActuator) updateResource(ctx context.Context, obj orcObject
 
 	_, err = actuator.osClient.UpdateServer(ctx, osResource.ID, updateOpts)
 
-	if orcerrors.IsConflict(err) {
-		err = orcerrors.Terminal(orcv1alpha1.ConditionReasonInvalidConfiguration, "invalid configuration updating resource: "+err.Error(), err)
-	}
 	if err != nil {
+		if !orcerrors.IsRetryable(err) {
+			err = orcerrors.Terminal(orcv1alpha1.ConditionReasonInvalidConfiguration, "invalid configuration updating resource: "+err.Error(), err)
+		}
 		return progress.WrapError(err)
 	}
 

--- a/internal/controllers/service/actuator.go
+++ b/internal/controllers/service/actuator.go
@@ -156,12 +156,10 @@ func (actuator serviceActuator) updateResource(ctx context.Context, obj orcObjec
 
 	_, err = actuator.osClient.UpdateService(ctx, osResource.ID, updateOpts)
 
-	// We should require the spec to be updated before retrying an update which returned a conflict
-	if orcerrors.IsConflict(err) {
-		err = orcerrors.Terminal(orcv1alpha1.ConditionReasonInvalidConfiguration, "invalid configuration updating resource: "+err.Error(), err)
-	}
-
 	if err != nil {
+		if !orcerrors.IsRetryable(err) {
+			err = orcerrors.Terminal(orcv1alpha1.ConditionReasonInvalidConfiguration, "invalid configuration updating resource: "+err.Error(), err)
+		}
 		return progress.WrapError(err)
 	}
 

--- a/internal/controllers/subnet/actuator.go
+++ b/internal/controllers/subnet/actuator.go
@@ -247,12 +247,10 @@ func (actuator subnetActuator) CreateResource(ctx context.Context, obj orcObject
 
 	osResource, err := actuator.osClient.CreateSubnet(ctx, &createOpts)
 
-	// We should require the spec to be updated before retrying a create which returned a conflict
-	if orcerrors.IsConflict(err) {
-		err = orcerrors.Terminal(orcv1alpha1.ConditionReasonInvalidConfiguration, "invalid configuration creating resource: "+err.Error(), err)
-	}
-
 	if err != nil {
+		if !orcerrors.IsRetryable(err) {
+			err = orcerrors.Terminal(orcv1alpha1.ConditionReasonInvalidConfiguration, "invalid configuration creating resource: "+err.Error(), err)
+		}
 		return nil, progress.WrapError(err)
 	}
 	return osResource, nil
@@ -312,12 +310,10 @@ func (actuator subnetActuator) updateResource(ctx context.Context, obj orcObject
 
 	_, err = actuator.osClient.UpdateSubnet(ctx, osResource.ID, updateOpts)
 
-	// We should require the spec to be updated before retrying an update which returned a conflict
-	if orcerrors.IsConflict(err) {
-		err = orcerrors.Terminal(orcv1alpha1.ConditionReasonInvalidConfiguration, "invalid configuration updating resource: "+err.Error(), err)
-	}
-
 	if err != nil {
+		if !orcerrors.IsRetryable(err) {
+			err = orcerrors.Terminal(orcv1alpha1.ConditionReasonInvalidConfiguration, "invalid configuration updating resource: "+err.Error(), err)
+		}
 		return progress.WrapError(err)
 	}
 

--- a/internal/controllers/trunk/actuator.go
+++ b/internal/controllers/trunk/actuator.go
@@ -255,12 +255,10 @@ func (actuator trunkActuator) updateResource(ctx context.Context, obj orcObjectP
 
 	_, err = actuator.osClient.UpdateTrunk(ctx, osResource.ID, updateOpts)
 
-	// We should require the spec to be updated before retrying an update which returned a conflict
-	if orcerrors.IsConflict(err) {
-		err = orcerrors.Terminal(orcv1alpha1.ConditionReasonInvalidConfiguration, "invalid configuration updating resource: "+err.Error(), err)
-	}
-
 	if err != nil {
+		if !orcerrors.IsRetryable(err) {
+			err = orcerrors.Terminal(orcv1alpha1.ConditionReasonInvalidConfiguration, "invalid configuration updating resource: "+err.Error(), err)
+		}
 		return progress.WrapError(err)
 	}
 
@@ -384,7 +382,7 @@ func (actuator trunkActuator) reconcileSubports(ctx context.Context, obj orcObje
 			Subports: subportsToRemove,
 		}
 		if err := actuator.osClient.RemoveSubports(ctx, osResource.ID, removeOpts); err != nil {
-			if orcerrors.IsConflict(err) {
+			if !orcerrors.IsRetryable(err) {
 				err = orcerrors.Terminal(orcv1alpha1.ConditionReasonInvalidConfiguration, "invalid configuration removing subports: "+err.Error(), err)
 			}
 			return reconcileStatus.WithError(err)
@@ -398,7 +396,7 @@ func (actuator trunkActuator) reconcileSubports(ctx context.Context, obj orcObje
 			Subports: subportsToAdd,
 		}
 		if _, err := actuator.osClient.AddSubports(ctx, osResource.ID, addOpts); err != nil {
-			if orcerrors.IsConflict(err) {
+			if !orcerrors.IsRetryable(err) {
 				err = orcerrors.Terminal(orcv1alpha1.ConditionReasonInvalidConfiguration, "invalid configuration adding subports: "+err.Error(), err)
 			}
 			return reconcileStatus.WithError(err)

--- a/internal/controllers/user/actuator.go
+++ b/internal/controllers/user/actuator.go
@@ -240,10 +240,10 @@ func (actuator userActuator) reconcilePassword(ctx context.Context, obj orcObjec
 			Password: password,
 		})
 
-		if orcerrors.IsConflict(err) {
-			err = orcerrors.Terminal(orcv1alpha1.ConditionReasonInvalidConfiguration, "invalid configuration updating resource: "+err.Error(), err)
-		}
 		if err != nil {
+			if !orcerrors.IsRetryable(err) {
+				err = orcerrors.Terminal(orcv1alpha1.ConditionReasonInvalidConfiguration, "invalid configuration updating resource: "+err.Error(), err)
+			}
 			return progress.WrapError(err)
 		}
 	}
@@ -295,12 +295,10 @@ func (actuator userActuator) updateResource(ctx context.Context, obj orcObjectPT
 
 	_, err = actuator.osClient.UpdateUser(ctx, osResource.ID, updateOpts)
 
-	// We should require the spec to be updated before retrying an update which returned a conflict
-	if orcerrors.IsConflict(err) {
-		err = orcerrors.Terminal(orcv1alpha1.ConditionReasonInvalidConfiguration, "invalid configuration updating resource: "+err.Error(), err)
-	}
-
 	if err != nil {
+		if !orcerrors.IsRetryable(err) {
+			err = orcerrors.Terminal(orcv1alpha1.ConditionReasonInvalidConfiguration, "invalid configuration updating resource: "+err.Error(), err)
+		}
 		return progress.WrapError(err)
 	}
 

--- a/internal/controllers/volume/actuator.go
+++ b/internal/controllers/volume/actuator.go
@@ -243,12 +243,10 @@ func (actuator volumeActuator) updateResource(ctx context.Context, obj orcObject
 
 	_, err = actuator.osClient.UpdateVolume(ctx, osResource.ID, updateOpts)
 
-	// We should require the spec to be updated before retrying an update which returned a conflict
-	if orcerrors.IsConflict(err) {
-		err = orcerrors.Terminal(orcv1alpha1.ConditionReasonInvalidConfiguration, "invalid configuration updating resource: "+err.Error(), err)
-	}
-
 	if err != nil {
+		if !orcerrors.IsRetryable(err) {
+			err = orcerrors.Terminal(orcv1alpha1.ConditionReasonInvalidConfiguration, "invalid configuration updating resource: "+err.Error(), err)
+		}
 		return progress.WrapError(err)
 	}
 

--- a/internal/controllers/volumetype/actuator.go
+++ b/internal/controllers/volumetype/actuator.go
@@ -202,12 +202,10 @@ func (actuator volumetypeActuator) updateResource(ctx context.Context, obj orcOb
 
 	_, err = actuator.osClient.UpdateVolumeType(ctx, osResource.ID, updateOpts)
 
-	// We should require the spec to be updated before retrying an update which returned a conflict
-	if orcerrors.IsConflict(err) {
-		err = orcerrors.Terminal(orcv1alpha1.ConditionReasonInvalidConfiguration, "invalid configuration updating resource: "+err.Error(), err)
-	}
-
 	if err != nil {
+		if !orcerrors.IsRetryable(err) {
+			err = orcerrors.Terminal(orcv1alpha1.ConditionReasonInvalidConfiguration, "invalid configuration updating resource: "+err.Error(), err)
+		}
 		return progress.WrapError(err)
 	}
 

--- a/internal/util/errors/errors.go
+++ b/internal/util/errors/errors.go
@@ -51,15 +51,26 @@ func (e noMatchesError) Is(err error) bool {
 	return err == ErrFilterMatch
 }
 
+// IsRetryable returns true if err may succeed when retried without changes to
+// the spec. This includes HTTP error responses other than 409 Conflict, since
+// some HTTP errors (like 400 Bad Request) can be transient when a dependency
+// is not yet ready in OpenStack, and server errors (5xx) are typically
+// transient.
+//
+// Non-HTTP errors from gophercloud (e.g. client-side validation such as
+// banned value_spec keys), 409 Conflict, and 501 Not Implemented are not
+// retryable.
 func IsRetryable(err error) bool {
-	var errUnexpectedResponseCode gophercloud.ErrUnexpectedResponseCode
-	if errors.As(err, &errUnexpectedResponseCode) {
-		statusCode := errUnexpectedResponseCode.GetStatusCode()
-		return statusCode >= 500 && statusCode != http.StatusNotImplemented
+	if IsConflict(err) || IsNotImplementedError(err) {
+		return false
 	}
-	return false
+
+	var errUnexpectedResponseCode gophercloud.ErrUnexpectedResponseCode
+	return errors.As(err, &errUnexpectedResponseCode)
 }
 
+// IsNotFound returns true if err indicates the requested OpenStack resource
+// was not found (HTTP 404 or gophercloud's ErrResourceNotFound).
 func IsNotFound(err error) bool {
 	if err == nil {
 		return false
@@ -78,14 +89,17 @@ func IsNotFound(err error) bool {
 	return gophercloud.ResponseCodeIs(err, http.StatusNotFound)
 }
 
+// IsInvalidError returns true if err is an HTTP 400 Bad Request response.
 func IsInvalidError(err error) bool {
 	return gophercloud.ResponseCodeIs(err, http.StatusBadRequest)
 }
 
+// IsConflict returns true if err is an HTTP 409 Conflict response.
 func IsConflict(err error) bool {
 	return gophercloud.ResponseCodeIs(err, http.StatusConflict)
 }
 
+// IsNotImplementedError returns true if err is an HTTP 501 Not Implemented response.
 func IsNotImplementedError(err error) bool {
 	return gophercloud.ResponseCodeIs(err, http.StatusNotImplemented)
 }


### PR DESCRIPTION
Rewrite `orcerrors.IsRetryable` and replace all uses of `orcerrors.IsConflict` with `!orcerrors.IsRetryable` when classifying errors as terminal in create and update paths. `IsConflict` only caught HTTP 409 responses, but non-HTTP errors from gophercloud (e.g. client-side validation such as banned value_spec keys) would cause infinite retries.

The rewritten `IsRetryable` returns `true` for more errors that may succeed when retried without changes to the spec:
- HTTP error responses other than 409 are retryable (some 4xx errors like 400 Bad Request can be transient, e.g. when a dependency is not yet ready in OpenStack)
- HTTP 409 Conflict is not retryable
- Non-HTTP errors from gophercloud are not retryable

The check is now nested inside an `if err != nil` guard for clarity and safety, matching the pattern already used in `CreateResource` paths.

Also add godoc comments to all public functions in the errors package.

Closes #241