### PR TITLE
E2E test roleassignment-dependency fix racy 

### DIFF
--- a/internal/controllers/roleassignment/tests/roleassignment-dependency/02-assert.yaml
+++ b/internal/controllers/roleassignment/tests/roleassignment-dependency/02-assert.yaml
@@ -1,18 +1,15 @@
 ---
 # Verify Project still exists (deletion blocked by finalizer)
-apiVersion: openstack.k-orc.cloud/v1alpha1
-kind: Project
-metadata:
-  name: roleassignment-dep-project
-  # deletionTimestamp should be set, but resource should still exist
-status:
-  conditions:
-  - type: Available
-    status: "True"
-    reason: Success
-  - type: Progressing
-    status: "False"
-    reason: Success
+apiVersion: kuttl.dev/v1beta1
+kind: TestAssert
+resourceRefs:
+    - apiVersion: openstack.k-orc.cloud/v1alpha1
+      kind: Project
+      name: roleassignment-dep-project
+      ref: project
+assertAll:
+    - celExpr: "project.metadata.deletionTimestamp != 0"
+    - celExpr: "'openstack.k-orc.cloud/roleassignment' in project.metadata.finalizers"
 ---
 # Verify RoleAssignment still Available
 apiVersion: openstack.k-orc.cloud/v1alpha1


### PR DESCRIPTION
The fix replaces the racy Project status condition assertions with CEL expressions that check what actually matters: the Project has a `deletionTimestamp` (deletion was requested) and the `openstack.k-orc.cloud/roleassignment finalizer` is still blocking it. The RoleAssignment assertions stay as-is since they're stable , the RoleAssignment itself isn't being deleted, so its conditions won't race. CEL expressions from security group used as inspiration https://github.com/k-orc/openstack-resource-controller/blob/main/internal/controllers/securitygroup/tests/securitygroup-dependency/02-assert.yaml


In response to OpenStack-Gazpacho roleassignment-dependency racy failure in #853