### PR TITLE
test: reduce possibility of namespace collision in unit tests

### DIFF
--- a/internal/controllers/floatingip/suite_test.go
+++ b/internal/controllers/floatingip/suite_test.go
@@ -25,6 +25,7 @@ import (
 	. "github.com/onsi/gomega"
 	corev1 "k8s.io/api/core/v1"
 	"k8s.io/apimachinery/pkg/types"
+	utilrand "k8s.io/apimachinery/pkg/util/rand"
 	"k8s.io/client-go/kubernetes/scheme"
 	"k8s.io/client-go/rest"
 	"sigs.k8s.io/controller-runtime/pkg/client"
@@ -82,7 +83,7 @@ var _ = Describe("EnvTest sanity check", func() {
 	It("should be able to create a namespace", func() {
 		ctx := context.TODO()
 		namespace := &corev1.Namespace{}
-		namespace.SetGenerateName("test-")
+		namespace.SetName("test-" + utilrand.String(10))
 
 		// Create the namespace
 		Expect(k8sClient.Create(ctx, namespace)).To(Succeed(), "create namespace")

--- a/internal/controllers/image/suite_test.go
+++ b/internal/controllers/image/suite_test.go
@@ -25,6 +25,7 @@ import (
 	. "github.com/onsi/gomega"
 	corev1 "k8s.io/api/core/v1"
 	"k8s.io/apimachinery/pkg/types"
+	utilrand "k8s.io/apimachinery/pkg/util/rand"
 	"k8s.io/client-go/kubernetes/scheme"
 	"k8s.io/client-go/rest"
 	"sigs.k8s.io/controller-runtime/pkg/client"
@@ -82,7 +83,7 @@ var _ = Describe("EnvTest sanity check", func() {
 	It("should be able to create a namespace", func() {
 		ctx := context.TODO()
 		namespace := &corev1.Namespace{}
-		namespace.SetGenerateName("test-")
+		namespace.SetName("test-" + utilrand.String(10))
 
 		// Create the namespace
 		Expect(k8sClient.Create(ctx, namespace)).To(Succeed(), "create namespace")

--- a/internal/controllers/image/upload_test.go
+++ b/internal/controllers/image/upload_test.go
@@ -28,6 +28,7 @@ import (
 	. "github.com/onsi/gomega"
 	"go.uber.org/mock/gomock"
 	corev1 "k8s.io/api/core/v1"
+	utilrand "k8s.io/apimachinery/pkg/util/rand"
 	ctrl "sigs.k8s.io/controller-runtime"
 
 	orcv1alpha1 "github.com/k-orc/openstack-resource-controller/v2/api/v1alpha1"
@@ -158,7 +159,7 @@ var _ = Describe("Upload tests", Ordered, func() {
 
 		// Create the namespace
 		namespace = &corev1.Namespace{}
-		namespace.SetGenerateName("test-")
+		namespace.SetName("test-" + utilrand.String(10))
 		Expect(k8sClient.Create(ctx, namespace)).To(Succeed(), "create namespace")
 		DeferCleanup(func() {
 			Expect(k8sClient.Delete(ctx, namespace)).To(Succeed(), "delete namespace")

--- a/internal/controllers/router/suite_test.go
+++ b/internal/controllers/router/suite_test.go
@@ -25,6 +25,7 @@ import (
 	. "github.com/onsi/gomega"
 	corev1 "k8s.io/api/core/v1"
 	"k8s.io/apimachinery/pkg/types"
+	utilrand "k8s.io/apimachinery/pkg/util/rand"
 	"k8s.io/client-go/kubernetes/scheme"
 	"k8s.io/client-go/rest"
 	"sigs.k8s.io/controller-runtime/pkg/client"
@@ -82,7 +83,7 @@ var _ = Describe("EnvTest sanity check", func() {
 	It("should be able to create a namespace", func() {
 		ctx := context.TODO()
 		namespace := &corev1.Namespace{}
-		namespace.SetGenerateName("test-")
+		namespace.SetName("test-" + utilrand.String(10))
 
 		// Create the namespace
 		Expect(k8sClient.Create(ctx, namespace)).To(Succeed(), "create namespace")

--- a/internal/controllers/routerinterface/suite_test.go
+++ b/internal/controllers/routerinterface/suite_test.go
@@ -25,6 +25,7 @@ import (
 	. "github.com/onsi/gomega"
 	corev1 "k8s.io/api/core/v1"
 	"k8s.io/apimachinery/pkg/types"
+	utilrand "k8s.io/apimachinery/pkg/util/rand"
 	"k8s.io/client-go/kubernetes/scheme"
 	"k8s.io/client-go/rest"
 	"sigs.k8s.io/controller-runtime/pkg/client"
@@ -82,7 +83,7 @@ var _ = Describe("EnvTest sanity check", func() {
 	It("should be able to create a namespace", func() {
 		ctx := context.TODO()
 		namespace := &corev1.Namespace{}
-		namespace.SetGenerateName("test-")
+		namespace.SetName("test-" + utilrand.String(10))
 
 		// Create the namespace
 		Expect(k8sClient.Create(ctx, namespace)).To(Succeed(), "create namespace")

--- a/internal/controllers/subnet/suite_test.go
+++ b/internal/controllers/subnet/suite_test.go
@@ -25,6 +25,7 @@ import (
 	. "github.com/onsi/gomega"
 	corev1 "k8s.io/api/core/v1"
 	"k8s.io/apimachinery/pkg/types"
+	utilrand "k8s.io/apimachinery/pkg/util/rand"
 	"k8s.io/client-go/kubernetes/scheme"
 	"k8s.io/client-go/rest"
 	"sigs.k8s.io/controller-runtime/pkg/client"
@@ -82,7 +83,7 @@ var _ = Describe("EnvTest sanity check", func() {
 	It("should be able to create a namespace", func() {
 		ctx := context.TODO()
 		namespace := &corev1.Namespace{}
-		namespace.SetGenerateName("test-")
+		namespace.SetName("test-" + utilrand.String(10))
 
 		// Create the namespace
 		Expect(k8sClient.Create(ctx, namespace)).To(Succeed(), "create namespace")

--- a/test/apivalidations/suite_test.go
+++ b/test/apivalidations/suite_test.go
@@ -24,6 +24,8 @@ import (
 	"testing"
 	"time"
 
+	utilrand "k8s.io/apimachinery/pkg/util/rand"
+
 	. "github.com/onsi/ginkgo/v2"
 	. "github.com/onsi/gomega"
 	corev1 "k8s.io/api/core/v1"
@@ -147,7 +149,7 @@ var _ = BeforeSuite(func() {
 func createNamespace() *corev1.Namespace {
 	By("Creating namespace")
 	namespace := corev1.Namespace{}
-	namespace.GenerateName = "test-"
+	namespace.Name = "test-" + utilrand.String(10)
 	Expect(k8sClient.Create(ctx, &namespace)).To(Succeed(), "Namespace creation should succeed")
 	DeferCleanup(func() {
 		By("Deleting namespace")


### PR DESCRIPTION
Replace `GenerateName()` with client-side name generation using `utilrand.String(10)` for test namespaces.

When using `GenerateName()`, it generates a new 5-char random suffix and the API server checks if that name exists. Envtest only runs kube-apiserver + etcd so namespaces marked for deletion are never actually cleaned up. On Kubernetes 1.29 (our envtest version, chosen as the minimum for CEL validation), the `RetryGenerateName` feature gate [1] doesn't exist yet (introduced in 1.30), so there are no retries and the collision is a hard failure.

By setting Name directly with a locally-generated 10-char random string, we considerably increase the pool of possible names, making collisions practically impossible.

[1] https://www.kubernetes.dev/resources/keps/4420/

Closes: #850