### PR TITLE
test: don't delete namespaces in unit tests

### DIFF
--- a/internal/controllers/floatingip/suite_test.go
+++ b/internal/controllers/floatingip/suite_test.go
@@ -86,9 +86,6 @@ var _ = Describe("EnvTest sanity check", func() {
 
 		// Create the namespace
 		Expect(k8sClient.Create(ctx, namespace)).To(Succeed(), "create namespace")
-		DeferCleanup(func() {
-			Expect(k8sClient.Delete(ctx, namespace)).To(Succeed(), "delete namespace")
-		})
 
 		// Check the result
 		namespaceResult := &corev1.Namespace{}

--- a/internal/controllers/image/suite_test.go
+++ b/internal/controllers/image/suite_test.go
@@ -86,9 +86,6 @@ var _ = Describe("EnvTest sanity check", func() {
 
 		// Create the namespace
 		Expect(k8sClient.Create(ctx, namespace)).To(Succeed(), "create namespace")
-		DeferCleanup(func() {
-			Expect(k8sClient.Delete(ctx, namespace)).To(Succeed(), "delete namespace")
-		})
 
 		// Check the result
 		namespaceResult := &corev1.Namespace{}

--- a/internal/controllers/image/upload_test.go
+++ b/internal/controllers/image/upload_test.go
@@ -160,9 +160,6 @@ var _ = Describe("Upload tests", Ordered, func() {
 		namespace = &corev1.Namespace{}
 		namespace.SetGenerateName("test-")
 		Expect(k8sClient.Create(ctx, namespace)).To(Succeed(), "create namespace")
-		DeferCleanup(func() {
-			Expect(k8sClient.Delete(ctx, namespace)).To(Succeed(), "delete namespace")
-		})
 
 		mockCtrl = gomock.NewController(GinkgoT())
 		actuator = &imageActuator{

--- a/internal/controllers/router/suite_test.go
+++ b/internal/controllers/router/suite_test.go
@@ -86,9 +86,6 @@ var _ = Describe("EnvTest sanity check", func() {
 
 		// Create the namespace
 		Expect(k8sClient.Create(ctx, namespace)).To(Succeed(), "create namespace")
-		DeferCleanup(func() {
-			Expect(k8sClient.Delete(ctx, namespace)).To(Succeed(), "delete namespace")
-		})
 
 		// Check the result
 		namespaceResult := &corev1.Namespace{}

--- a/internal/controllers/routerinterface/suite_test.go
+++ b/internal/controllers/routerinterface/suite_test.go
@@ -86,9 +86,6 @@ var _ = Describe("EnvTest sanity check", func() {
 
 		// Create the namespace
 		Expect(k8sClient.Create(ctx, namespace)).To(Succeed(), "create namespace")
-		DeferCleanup(func() {
-			Expect(k8sClient.Delete(ctx, namespace)).To(Succeed(), "delete namespace")
-		})
 
 		// Check the result
 		namespaceResult := &corev1.Namespace{}

--- a/internal/controllers/subnet/suite_test.go
+++ b/internal/controllers/subnet/suite_test.go
@@ -86,9 +86,6 @@ var _ = Describe("EnvTest sanity check", func() {
 
 		// Create the namespace
 		Expect(k8sClient.Create(ctx, namespace)).To(Succeed(), "create namespace")
-		DeferCleanup(func() {
-			Expect(k8sClient.Delete(ctx, namespace)).To(Succeed(), "delete namespace")
-		})
 
 		// Check the result
 		namespaceResult := &corev1.Namespace{}

--- a/test/apivalidations/suite_test.go
+++ b/test/apivalidations/suite_test.go
@@ -27,7 +27,6 @@ import (
 	. "github.com/onsi/ginkgo/v2"
 	. "github.com/onsi/gomega"
 	corev1 "k8s.io/api/core/v1"
-	metav1 "k8s.io/apimachinery/pkg/apis/meta/v1"
 	"k8s.io/apimachinery/pkg/runtime"
 	"k8s.io/apimachinery/pkg/types"
 	"k8s.io/client-go/discovery"
@@ -149,10 +148,6 @@ func createNamespace() *corev1.Namespace {
 	namespace := corev1.Namespace{}
 	namespace.GenerateName = "test-"
 	Expect(k8sClient.Create(ctx, &namespace)).To(Succeed(), "Namespace creation should succeed")
-	DeferCleanup(func() {
-		By("Deleting namespace")
-		Expect(k8sClient.Delete(ctx, &namespace, client.PropagationPolicy(metav1.DeletePropagationForeground))).To(Succeed(), "Namespace deletion should succeed")
-	})
 	By(fmt.Sprintf("Using namespace %s", namespace.Name))
 	return &namespace
 }


### PR DESCRIPTION
Namespace deletion is asynchronous — a deleted namespace enters a Terminating state before being fully removed. If the next test's GenerateName produces a suffix that collides with a still-Terminating namespace, the API server returns a hard error rather than retrying with a new name.

Since all unit tests run against an envtest API server that is torn down in AfterSuite, explicit namespace deletion is unnecessary. Remove the DeferCleanup blocks that delete namespaces to eliminate the flake.

Closes #850