### PR TITLE
e2e: pin glance before LP#2166488 breakage

### DIFF
--- a/.github/workflows/e2e.yaml
+++ b/.github/workflows/e2e.yaml
@@ -17,12 +17,18 @@ jobs:
           - name: "gazpacho"
             openstack_version: "stable/2026.1"
             ubuntu_version: "24.04"
+            # Pin glance before LP#2166488 breakage. Remove once the fix is backported.
+            glance_pin: "24eab18960afaaf246e38efcb9eded21c7e5da9b"
           - name: "flamingo"
             openstack_version: "stable/2025.2"
             ubuntu_version: "24.04"
+            # Pin glance before LP#2166488 breakage. Remove once the fix is backported.
+            glance_pin: "577b1a16bd8c2fd4df4ad66c902f4e6b44d71618"
           - name: "epoxy"
             openstack_version: "stable/2025.1"
             ubuntu_version: "24.04"
+            # Pin glance before LP#2166488 breakage. Remove once the fix is backported.
+            glance_pin: "0b97347daaf0055cb18d94d32361265d81d15803"
     env:
       image_tag: virtual-registry.k-orc.cloud/ci:commit-${GITHUB_SHA::7}
 
@@ -40,6 +46,7 @@ jobs:
         branch: ${{ matrix.openstack_version }}
         enabled_services: "openstack-cli-server,neutron-trunk,neutron-port-trusted-vif,neutron-uplink-status-propagation"
         conf_overrides: |
+          ${{ matrix.glance_pin && format('GLANCE_BRANCH={0}', matrix.glance_pin) || '' }}
           enable_plugin neutron https://github.com/openstack/neutron ${{ matrix.openstack_version }}
           enable_plugin manila https://github.com/openstack/manila ${{ matrix.openstack_version }}
 


### PR DESCRIPTION
Pin glance to the commit right before the "Pin import downloads to validated destination addresses" change (fix for LP#2158999) which introduced LP#2166488: image web-download randomly fails when DNS returns both IPv4 and IPv6 addresses and glance picks the wrong address family.

Pinned commits:
- gazpacho (stable/2026.1): 24eab18960af (last merge before breakage)
- flamingo (stable/2025.2): 577b1a16bd8c (parent of breaking commit)
- epoxy (stable/2025.1): 0b97347daaf0 (last merge before breakage)