### PR TITLE
Update zensical and make use of new compatibilty plugins

### DIFF
--- a/.github/workflows/website.yaml
+++ b/.github/workflows/website.yaml
@@ -27,7 +27,7 @@ jobs:
     - name: Build the site
       run: zensical build --strict --config-file website/mkdocs.yml
 
-    - name: Post-build (redirects and analytics)
+    - name: Post-build (analytics)
       run: bash website/post-build.sh website/rendered
 
     - name: Publish to Cloudflare Pages

--- a/website/mkdocs.yml
+++ b/website/mkdocs.yml
@@ -75,6 +75,23 @@ theme:
         name: Switch to light mode
 plugins:
   - search:
+  - minify:
+      minify_html: true
+      minify_js: true
+      minify_css: true
+      htmlmin_opts:
+        remove_comments: true
+      cache_safe: true
+  - redirects:
+      redirect_maps:
+        'getting_started.md': 'getting-started.md'
+        'development/index.md': 'development/contributing.md'
+        'development/controller-design.md': 'development/controller-implementation.md'
+        'development/design-decisions.md': 'concepts/design-principles.md'
+        'development/coding-convention.md': 'development/coding-standards.md'
+        'development/api-contracts.md': 'development/api-design.md'
+        'user-guide/index.md': 'concepts/core-concepts.md'
+        'user-guide/drift-detection.md': 'concepts/drift-detection.md'
 markdown_extensions:
   - admonition
   - attr_list

--- a/website/post-build.sh
+++ b/website/post-build.sh
@@ -1,66 +1,15 @@
 #!/bin/bash
 # Post-build script for zensical/mkdocs site.
-# Generates redirect pages and analytics proxy endpoint.
+# Generates the analytics proxy endpoint.
+#
+# Redirects and HTML/asset minification are now handled natively by
+# zensical's built-in `redirects` and `minify` plugin replacements
+# (see mkdocs.yml), so this script only needs to cover what zensical
+# doesn't support yet: arbitrary MkDocs `hooks`.
 
 set -euo pipefail
 
 SITE_DIR="${1:?Usage: $0 <site-dir>}"
-
-# --- Redirects ---
-# Replaces mkdocs-redirects plugin. Each entry maps an old path (directory URL)
-# to a new relative URL.
-declare -A REDIRECTS=(
-  ["getting_started"]="../getting-started/"
-  ["development/controller-design"]="../controller-implementation/"
-  ["development/design-decisions"]="../../concepts/design-principles/"
-  ["development/coding-convention"]="../coding-standards/"
-  ["development/api-contracts"]="../api-design/"
-  ["user-guide/drift-detection"]="../../concepts/drift-detection/"
-)
-
-# index.md redirects are special: they build to <dir>/index.html directly
-declare -A INDEX_REDIRECTS=(
-  ["development"]="contributing/"
-  ["user-guide"]="../concepts/core-concepts/"
-)
-
-for src in "${!REDIRECTS[@]}"; do
-  dest="${REDIRECTS[$src]}"
-  dir="$SITE_DIR/$src"
-  mkdir -p "$dir"
-  cat > "$dir/index.html" <<EOF
-<!DOCTYPE html>
-<html>
-<head>
-  <meta charset="utf-8">
-  <meta http-equiv="refresh" content="0; url=$dest">
-  <link rel="canonical" href="$dest">
-</head>
-<body>
-  <p>This page has moved. If you are not redirected, <a href="$dest">click here</a>.</p>
-</body>
-</html>
-EOF
-done
-
-for src in "${!INDEX_REDIRECTS[@]}"; do
-  dest="${INDEX_REDIRECTS[$src]}"
-  dir="$SITE_DIR/$src"
-  mkdir -p "$dir"
-  cat > "$dir/index.html" <<EOF
-<!DOCTYPE html>
-<html>
-<head>
-  <meta charset="utf-8">
-  <meta http-equiv="refresh" content="0; url=$dest">
-  <link rel="canonical" href="$dest">
-</head>
-<body>
-  <p>This page has moved. If you are not redirected, <a href="$dest">click here</a>.</p>
-</body>
-</html>
-EOF
-done
 
 # --- Analytics proxy endpoint ---
 # Replaces hooks.py on_post_build. Creates an empty script for the Plausible

--- a/website/requirements.txt
+++ b/website/requirements.txt
@@ -1,1 +1,1 @@
-zensical==0.0.56
+zensical==0.0.59


### PR DESCRIPTION
Zensical v0.0.58 comes with some of the missing plugins we were using before the migration away from mkdocks.

Use these new plugins instead of our hacks.