### PR TITLE
EOL release-1.0 branch

### DIFF
--- a/.github/dependabot.yml
+++ b/.github/dependabot.yml
@@ -43,47 +43,6 @@ updates:
   - dependency-name: "k8s.io/*"
     update-types: ["version-update:semver-major", "version-update:semver-minor"]
 ## main branch config ends here
-## release-1.0 branch config starts here
-# github-actions
-- directory: "/"
-  package-ecosystem: "github-actions"
-  schedule:
-    interval: "weekly"
-    day: "monday"
-  cooldown:
-    default-days: 7
-  target-branch: release-1.0
-  groups:
-    all-github-actions:
-      patterns: [ "*" ]
-  commit-message:
-    prefix: ":seedling:"
-    include: scope
-# Go directories
-- directories:
-  - "/"
-  package-ecosystem: "gomod"
-  schedule:
-    interval: "weekly"
-    day: "monday"
-  cooldown:
-    default-days: 7
-  target-branch: release-1.0
-  groups:
-    all-go-mod-patch-and-minor:
-      patterns: [ "*" ]
-      update-types: [ "patch", "minor" ]
-  commit-message:
-    prefix: ":seedling:"
-    include: scope
-  ignore:
-  # Ignore controller-runtime major and minor bumps as its upgraded manually.
-  - dependency-name: "sigs.k8s.io/controller-runtime"
-    update-types: ["version-update:semver-major", "version-update:semver-minor"]
-  # Ignore k8s major and minor bumps and its transitives modules
-  - dependency-name: "k8s.io/*"
-    update-types: ["version-update:semver-major", "version-update:semver-minor"]
-## release-1.0 branch config ends here
 ## release-2.0 branch config starts here
 # github-actions
 - directory: "/"

--- a/.github/labels.yaml
+++ b/.github/labels.yaml
@@ -1,7 +1,4 @@
 - color: '30ABB9'
-  description: This PR will be backported to v1.0
-  name: backport-v1.0
-- color: '30ABB9'
   description: This PR targets v1.0
   name: v1.0
 - color: 'D97706'

--- a/.github/workflows/backport.yaml
+++ b/.github/workflows/backport.yaml
@@ -9,68 +9,6 @@ on:
 permissions: {}
 
 jobs:
-  backport_v1_0:
-    name: "Backport to v1.0"
-    permissions:
-      contents: read
-      pull-requests: write
-    # Only react to merged PRs for security reasons.
-    # See https://docs.github.com/en/actions/using-workflows/events-that-trigger-workflows#pull_request_target.
-    if: >
-      github.event.pull_request.merged
-      && (
-        github.event.action == 'closed'
-          && contains(github.event.pull_request.labels.*.name, 'backport-v1.0')
-        || (
-          github.event.action == 'labeled'
-          && contains(github.event.label.name, 'backport-v1.0')
-        )
-      )
-    runs-on: ubuntu-latest
-    steps:
-      - name: Generate a token from the orc-backport-bot github-app
-        id: generate_token
-        uses: getsentry/action-github-app-token@5c1e90706fe007857338ac1bfbd7a4177db2f789 # tag=v4.0.0
-        with:
-          app_id: ${{ secrets.BACKPORT_APP_ID }} # zizmor: ignore[secrets-outside-env]
-          private_key: ${{ secrets.BACKPORT_APP_PRIVATE_KEY }} # zizmor: ignore[secrets-outside-env]
-
-      - name: Backporting
-        if: >
-          contains(github.event.pull_request.labels.*.name, 'semver:patch')
-          || contains(github.event.label.name, 'semver:patch')
-        uses: kiegroup/git-backporting@08da0b07ef2330d189f6074ec8db736b3aa9f465 # tag=v4.9.1
-        with:
-          target-branch: release-1.0
-          pull-request: ${{ github.event.pull_request.url }}
-          auth: ${{ steps.generate_token.outputs.token }}
-          no-squash: true
-          strategy-option: find-renames
-
-      - name: Report failure
-        if: failure()
-        run: gh issue comment "$NUMBER" --body "$BODY"
-        env:
-          GH_TOKEN: ${{ secrets.GITHUB_TOKEN }}
-          GH_REPO: ${{ github.repository }}
-          NUMBER: ${{ github.event.pull_request.number }}
-          BODY: >
-            Failed to backport PR to `release-1.0` branch. See [logs](${{ github.server_url }}/${{ github.repository }}/actions/runs/${{ github.run_id }}) for details.
-
-      - name: Report an error if backport unsupported labels
-        if: >
-          contains(github.event.pull_request.labels.*.name, 'semver:major')
-          || contains(github.event.pull_request.labels.*.name, 'semver:minor')
-          || contains(github.event.label.name, 'semver:major')
-          || contains(github.event.label.name, 'semver:minor')
-        run: gh pr comment "$NUMBER" --body "$BODY"
-        env:
-          GH_TOKEN: ${{ secrets.GITHUB_TOKEN }}
-          GH_REPO: ${{ github.repository }}
-          NUMBER: ${{ github.event.pull_request.number }}
-          BODY: >
-            Labels `semver:major` and `semver:minor` block backports to the branch `release-1.0`.
-
   backport_v2_0:
     name: "Backport to v2.0"
     permissions:

--- a/.github/workflows/weekly-security-scan.yaml
+++ b/.github/workflows/weekly-security-scan.yaml
@@ -13,7 +13,7 @@ jobs:
     strategy:
       fail-fast: false
       matrix:
-        branch: [main, release-1.0, release-2.0]
+        branch: [main, release-2.0]
     name: Trivy
     runs-on: ubuntu-latest
     steps:

--- a/README.md
+++ b/README.md
@@ -71,7 +71,7 @@ kubectl delete -f $ORC_RELEASE
 
 ## Supported OpenStack resources
 
-| **controller**              | **1.x** | **2.x** | **main** |
+| **controller**              | **1.x (EOL)** | **2.x** | **main** |
 |:---------------------------:|:-------:|:-------:|:--------:|
 | addressscope                |         |    ✔    |     ✔    |
 | application credential      |         |    ◐    |     ◐    |

--- a/SECURITY.md
+++ b/SECURITY.md
@@ -5,7 +5,7 @@
 | Version | Supported          |
 | ------- | ------------------ |
 | < 1.0   | :x:                |
-| 1.x     | :white_check_mark: |
+| 1.x     | :x:                |
 | 2.x     | :white_check_mark: |
 
 ## Reporting a Vulnerability


### PR DESCRIPTION
Remove release-1.0 Dependabot configuration, mark v1.x as EOL in the README supported resources matrix, and mark v1.x as unsupported in SECURITY.md.