### PR TITLE
Fix ORC managed log collection

### DIFF
--- a/.github/workflows/e2e.yaml
+++ b/.github/workflows/e2e.yaml
@@ -47,6 +47,10 @@ jobs:
           [filter_scheduler]
           enabled_filters = ComputeFilter,ComputeCapabilitiesFilter,ImagePropertiesFilter,ServerGroupAntiAffinityFilter,ServerGroupAffinityFilter,SameHostFilter,DifferentHostFilter,SimpleCIDRAffinityFilter,JsonFilter
 
+          [[post-config|/etc/neutron/neutron.conf]]
+          [quotas]
+          quota_router = 30
+
     - name: Deploy a Kind Cluster
       uses: helm/kind-action@ef37e7f390d99f746eb8b610417061a60e82a6cc # tag=v1.14.0
       with:

--- a/.github/workflows/e2e.yaml
+++ b/.github/workflows/e2e.yaml
@@ -66,6 +66,8 @@ jobs:
       run: |
         make test-e2e
         make test-examples
+      env:
+        E2E_KUTTL_SKIP_DELETE: 1
 
     - name: Generate logs on failure
       run: ./hack/collectlogs

--- a/hack/collectlogs
+++ b/hack/collectlogs
@@ -41,7 +41,7 @@ kubectl get -n orc-system all -o yaml > "$LOG_DIR/orc-resources.yaml"
 mkdir "$LOG_DIR/orc-managed-resources"
 for crd in config/crd/bases/openstack.k-orc.cloud_*; do
     resource=${crd:39:-5}
-    kubectl get "${resource}" -A -o yaml > "$LOG_DIR/orc-managed-resources/${resource}.yaml"
+    kubectl get "${resource}.openstack.k-orc.cloud" -A -o yaml > "$LOG_DIR/orc-managed-resources/openstack.k-orc.cloud_${resource}.yaml"
 done
 
 sudo find "$LOG_DIR" -type d -exec chmod 0755 {} \;

--- a/hack/e2e.sh
+++ b/hack/e2e.sh
@@ -29,10 +29,18 @@ if [ -n "$E2E_KUTTL_TIMEOUT" ]; then
     E2E_KUTTL_TIMEOUT_OPT="--timeout $E2E_KUTTL_TIMEOUT"
 fi
 
+# Skip deleting test resources on failure so collectlogs can capture them.
+# Set this variable to 1 to skip deletion.
+E2E_KUTTL_SKIP_DELETE=${E2E_KUTTL_SKIP_DELETE:-0}
+E2E_KUTTL_SKIP_DELETE_OPT=
+if [ "$E2E_KUTTL_SKIP_DELETE" == 1 ]; then
+    E2E_KUTTL_SKIP_DELETE_OPT="--skip-delete"
+fi
+
 # Export variables referenced in kuttl tests.
 export E2E_EXTERNAL_NETWORK_NAME
 export E2E_KUTTL_OSCLOUDS=${PREPARED_OSCLOUDS}
 export E2E_KUTTL_CACERT_OPT
 export E2E_KUTTL_FLAVOR
 
-kubectl kuttl test $E2E_KUTTL_DIR $E2E_KUTTL_TIMEOUT_OPT --test "$E2E_KUTTL_TEST"
+kubectl kuttl test $E2E_KUTTL_DIR $E2E_KUTTL_TIMEOUT_OPT $E2E_KUTTL_SKIP_DELETE_OPT --test "$E2E_KUTTL_TEST"

--- a/website/docs/development/writing-tests.md
+++ b/website/docs/development/writing-tests.md
@@ -321,17 +321,18 @@ commands:
 
 We use environment variables to configure how the tests run.
 
-| Variable      | Description | Default |
-| ----------- | ----------- |----------- |
-| `E2E_OSCLOUDS` | Path to clouds.yaml | `/etc/openstack/clouds.yaml` |
-| `E2E_CACERT`   | Path to a CA certificate (if needed) | |
-| `E2E_OPENSTACK_CLOUD_NAME` | Cloud name for regular credentials | `devstack` |
-| `E2E_OPENSTACK_ADMIN_CLOUD_NAME` | Cloud name for admin credentials | `devstack-admin-demo` |
-| `E2E_EXTERNAL_NETWORK_NAME` | Name of the external network to use | `public` |
-| `E2E_KUTTL_DIR` | Run tests from specific directory | |
-| `E2E_KUTTL_TEST` | Run a specific kuttl test | |
-| `E2E_KUTTL_FLAVOR` | Flavor name to use for tests | `m1.tiny` |
-| `E2E_KUTTL_TIMEOUT` | Override default timeout for tests | |
+| Variable                         | Description                                     | Default                      |
+|----------------------------------|-------------------------------------------------|------------------------------|
+| `E2E_OSCLOUDS`                   | Path to clouds.yaml                             | `/etc/openstack/clouds.yaml` |
+| `E2E_CACERT`                     | Path to a CA certificate (if needed)            |                              |
+| `E2E_OPENSTACK_CLOUD_NAME`       | Cloud name for regular credentials              | `devstack`                   |
+| `E2E_OPENSTACK_ADMIN_CLOUD_NAME` | Cloud name for admin credentials                | `devstack-admin-demo`        |
+| `E2E_EXTERNAL_NETWORK_NAME`      | Name of the external network to use             | `public`                     |
+| `E2E_KUTTL_DIR`                  | Run tests from specific directory               |                              |
+| `E2E_KUTTL_TEST`                 | Run a specific kuttl test                       |                              |
+| `E2E_KUTTL_FLAVOR`               | Flavor name to use for tests                    | `m1.tiny`                    |
+| `E2E_KUTTL_TIMEOUT`              | Override default timeout for tests              |                              |
+| `E2E_KUTTL_SKIP_DELETE`          | Skip deletion of resources created during tests. Set 1 to enable |  `0`                         |
 
 For example, to run the `import-dependency` test from the `subnet` controller:
 


### PR DESCRIPTION
When a failure in the CI occurs, the `collectlogs` script is not properly collecting logs for two reasons:
1. It is not using the FQDN name for the resources, which causes the script to collect the Kubernetes service resource, instead of the Openstack service managed by ORC
2. After the completion of `kuttl test`, it deletes all of the resources, preventing the script which runs afterwards to collect the managed resources. 

This PR add the `KUTTL_SKIP_DELETE` flag to prevent kuttl of deleting the resources and use FQDN resource names.

Closes #855 