### PR TITLE
Fix endless update when MAC is empty in AllowedAddressPairs

### DIFF
--- a/internal/controllers/port/actuator.go
+++ b/internal/controllers/port/actuator.go
@@ -506,7 +506,7 @@ func handleAllowedAddressPairsUpdate(updateOpts *ports.UpdateOpts, resource *orc
 	for _, desired := range desiredPairs {
 		found := false
 		for _, actual := range osResource.AllowedAddressPairs {
-			if actual.IPAddress == desired.IPAddress && actual.MACAddress == desired.MACAddress {
+			if actual.IPAddress == desired.IPAddress && (desired.MACAddress == "" || actual.MACAddress == desired.MACAddress) {
 				found = true
 				break
 			}
@@ -521,7 +521,7 @@ func handleAllowedAddressPairsUpdate(updateOpts *ports.UpdateOpts, resource *orc
 	for _, actual := range osResource.AllowedAddressPairs {
 		found := false
 		for _, desired := range desiredPairs {
-			if actual.IPAddress == desired.IPAddress && actual.MACAddress == desired.MACAddress {
+			if actual.IPAddress == desired.IPAddress && (desired.MACAddress == "" || actual.MACAddress == desired.MACAddress) {
 				found = true
 				break
 			}

--- a/internal/controllers/port/actuator_test.go
+++ b/internal/controllers/port/actuator_test.go
@@ -206,6 +206,28 @@ func TestHandleAllowedAddressPairsUpdate(t *testing.T) {
 			},
 			expectChange: true,
 		},
+		{
+			name: "Entry with empty MAC address",
+			newValue: []orcv1alpha1.AllowedAddressPair{
+				{IP: orcv1alpha1.IPvAny("192.168.100.1")},
+			},
+			existingValue: []ports.AddressPair{
+				{IPAddress: "192.168.100.1", MACAddress: "00:1A:2B:3C:4D:5E"},
+			},
+			expectChange: false,
+		},
+		{
+			name: "Entries with empty and filled MAC addresses",
+			newValue: []orcv1alpha1.AllowedAddressPair{
+				{IP: orcv1alpha1.IPvAny("192.168.100.1")},
+				{IP: orcv1alpha1.IPvAny("192.168.200.1"), MAC: ptr.To(orcv1alpha1.MAC("00:1A:2B:3C:4D:6E"))},
+			},
+			existingValue: []ports.AddressPair{
+				{IPAddress: "192.168.100.1", MACAddress: "00:1A:2B:3C:4D:5E"},
+				{IPAddress: "192.168.200.1", MACAddress: "00:1A:2B:3C:4D:6E"},
+			},
+			expectChange: false,
+		},
 	}
 
 	for _, tt := range testCases {


### PR DESCRIPTION
This PR refines the check of AllowedAddressPairs between resource spec in ORC and actual port state in OpenStack to avoid endless update.

Close #852