### PR TITLE
Fix controllers version matrix

### DIFF
--- a/README.md
+++ b/README.md
@@ -91,7 +91,7 @@ kubectl delete -f $ORC_RELEASE
 | server                      |         |    ◐    |     ◐    |
 | server group                |         |    ✔    |     ✔    |
 | service                     |         |    ✔    |     ✔    |
-| share network               |         |    ◐    |     ◐    |
+| share network               |         |         |     ◐    |
 | subnet                      |         |    ◐    |     ◐    |
 | trunk                       |         |    ✔    |     ✔    |
 | user                        |         |    ◐    |     ◐    |


### PR DESCRIPTION
Share Network controller merged in main, after we branched out v2 and was not backported. It's going to be in the next major version.