### PR TITLE
[v2] ci: verify generate-bundle in CI

### DIFF
--- a/.github/workflows/generate.yaml
+++ b/.github/workflows/generate.yaml
@@ -20,3 +20,9 @@ jobs:
       - run: |
           make generate
           git diff --exit-code
+
+      - run: sudo apt-get install -y libgpgme-dev
+
+      - run: |
+          make generate-bundle
+          git diff --exit-code

--- a/config/manifests/bases/orc.clusterserviceversion.yaml
+++ b/config/manifests/bases/orc.clusterserviceversion.yaml
@@ -19,6 +19,16 @@ spec:
   apiservicedefinitions: {}
   customresourcedefinitions:
     owned:
+    - description: AddressScope is the Schema for an ORC resource.
+      displayName: Address Scope
+      kind: AddressScope
+      name: addressscopes.openstack.k-orc.cloud
+      version: v1alpha1
+    - description: ApplicationCredential is the Schema for an ORC resource.
+      displayName: Application Credential
+      kind: ApplicationCredential
+      name: applicationcredentials.openstack.k-orc.cloud
+      version: v1alpha1
     - description: Domain is the Schema for an ORC resource.
       displayName: Domain
       kind: Domain
@@ -108,6 +118,16 @@ spec:
       displayName: Subnet
       kind: Subnet
       name: subnets.openstack.k-orc.cloud
+      version: v1alpha1
+    - description: Trunk is the Schema for an ORC resource.
+      displayName: Trunk
+      kind: Trunk
+      name: trunks.openstack.k-orc.cloud
+      version: v1alpha1
+    - description: User is the Schema for an ORC resource.
+      displayName: User
+      kind: User
+      name: users.openstack.k-orc.cloud
       version: v1alpha1
     - description: Volume is the Schema for an ORC resource.
       displayName: Volume


### PR DESCRIPTION
Add a step to the generate workflow to run 'make generate-bundle' and verify the result is committed. This ensures that
config/manifests/bases/orc.clusterserviceversion.yaml does not drift when new CRDs are added.

Update the CSV base to include AddressScope, ApplicationCredential, Trunk, and User CRDs which were added without running generate-bundle.