### PR TITLE
CI: fix flaky floatingip-create-full E2E test

### DIFF
--- a/internal/controllers/floatingip/tests/floatingip-create-full/00-create-resource.yaml
+++ b/internal/controllers/floatingip/tests/floatingip-create-full/00-create-resource.yaml
@@ -35,6 +35,9 @@ spec:
     networkRef: floatingip-create-full-external
     ipVersion: 4
     cidr: 192.168.155.0/24
+    allocationPools:
+      - start: 192.168.155.100
+        end: 192.168.155.200
 ---
 apiVersion: openstack.k-orc.cloud/v1alpha1
 kind: Router


### PR DESCRIPTION
Add allocationPools to the external subnet to prevent the router gateway port from grabbing the IP address requested by the FloatingIP.

Without allocationPools, Neutron auto-allocates from the full subnet range and can non-deterministically assign 192.168.155.5 to the router gateway port, causing the FloatingIP creation to fail with a 409 Conflict.

Fixes #812